### PR TITLE
Add django-oauth-toolkit setting to support vscode:// redirects

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -103,6 +103,7 @@ SEGMENT_WRITE_KEY = os.environ.get("SEGMENT_WRITE_KEY")
 
 OAUTH2_PROVIDER = {
     'SCOPES': {'read': "Read scope", 'write': "Write scope"},
+    'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https', 'vscode'],
 }
 
 # ACCESS_TOKEN_EXPIRE_SECONDS = 36_000  # = 10 hours, default value


### PR DESCRIPTION
https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#allowed-redirect-uri-schemes

This setting is needed to allow us to directly redirect back to the VSCode plugin.