### PR TITLE
Makefile change for running backends from containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,8 @@ docker-compose:
 
 # Run backend services in container for running Django application from source
 run-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose.yaml up --remove-orphans --detach
-	@until $$(curl -sfo /dev/null http://localhost:8000); do printf '.'; sleep 5; done
-	@printf '\nDjango Server is up and running.\n'
-	@sleep 3
-	@printf 'Kill Django server...\n'
-	${CONTAINER_RUNTIME} kill docker-compose_django_1
-	@sleep 3
-	${CONTAINER_RUNTIME} ps -a
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml up --remove-orphans
 
 # Stop backend services
 stop-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose.yaml down
-	@sleep 3
-	${CONTAINER_RUNTIME} ps -a
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml down

--- a/README.md
+++ b/README.md
@@ -124,14 +124,16 @@ services on your local machine.
     make ansible-wisdom-container
     ```
 
-2. Start backend services. This will start the Django application from container
-first, run `manage.py migrate` to set up DB, then kill the application.
+2. Start backend services.
 
     ```bash
     make run-backends
     ```
 
 For terminating backend services, run `make stop-backends`.
+
+Note that you need to run `manage.py migrate` to set up DB
+before running the Django application from source,
 
 The setup for debugging is different depending on the Python development tool.
 For PyCharm, please look at [this document](https://docs.google.com/document/d/1QkdvtthnvdHc4TKbWV00pxnEKRU8L8jHNC2IaQ950_E/edit?usp=sharing).

--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -1,0 +1,51 @@
+version: "3.8"
+services:
+  redis:
+    image: docker.io/library/redis:alpine
+    restart: always
+    networks:
+      - dbnet
+    ports:
+      - "6379:6379"
+  db:
+    image: docker.io/library/postgres:alpine
+    environment:
+      - POSTGRES_PASSWORD=wisdom
+      - POSTGRES_DB=wisdom
+      - POSTGRES_USER=wisdom
+    restart: always
+    networks:
+      - dbnet
+# Disabled because this doesn't work properly on MacOS.
+# [33] CONTEXT:  writing block 0 of relation base/16384/2658
+# 2023-01-17 21:46:56.579 UTC [33] LOG:  out of file descriptors: No file descriptors available; release and retry
+#    volumes:
+#      - $PWD/db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  prometheus:
+    image: docker.io/prom/prometheus
+    command:
+      - --config.file=/opt/prometheus/prometheus.yaml
+      - --web.enable-lifecycle
+    volumes:
+      - $PWD/prometheus/prometheus.yaml:/opt/prometheus/prometheus.yaml
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    networks:
+      - dbnet
+  grafana:
+    image: docker.io/grafana/grafana:latest
+    environment:
+      - GF_LOG_LEVEL=warn
+    ports:
+      - "3000:3000"
+    volumes:
+      - $PWD/grafana:/opt/grafana
+    restart: unless-stopped
+    networks:
+      - dbnet
+
+networks:
+  dbnet:


### PR DESCRIPTION
Makefile change for running backends from containers. It is mainly for debugging the Django application on local development environment without having backend services (Postgres, Redis, etc.) installed.