### PR TITLE
Adding static file handling and configuration

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -184,6 +184,10 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
+# Absolute filesystem path to the directory where static file are collected via
+# the collectstatic command.
+STATIC_ROOT = '/var/www/wisdom/public/static'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 

--- a/tools/configs/nginx-wisdom.conf
+++ b/tools/configs/nginx-wisdom.conf
@@ -6,6 +6,10 @@ server {
     listen 8000 default_server;
     server_name _;
 
+    location /static/ {
+        alias /var/www/wisdom/public/static/;
+    }
+
     location / {
         uwsgi_pass uwsgi;
         include /etc/nginx/uwsgi_params;

--- a/tools/scripts/launch-wisdom.sh
+++ b/tools/scripts/launch-wisdom.sh
@@ -20,6 +20,7 @@ do
 done
 
 /var/www/venv/bin/python ansible_wisdom/manage.py migrate --noinput
+/var/www/venv/bin/python ansible_wisdom/manage.py collectstatic --noinput
 
 cd ansible_wisdom/
 /usr/local/bin/supervisord -n

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -34,6 +34,7 @@ RUN /usr/bin/python3 -m pip --no-cache-dir install supervisor
 RUN for dir in \
       /var/log/supervisor \
       /var/run/supervisor \
+      /var/www/wisdom \
       /var/log/nginx \
       /etc/ari \
       /etc/ansible ; \


### PR DESCRIPTION
This PR adds:

- `settings.STATIC_ROOT`, the location where the files are gathered
- a `/static/` location in the nginx configuration, to serve up those files
- a call to the Django `collectstatic` command in `launch-wisdom.sh`
- setting the permissions on the `/var/www/wisdom/` directory in the container file, so that the files can be copied there and read

**Note:** this was split off of @matburt 's work on #61