### PR TITLE
Send a 500 when the model server returns an invalid data

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -3,6 +3,7 @@ DRF Serializer classes for input/output validations and OpenAPI document generat
 """
 from drf_spectacular.utils import OpenApiExample, extend_schema_serializer
 from rest_framework import serializers
+from rest_framework.exceptions import APIException, ValidationError
 
 
 @extend_schema_serializer(
@@ -88,3 +89,10 @@ class CompletionResponseSerializer(serializers.Serializer):
         fields = ['predictions']
 
     predictions = serializers.ListField(child=serializers.CharField(trim_whitespace=False))
+
+    def is_valid(self, raise_exception=False):
+        # Replace the default 400 status code for invalid data with a 500 server error
+        try:
+            return super().is_valid(raise_exception=raise_exception)
+        except ValidationError:
+            raise APIException()

--- a/ansible_wisdom/ai/api/test_serializers.py
+++ b/ansible_wisdom/ai/api/test_serializers.py
@@ -3,7 +3,9 @@ Test serializers
 """
 from unittest.case import TestCase
 
-from .serializers import CompletionRequestSerializer
+from rest_framework.exceptions import APIException
+
+from .serializers import CompletionRequestSerializer, CompletionResponseSerializer
 
 
 class CompletionRequestSerializerTest(TestCase):
@@ -27,3 +29,20 @@ class CompletionRequestSerializerTest(TestCase):
         self.run_a_test('', '', '', '')
         self.run_a_test('', None, '', '')
         self.run_a_test('---\n', None, '---\n', '')
+
+    def test_is_valid_response(self):
+        VALID_DATA = {
+            'predictions': ['  ansible.builtin.yum:\n    name: httpd\n    state: present\n']
+        }
+        serializer = CompletionResponseSerializer(data=VALID_DATA)
+        serializer.is_valid()  # raise_exception=False
+        serializer.is_valid(raise_exception=True)
+
+        INVALID_DATA = {}
+        serializer = CompletionResponseSerializer(data=INVALID_DATA)
+        serializer.is_valid()  # raise_exception=False
+
+        # Expect an APIException that will return a 500 will be raised
+        # for an invalid data.
+        with self.assertRaises(APIException):
+            serializer.is_valid(raise_exception=True)

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -32,6 +32,7 @@ class Completions(APIView):
             400: OpenApiResponse(description='Bad Request'),
             401: OpenApiResponse(description='Unauthorized'),
             429: OpenApiResponse(description='Request was throttled'),
+            500: OpenApiResponse(description='Internal Server Error'),
         },
         summary="Inline code suggestions",
     )

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -39,7 +39,7 @@ if DEBUG:
     SPECTACULAR_SETTINGS = {
         'TITLE': 'Ansible Wisdom Service',
         'DESCRIPTION': 'Equip the automation developer with Wisdom super powers.',
-        'VERSION': '0.0.2',
+        'VERSION': '0.0.3',
         'SERVE_INCLUDE_SCHEMA': False,
         # OTHER SETTINGS
         'TAGS': [{"name": "ai", "description": "AI-related operations"}],

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Ansible Wisdom Service
-  version: 0.0.2
+  version: 0.0.3
   description: Equip the automation developer with Wisdom super powers.
 paths:
   /api/ai/completions/:
@@ -61,6 +61,8 @@ paths:
           description: Unauthorized
         '429':
           description: Request was throttled
+        '500':
+          description: Internal Server Error
 components:
   schemas:
     CompletionRequest:


### PR DESCRIPTION
This was found by @kdelee in his testing ([AAP-9658](https://issues.redhat.com/browse/AAP-9658))

When the model server returns data without predictions, the response serializer checks its validity and raise ValidationError. Django REST Framework converts it into a 400 status code by default. Since it is a server-side error, 400 is misleading and we should send a 5xx error. With this PR, the code will send a generic 500 (Internal Server Error) for such cases. 