### PR TITLE
Exception thrown with VSCode extension

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -46,8 +46,8 @@ class Completions(APIView):
                 {
                     "prompt": payload.prompt,
                     "context": payload.context,
-                    "userId": str(payload.userId),
-                    "suggestionId": str(payload.suggestionId),
+                    "userId": str(payload.userId) if payload.userId else None,
+                    "suggestionId": str(payload.suggestionId) if payload.suggestionId else None,
                 }
             ]
         )


### PR DESCRIPTION
With PR #74, the new parameter verification logic was added in serializer for `userId` and `suggestionId` so that they are in expected UUID format and corresponding model (`APIPayload`) was also updated to have UUIDs. However, the model to be sent to the model server (`ModelMeshData`) was not updated and it should not be changed because it is passed to the model server. Therefore, when the view sets `userId` and `suggestionId` for `ModelMeshData`, UUID data need to be changed to `str`, but it was not done in #74.