### PR TITLE
use cheaper for uwsgi

### DIFF
--- a/tools/configs/uwsgi.ini
+++ b/tools/configs/uwsgi.ini
@@ -1,6 +1,11 @@
 [uwsgi]
 socket = 127.0.0.1:8050
-processes = 5
+listen = 100                         ; This is limited by net.core.somaxconn
+cheaper-algo = spare
+processes = 100                      ; Maximum number of workers allowed
+cheaper = 8                          ; Minimum number of workers allowed
+cheaper-initial = 16                 ; Workers created at startup
+cheaper-step = 16                    ; How many workers to spawn at a time
 master = true
 vacuum = true
 no-orphans = true


### PR DESCRIPTION
this allows us to scale up number of workers as requests come in, and they scale down if not busy

we still face limit of "listen" queue that is limited by "somaxconn" but that will be addressed seperately as requires more thinking about the deployment

I have tested this locally and it does immediately ease problems for 100 or less concurrent requests, whereas previously we get immediate problems with overwhelming the listen queue for the yet-to-be-handled requests.

Planning on building an image and pushing to the perf cluster for further testing