### PR TITLE
add a script to generate performance test users

### DIFF
--- a/ansible_wisdom/generate_users.py
+++ b/ansible_wisdom/generate_users.py
@@ -7,7 +7,7 @@ from rest_framework.authtoken.models import Token
 fake = Faker()
 
 group_name = "perf"
-requested_users = 10
+requested_users = 1000
 
 
 def get_or_create_group(group_name):

--- a/ansible_wisdom/requirements.txt
+++ b/ansible_wisdom/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary==2.9.5
 redis==4.4.2
 uwsgi==2.0.21
 django_prometheus==2.2.0
+factory_boy==3.2.1


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-9279

This script will allow us to generate 1000 users for the performance team and retrieve their drf tokens.
Reviewer: Where does this script belong? How can it best be run against a containerized environment?

requested_users is currently hardcoded to 10 but will be bumped to 1000 before running. 

Tested locally via:
`cat generate_users.py | SECRET_KEY=fred python3 manage.py shell `