### PR TITLE
update makefile to choose available CONTAINER_RUNTIME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ TAG=latest
 
 # Choose between docker and podman based on what is available 
 ifeq (, $(shell which podman))
-	CONTAINER_RUNTIME = docker
+	CONTAINER_RUNTIME ?= docker
 else
-	CONTAINER_RUNTIME = podman
+	CONTAINER_RUNTIME ?= podman
 endif
 
 model-archive:


### PR DESCRIPTION
updated the makefile to set CONTAINER_RUNTIME to either podman or docker based on what is available on the host system