### PR TITLE
slack notification for image build

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Print image url
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-      
+
     - name: Report to slack
       id: slack
       uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
added a step to the Build_Push_Image action to report to slack when the action completes (both success and failure will be reported)

note that this PR should only be merged after SLACK_WEBHOOK_URL was added as a github secret 