### PR TITLE
Add back in the Google protobuf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ djangorestframework==3.14.0
 grpcio==1.51.1
 social-auth-app-django==5.0.0
 social-auth-core==4.3.0
+protobuf==4.22.0
 pydantic==1.10.2
 psycopg2-binary==2.9.5
 redis==4.4.2


### PR DESCRIPTION
I just noticed this error:

```
django_1      |   File "/var/www/ansible_wisdom/ai/api/model_client/grpc_pb/inference_pb2.py", line 4, in <module>
django_1      |     from google.protobuf import descriptor as _descriptor
django_1      | ModuleNotFoundError: No module named 'google'
```