### PR TITLE
install postgres dependency

### DIFF
--- a/ansible_wisdom.Containerfile
+++ b/ansible_wisdom.Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.1.0-1646.1669627755
 
 ARG DJANGO_SETTINGS_MODULE=main.settings.development
 
-RUN dnf install -y python39 python3-pip
+RUN dnf install -y libpq libpq-dev python39 python3-pip
 
 COPY ansible_wisdom /opt/ansible_wisdom
 COPY requirements.txt /tmp


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AAP-8526

>File "/usr/local/lib64/python3.9/site-packages/psycopg2/_init_.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
django.db.utils.OperationalError: SCRAM authentication requires libpq version 10 or above

To test:
```bash
podman-compose -f tools/docker-compose/compose.yaml up
```

Signed-off-by: Richard Gebhardt <gebhardtr@redhat.com>