### PR TITLE
docker-compose fails with segment module missing

### DIFF
--- a/ansible_wisdom/requirements.txt
+++ b/ansible_wisdom/requirements.txt
@@ -12,3 +12,4 @@ django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
 git+https://github.com/ansible/ansible-risk-insight#egg=ansible_risk_insight==0.1.0
+segment-analytics-python==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,6 @@ requirements-parser==0.5.0
 resolvelib==0.8.1
 responses==0.18.0
 rich==12.5.1
-segment-analytics-python==2.2.2
 six==1.16.0
 sqlparse==0.4.3
 starlette==0.14.2


### PR DESCRIPTION
ansible-service docker-compose (`make docker-compose`) fails with
```
ModuleNotFoundError: No module named 'segment'
```
It was because #95 added `segment-analytics-python` to `requirements.txt` in the project root.  It should have been added to `ansible_wisdom/requirements.txt`.