### PR TITLE
DRAFT - completions/: add a rate limit

### DIFF
--- a/ansible_wisdom/ai/api/test_views.py
+++ b/ansible_wisdom/ai/api/test_views.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from django.test import TestCase
+
+import ai.api.views as views
+
+
+class CompletionsTestCase(TestCase):
+    def test_rate_limit_ok(self):
+        session = {}
+        self.assertEqual(views.rate_limit(session), False)
+        self.assertIn("last_call", session)
+
+    def test_rate_limit_ko(self):
+        session = {"last_call": datetime.now().isoformat()}
+        self.assertEqual(views.rate_limit(session), True)

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -1,7 +1,10 @@
 # Create your views here.
 import logging
 
+from datetime import datetime, timedelta
+
 from django.apps import apps
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -11,8 +14,17 @@ logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
+def rate_limit(session, duration=10):
+    last_call = datetime.fromisoformat(session.get('last_call', "1970-01-01"))
+    session['last_call'] = datetime.now().isoformat()
+    return last_call > datetime.now() - timedelta(seconds=duration)
+
+
 class Completions(APIView):
     def post(self, request) -> Response:
+        if rate_limit(request.session):
+            return Response("429 Too Many Requests", status=status.HTTP_429_TOO_MANY_REQUESTS)
+
         model_mesh_client = apps.get_app_config("ai").model_mesh_client
         payload = APIPayload(**request.data)
         model_name = payload.model_name


### PR DESCRIPTION
Raise 429 error when the last call was done less than 10s ago. The feature relies on the user session to store the last request date.
Note: I would like to test the behaviour once we've got the integration with Github is merged.