### PR TITLE
Add authentication code to test_views.py

### DIFF
--- a/ansible_wisdom/ai/api/test_views.py
+++ b/ansible_wisdom/ai/api/test_views.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 
+import time
+import uuid
 from unittest.mock import patch
 
 from django.apps import apps
-from django.test import Client, TestCase
+from django.contrib.auth import get_user_model
+from django.test import modify_settings
 from rest_framework.response import Response
+from rest_framework.test import APITestCase
 
 
 class DummyMeshClient:
-    def __init__(self, test, payload):
+    def __init__(self, test, payload, response_data):
         self.test = test
         self.expects = {
             "instances": [
@@ -20,38 +24,63 @@ class DummyMeshClient:
                 }
             ]
         }
+        self.response_data = response_data
 
     def infer(self, data, model_name=None):
         self.test.assertEqual(data, self.expects)
-        return Response(data)
+        time.sleep(0.1)  # w/o this line test_rate_limit() fails...
+        # i.e., still receives 200 after 10 API calls...
+        return Response(self.response_data)
 
 
-class CompletionsTestCase(TestCase):
+@modify_settings()
+class TestCompletionView(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.username = 'u' + str(int(time.time()))
+        cls.user = get_user_model().objects.create_user(
+            username=cls.username,
+            email='user@example.com',
+            password='secret',
+        )
+        cls.user_id = str(uuid.uuid4())
+
     def test_full_payload(self):
-        c = Client()
         payload = {
-            "prompt": "- name: install openshift\n",
-            "context": "",
-            "userId": "bixler",
-            "suggestionId": "105625",
+            "prompt": "    - name: Install Apache\n",
+            "context": "---\n- hosts: all\n  become: yes\n\n  tasks:\n",
+            "userId": self.user_id,
+            "suggestionId": str(uuid.uuid4()),
         }
-
+        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        self.client.force_authenticate(user=self.user)
         with patch.object(
-            apps.get_app_config('ai'), 'model_mesh_client', DummyMeshClient(self, payload)
+            apps.get_app_config('ai'),
+            'model_mesh_client',
+            DummyMeshClient(self, payload, response_data),
         ):
-            r = c.post('/api/ai/completions/', payload)
+            r = self.client.post('/api/ai/completions/', payload)
             self.assertEqual(r.status_code, 200)
+            self.assertIsNotNone(r.data['predictions'])
 
     def test_rate_limit(self):
-        c = Client()
         payload = {
-            "prompt": "- name: install rhel\n",
+            "prompt": "    - name: Install Apache\n",
+            "context": "---\n- hosts: all\n  become: yes\n\n  tasks:\n",
+            "userId": self.user_id,
+            "suggestionId": str(uuid.uuid4()),
         }
+        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        self.client.force_authenticate(user=self.user)
         with patch.object(
-            apps.get_app_config('ai'), 'model_mesh_client', DummyMeshClient(self, payload)
+            apps.get_app_config('ai'),
+            'model_mesh_client',
+            DummyMeshClient(self, payload, response_data),
         ):
-            r = c.post('/api/ai/completions/', payload)
+            r = self.client.post('/api/ai/completions/', payload)
             self.assertEqual(r.status_code, 200)
+            self.assertIsNotNone(r.data['predictions'])
             for _ in range(10):
-                r = c.post('/api/ai/completions/', payload)
+                r = self.client.post('/api/ai/completions/', payload)
             self.assertEqual(r.status_code, 429)


### PR DESCRIPTION
This is for removing the 401 error when `test_views.py` is executed with `manage.py test`.
Please take a look at [this Slack thread](https://redhat-internal.slack.com/archives/C04G3TZBGHJ/p1677772783329229) for your reference.


This assumes Postgres DB and Redis are available.  I ran them with `make run-backends` and I executed  `manage.py test` with the following `.env` file:
```bash
ANSIBLE_AI_CACHE_URI=redis://localhost:6379
ANSIBLE_AI_DATABASE_HOST=localhost
ANSIBLE_AI_DATABASE_NAME=wisdom
ANSIBLE_AI_DATABASE_PASSWORD=wisdom
ANSIBLE_AI_DATABASE_USER=wisdom
ARI_KB_PATH=../ari/kb/
DJANGO_SETTINGS_MODULE=main.settings.development
ENABLE_ARI_POSTPROCESS=True
PYTHONUNBUFFERED=1
SECRET_KEY=somesecret
```

 