### PR TITLE
makefiel/model-archive: use pip from the venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ TAG=latest
 
 model-archive:
 	python -m venv .venv
-	(source .venv/bin/activate)
-	pip install -r requirements-dev.txt
-	torch-model-archiver -f \
+	.venv/bin/pip install -r requirements-dev.txt
+	.venv/bin/torch-model-archiver -f \
 	--model-name=wisdom \
 	--version=1.0 \
 	--serialized-file=${MODEL_PATH}/pytorch_model.bin \


### PR DESCRIPTION
Ensure we actually use the `pip` command from the venv. Otherwise
we default on the system `pip` and the packages are installed either
in the user environment or directly on the system.
