### PR TITLE
docker-compose: drop the depends_on migrate and full image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ or `podman-compose`:
 $ podman-compose -f tools/docker-compose/compose.yaml up
 ```
 
-The Django services listen on 127.0.0.1:8000.
+Once the service is running, you can monitor your Django application with:
+
+- Docker: `docker logs -f docker-compose_django_1`
+- Podman: `podman logs -f docker-compose_django_1`
+
+The Django service listen on 127.0.0.1:8000.
 
 There is no pytorch service, you should adjust the `ANSIBLE_AI_MODEL_MESH_HOST` configuration key to point on an existing service.

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -5,7 +5,6 @@ services:
       context: $PWD
       dockerfile: ansible_wisdom.Containerfile
     depends_on:
-      - migrate
       - redis
       - db
     restart: always
@@ -19,7 +18,7 @@ services:
       - SOCIAL_AUTH_GITHUB_TEAM_SECRET=${SOCIAL_AUTH_GITHUB_TEAM_SECRET}
     command: bash -c "/usr/bin/python3 /opt/ansible_wisdom/manage.py migrate --noinput && /usr/bin/python3 /opt/ansible_wisdom/manage.py runserver 0.0.0.0:8000"
   redis:
-    image: redis:alpine
+    image: docker.io/library/redis:alpine
     restart: always
     networks:
       - dbnet


### PR DESCRIPTION
- the `depends_on` section mentions a non existing service.
- use the full redis image path to avoid the interactive menu with Podman.
- minor README update
