### PR TITLE
ansible_wisdom.Containerfile: fix the libpq-devel package name

### DIFF
--- a/ansible_wisdom.Containerfile
+++ b/ansible_wisdom.Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.1.0-1646.1669627755
 
 ARG DJANGO_SETTINGS_MODULE=main.settings.development
 
-RUN dnf install -y libpq libpq-dev python39 python3-pip
+RUN dnf install -y libpq libpq-devel python39 python3-pip
 
 COPY ansible_wisdom /opt/ansible_wisdom
 COPY requirements.txt /tmp


### PR DESCRIPTION
On RHEL/Fedora, the libpq headers package is called libpq-devel.

Thanks Craig.
