### PR TITLE
Bump the Grafana container's log level to 'warn'

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -64,6 +64,8 @@ services:
       - dbnet
   grafana:
     image: grafana/grafana:latest
+    environment:
+      - GF_LOG_LEVEL=warn
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
The default level of 'info' seems quite spammy.