### PR TITLE
Update README to use pre-commit autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use pre-commit you need to first install it and it's dependencies by running:
 once installed you can run the hooks with:
 
     ```bash
-    pre-commit run --all
+    pre-commit autoupdate && pre-commit run -a
     ```
 
 ## Full Development Environment


### PR DESCRIPTION
Best practice is to use "pre-commit autoupdate" when running the pre-commit command.
This updates automatically the dependencies.