### PR TITLE
Specify ARI rules via env var

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -219,4 +219,6 @@ ARI_RULES = [
     "W012",
     "W013",
 ]
-ARI_RULE_FOR_OUTPUT_RESULT = "W007"
+if 'ARI_RULES' in os.environ:
+    ARI_RULES = os.environ['ARI_RULES'].split(',')
+ARI_RULE_FOR_OUTPUT_RESULT = os.getenv('ARI_RULE_FOR_OUTPUT_RESULT', "W007")


### PR DESCRIPTION
Allow override of ARI_RULES (and ARI_RULE_FOR_OUTPUT_RESULT) via environment variable containing a comma-separated string of rules (e.g. "P001,P002,P003,P004,W001,W003").