### PR TITLE
introduce mock model client allow testing of django service in isolation

### DIFF
--- a/ansible_wisdom/ai/api/model_client/mock_client.py
+++ b/ansible_wisdom/ai/api/model_client/mock_client.py
@@ -1,0 +1,26 @@
+import json
+import logging
+import random
+import time
+
+import requests
+from django.conf import settings
+from rest_framework.response import Response
+
+from .base import ModelMeshClient
+
+logger = logging.getLogger(__name__)
+
+
+class MockClient(ModelMeshClient):
+    def __init__(self, inference_url, management_url):
+        super().__init__(inference_url=inference_url, management_url=management_url)
+        self.session = requests.Session()
+        self.headers = {"Content-Type": "application/json"}
+
+    def infer(self, model_input, model_name="wisdom") -> Response:
+        logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'mock' !!!!")
+        logger.debug("!!!! Mocking Model response !!!!")
+        jitter = random.random() if settings.MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER else 1
+        time.sleep((settings.MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter) / 1000)
+        return Response(json.loads(settings.MOCK_MODEL_RESPONSE_BODY))

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -30,6 +30,13 @@ class AiConfig(AppConfig):
                 inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
                 management_url=settings.ANSIBLE_AI_MODEL_MESH_MANAGEMENT_URL,
             )
+        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock":
+            from .api.model_client.mock_client import MockClient
+
+            self.model_mesh_client = MockClient(
+                inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
+                management_url=settings.ANSIBLE_AI_MODEL_MESH_MANAGEMENT_URL,
+            )
         else:
             raise ValueError(
                 f"Invalid model mesh client type: {settings.ANSIBLE_AI_MODEL_MESH_API_TYPE}"

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -233,6 +233,17 @@ APPEND_SLASH = False
 COMPLETION_USER_RATE_THROTTLE = (
     os.environ.get('COMPLETION_USER_RATE_THROTTLE', '10/minute').strip('"').strip("'")
 )
+MOCK_MODEL_RESPONSE_BODY = os.environ.get(
+    'MOCK_MODEL_RESPONSE_BODY',
+    (
+        '{"predictions":["  ansible.builtin.apt:\\n    name: nginx\\n'
+        'update_cache: true\\n    state: present\\n"]}'
+    ),
+)
+MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC = int(os.environ.get('MOCK_MODEL_RESPONSE_LATENCY_MSEC', 3000))
+MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER = bool(
+    os.environ.get('MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER', False)
+)
 
 ENABLE_ARI_POSTPROCESS = os.getenv('ENABLE_ARI_POSTPROCESS', 'False').lower() == 'true'
 ARI_BASE_DIR = os.getenv('ARI_KB_PATH', '/etc/ari/kb/')

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -23,7 +23,9 @@ ANSIBLE_AI_MODEL_MESH_MANAGEMENT_URL = (
     f"{ANSIBLE_AI_MODEL_MESH_HOST}:{ANSIBLE_AI_MODEL_MESH_MANAGEMENT_PORT}"
 )
 
-ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http"] = "http"
+ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http", "mock"] = os.getenv(
+    "ANSIBLE_AI_MODEL_MESH_API_TYPE", "http"
+)
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -25,7 +25,9 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 
 ALLOWED_HOSTS = [ANSIBLE_WISDOM_DOMAIN]
 
-ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http"] = "http"
+ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http", "mock"] = os.getenv(
+    "ANSIBLE_AI_MODEL_MESH_API_TYPE", "http"
+)
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"


### PR DESCRIPTION
currently the stage and perf deployments cannot scale out the model server sufficently to serve our target requests per second.

This introduces a setting to mock the model so we can isolate the django service and test the latency it introduces and the concurrency it can handle given configurable amount of latency we can inject to mock the model server.

This would unblock perf testing of the django service which right now is a bit of a dead end given the non-scalable deployment of the model in the perf and stage clusters, and allow us to verify if rest of application can handle the peak load we want to handle _given_ the model can be scaled to give a target latency.