### PR TITLE
Update OpenAPI schema to make context be a non-required field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ run-backends:
 # Stop backend services
 stop-backends:
 	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml down
+
+# Update OpenAPI 3.0 schema while running the service in development env
+update-openapi-schema:
+	curl -X GET http://localhost:8000/api/schema/ -o tools/openapi-schema/ansible-wisdom-service.yaml

--- a/README.md
+++ b/README.md
@@ -221,11 +221,22 @@ Another OpenAPI UI in the ReDoc format is also available at  http://localhost:80
 
 ### OpenAPI 3.0 Schema
 
-The OpenAPI 3.0 Schema YAML files can be downloaded either:
+The static OpenAPI Schema YAML file is stored as
+[/tools/openapi-schema/ansible-wisdom-service.yaml](https://github.com/ansible/ansible-wisdom-service/blob/main/tools/openapi-schema/ansible-wisdom-service.yaml) in this repository.
+
+When you make code changes, please update the static OpenAPI Schema YAML file
+with the following steps:
+
+1. Update API descriptions.  See [this doc](https://docs.google.com/document/d/1iF32yui3JTG808GhInN7CUTEn4Ocimed1szOn0N0P_E/edit#heading=h.sufj9xfpwkbn)
+to find where to update.
+2. Make sure the API version is updated in [development.yaml](https://github.com/ansible/ansible-wisdom-service/blob/7a9669be1ac5b037d1bd92793db48e6aed15bb4e/ansible_wisdom/main/settings/development.py#L38)
+3. Run `make update-openapi-schema` in the project root.
+4. Checkin the updated OpenAPI Schema YAML file with your API changes.
+
+Also a dynamically generated OpenAPI 3.0 Schema YAML file can be downloaded either:
 
 - Click the /api/schema/ link on Swagger UI, or
 - Click the Download button on ReDoc UI
-
 
 ## Test cases
 

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -26,8 +26,10 @@ class CompletionRequestSerializer(serializers.Serializer):
 
     context = serializers.CharField(
         trim_whitespace=False,
+        default='',
+        allow_blank=True,
         label='Context',
-        help_text='Editor context. This is required.',
+        help_text='Editor context.',
     )
     prompt = serializers.CharField(
         trim_whitespace=False,

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -30,6 +30,7 @@ class Completions(APIView):
             200: CompletionResponseSerializer,
             400: OpenApiResponse(description='Bad Request'),
             401: OpenApiResponse(description='Unauthorized'),
+            429: OpenApiResponse(description='Request was throttled'),
         },
         summary="Inline code suggestions",
     )

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -39,7 +39,7 @@ if DEBUG:
     SPECTACULAR_SETTINGS = {
         'TITLE': 'Ansible Wisdom Service',
         'DESCRIPTION': 'Equip the automation developer with Wisdom super powers.',
-        'VERSION': '0.0.1',
+        'VERSION': '0.0.2',
         'SERVE_INCLUDE_SCHEMA': False,
         # OTHER SETTINGS
         'TAGS': [{"name": "ai", "description": "AI-related operations"}],

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Ansible Wisdom Service
-  version: 0.0.1
+  version: 0.0.2
   description: Equip the automation developer with Wisdom super powers.
 paths:
   /api/ai/completions/:
@@ -36,7 +36,6 @@ paths:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/CompletionRequest'
-        required: true
       security:
       - tokenAuth: []
       responses:
@@ -60,6 +59,8 @@ paths:
           description: Bad Request
         '401':
           description: Unauthorized
+        '429':
+          description: Request was throttled
 components:
   schemas:
     CompletionRequest:
@@ -67,7 +68,8 @@ components:
       properties:
         context:
           type: string
-          description: Editor context. This is required.
+          default: ''
+          description: Editor context.
         prompt:
           type: string
           description: Editor prompt.
@@ -81,8 +83,6 @@ components:
           format: uuid
           title: Suggestion ID
           description: A UUID that identifies a suggestion.
-      required:
-      - context
     CompletionResponse:
       type: object
       properties:


### PR DESCRIPTION
Update OpenAPI schema to make context be a non-required field.
This is for fixing the issue that @jameswnl pointed out at today's (Feb 22) scrum mtg.