### PR TITLE
Running torchserve on Mac natively (non-docker)

### DIFF
--- a/torchserve/handler.py
+++ b/torchserve/handler.py
@@ -137,6 +137,9 @@ class TransformersClassifierHandler(BaseHandler):
         :param context: Initial context contains model server system properties.
         :return: prediction output
         """
+        logger.info(f'handle data: {data}')
+        # yet to determine why this data structure is different when running mac local torchserve
+        data = data[0].get('body').get('instances')
         model_input = self.preprocess(data)
         model_output = self.inference(model_input)
         return self.postprocess([model_output])


### PR DESCRIPTION
This is running torchserve without docker.

Somehow the incoming data we need is [a couple of levels nested](https://github.com/ansible/ansible-wisdom-service/blob/e9ae4e4cccde0745c08a38704a833948ba2d67f8/torchserve/handler.py#L142) in the payload, and so I have to modify the handler.py.

i haven’t connected to Django yet, simply testing using curl hitting the torchserve directly now. Not sure if it’s the django server stripping the incoming data. Looking into it...