### PR TITLE
add need-app and a few more uwsgi configs

### DIFF
--- a/tools/configs/uwsgi.ini
+++ b/tools/configs/uwsgi.ini
@@ -1,17 +1,27 @@
 [uwsgi]
 socket = 127.0.0.1:8050
 listen = 100                         ; This is limited by net.core.somaxconn
-cheaper-algo = spare
-processes = 100                      ; Maximum number of workers allowed
-cheaper = 8                          ; Minimum number of workers allowed
-cheaper-initial = 16                 ; Workers created at startup
-cheaper-step = 16                    ; How many workers to spawn at a time
 master = true
 vacuum = true
 no-orphans = true
 lazy-apps = true
+manage-script-name = true
+mount = /=main.wsgi:application
+
+need-app = true                      ; Exit if no python application loaded
+harakiri = 60                        ; Forcefully kill workers after 60 seconds
+max-requests = 1000                  ; Restart workers after this many requests
+max-worker-lifetime = 3600           ; Restart workers after this many seconds
+reload-on-rss = 2048                 ; Restart workers after this much resident memory
+worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
+py-callos-afterfork = true           ; allow workers to trap signals
+
+cheaper-algo = spare
+processes = 100                      ; Maximum number of workers allowed
+cheaper = 8                          ; Minimum number of workers allowed
+cheaper-initial = 8                  ; Workers created at startup
+cheaper-step = 8                     ; How many workers to spawn at a time
+
 log-4xx = true
 log-5xx = true
 disable-logging = true
-manage-script-name = true
-mount = /=main.wsgi:application


### PR DESCRIPTION
need-app makes uwsgi exit if there is no python application loaded, this came up for me when the python app exited after running into a fatal error, but pods stayed up and uwsgi kept responding with 50x errors.

Also added a few more sane configs around recycling workers, having a max timeout for workers (harikiri) and allowing workers to trap signals. These were sourced from article jrb and I both
have been reading
https://www.bloomberg.com/company/stories/configuring-uwsgi-production-deployment/

finally, set initial workers equal to min workers to avoid excess logging from idle app as workers scale down.