### PR TITLE
Makefile: call the Python binary: python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ else
 endif
 
 model-archive:
-	python -m venv .venv
-	.venv/bin/pip install -r requirements-dev.txt
+	python3 -m venv .venv
+	.venv/bin/pip3 install -r requirements-dev.txt
 	.venv/bin/torch-model-archiver -f \
 	--model-name=wisdom \
 	--version=1.0 \


### PR DESCRIPTION
By default RHEL comes without any `python` binary. By calling `python3`
directly we end up with a command that can work in any cases.
