### PR TITLE
Slack wisdom-cicd-events link issue

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -67,7 +67,7 @@ jobs:
         # For posting a rich message using Block Kit
         payload: |
           {
-            "text": "wisdom service image build result: ${{ job.status }}\nimage tag: ${{ steps.build-image.outputs.tags }}\nlink to action: ${{ github.server_url }}${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "text": "wisdom service image build result: ${{ job.status }}\nimage tag: ${{ steps.build-image.outputs.tags }}\nlink to action: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This is for inserting `/` between `github.com` and `ansible` in the link sent to the wisdom-cicd-events channel.

![Screenshot from 2023-03-10 15-49-25](https://user-images.githubusercontent.com/27698807/224425646-30e696eb-0d32-45ea-832a-00963ed95f06.png)
