### PR TITLE
redis: add support for Redis Cluster

### DIFF
--- a/ansible_wisdom/main/redis.py
+++ b/ansible_wisdom/main/redis.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import redis.exceptions
+from django.core.cache.backends.redis import RedisCache, RedisCacheClient
+from redis import RedisCluster
+
+
+class RedisClusterCacheClient(RedisCacheClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = RedisCluster
+
+    def get_client(self, key=None, *, write=False):
+        for server in self._servers:
+            try:
+                return self._client.from_url(server)
+            except redis.exceptions.RedisClusterException:
+                continue
+
+
+class CustomRedisCluster(RedisCache):
+    """Redis client for Django based on RedisCluster
+
+    This driver only works with the Redis Clusters. Use
+    "django.core.cache.backends.redis.RedisCache" for the
+    regular deployment.
+    """
+
+    def __init__(self, server, params):
+        super().__init__(server, params)
+        self._class = RedisClusterCacheClient

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -29,7 +29,12 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        # In production, we use a Redis in Cluster mode. The consequence is that
+        # we cannot use the standard driver and we need instead to use Redis-Py's
+        # new RedisCluster client. This is what main.redis.CustomRedisCluster is
+        # for.
+        "BACKEND": "main.redis.CustomRedisCluster",
+        # NOTE: Use ',' to seperate the different servers
         "LOCATION": os.environ["ANSIBLE_AI_CACHE_URI"],
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ opensearch-py==2.1.1
 protobuf==4.22.1
 pydantic==1.10.2
 psycopg2-binary==2.9.5
-redis==4.4.2
+redis==4.5.1
 requests==2.28.1
 sentence-transformers==2.2.2
 uwsgi==2.0.21


### PR DESCRIPTION
Since version 4.1.0 (Dec 26, 2021), the Redis-Py library can directly
deal with Redis Cluster.

See: https://github.com/redis/redis-py/blob/master/docs/clustering.rst

Django's new Redis driver nor the Djang-Redis driver support yet the feature
natively.

This commit bump:
- Redis-Py to the last 4.5.1 release.
- Extend the `django.core.cache.backends.redis.rediscache` driver to add
  support for set-up with multiple master nodes.
- Adjust the setting files.

Note: My test environment was deployed using this image:
  https://hub.docker.com/r/bitnami/redis-cluster/
