### PR TITLE
handler: temporarily disable the anonymizor

### DIFF
--- a/torchserve/handler.py
+++ b/torchserve/handler.py
@@ -8,8 +8,6 @@ import torch
 from transformers import CodeGenForCausalLM, CodeGenTokenizerFast
 from ts.torch_handler.base_handler import BaseHandler
 
-from anonymizor import anonymizor
-
 logger = logging.getLogger(__name__)
 
 
@@ -98,11 +96,7 @@ class TransformersClassifierHandler(BaseHandler):
         return output
 
     def postprocess(self, inference_output):
-        logger.debug(f"structure before PII clean up: {inference_output}")
-        anonymized = anonymizor.anonymize_batch(inference_output)
-        logger.debug(f"structure after PII clean up: {anonymized}")
-
-        return anonymized
+        return inference_output
 
     def handle(self, data, context):
         model_input = self.preprocess(data)


### PR DESCRIPTION
The new model now returns YAML structures that is slightly different
comparing to what we used during the development.
The `- name:` line is not part of the answer anymore, however the
indentation is preserved.
Which results in strings like this that start with 2 spaces:
 `  debug:\n    msg:\n      - "{{ my_fact }}"\n`

PyYAML is able to load such string, but it won't preserve the two
leading spaces. As a consequence, when we write the result back, we
lose the indentation.

In addition, sometimes, the model generates YAML structures that are
actually not valid, if we use a try/except block to ignore this case,
we will have a situation where the leading spaces are preserved.

The silent corruption of the data structure and the inconsistency
are not desirable and may be a source of new problems. We prefer to
disable the feature for now.
