### PR TITLE
makefile/run-model-server: expose wisdom.mar with the SELinux context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ model-container:
 # Start torchserve container
 run-model-server:
 	@if [ "${ENVIRONMENT}" != "production" ]; then\
-		${CONTAINER_RUNTIME} run -it --gpus all --rm -p 7080:7080 -v ${MODEL_PATH}/wisdom.mar:/home/model-server/model-store/wisdom.mar --name=wisdom wisdom:${TAG};\
+		${CONTAINER_RUNTIME} run -it --gpus all --rm -p 7080:7080 -v ${MODEL_PATH}/wisdom.mar:/home/model-server/model-store/wisdom.mar:Z --name=wisdom wisdom:${TAG};\
 	else\
 		${CONTAINER_RUNTIME} run -it --gpus all --rm -p 7080:7080 ${SECURITY_OPT} --name=wisdom wisdom:${TAG};\
 	fi


### PR DESCRIPTION
From https://docs.podman.io/en/latest/markdown/podman-run.1.html


To change a label in the container context, add either of two suffixes :z or :Z to the volume mount. These suffixes tell Podman to relabel file objects on the shared volumes. The z option tells Podman that two or more containers share the volume content. As a result, Podman labels the content with a shared content label. Shared volume labels allow all containers to read/write content. The Z option tells Podman to label the content with a private unshared label Only the current container can use a private volume.


Also see: https://blog.christophersmart.com/2021/01/31/podman-volumes-and-selinux/
