### PR TITLE
Changes for local debug with containers

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -32,8 +32,8 @@ services:
     restart: always
     networks:
       - dbnet
-    expose:
-      - 6379
+    ports:
+      - "6379:6379"
   db:
     image: docker.io/library/postgres:alpine
     environment:
@@ -48,8 +48,8 @@ services:
 # 2023-01-17 21:46:56.579 UTC [33] LOG:  out of file descriptors: No file descriptors available; release and retry
 #    volumes:
 #      - $PWD/db_data:/var/lib/postgresql/data
-    expose:
-      - 5432
+    ports:
+      - "5432:5432"
   prometheus:
     image: docker.io/prom/prometheus
     command:


### PR DESCRIPTION
This is a small (four lines) change in `compose.yaml` so that we could debug wisdom service with backends running by `(docker|podman)-compose`. The modified `compose.yaml` will be used as:

1. Run podman-compose (or docker-compose) using the modified `compose.yaml`
2.  Once the wisdom service is started, kill it with `podman kill`  (or `docker kill`) command like:
    `podman kill docker-compose_django_1`
3. Then start the wisdom service from source, which is configured to use Redis and DB in containers.

Eventually we may want to automate these steps in `Makefile`. This PR contains the changes in `compose.yaml` only.