### PR TITLE
Turn on Django's APPEND_SLASH setting

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -228,7 +228,7 @@ STATIC_ROOT = '/var/www/wisdom/public/static'
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-APPEND_SLASH = False
+APPEND_SLASH = True
 
 # Depending on how env var is set, can end up with extraneous quotes.
 # this is defensive, we could just let it happen and


### PR DESCRIPTION
We should _not_ be 404-ing when someone leaves the slash off.