### PR TITLE
Capture the host OAUTH2_ENABLE and pass it on to the dev container

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -28,6 +28,7 @@ services:
       - SOCIAL_AUTH_GITHUB_TEAM_SECRET=${SOCIAL_AUTH_GITHUB_TEAM_SECRET}
       - SECRET_KEY=${SECRET_KEY:-somesecret}
       - SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
+      - OAUTH2_ENABLE=${OAUTH2_ENABLE}
     command:
       - /usr/bin/launch-wisdom.sh
     networks:


### PR DESCRIPTION
so that we can easily switch it on and off in the development environment.