### PR TITLE
enable dependency caching for builds

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -43,6 +43,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up python3
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
Cache dependencies to speed up builds.

### Reviewer's notes:
⚠️ Please consider this [note from GitHub](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#about-caching-workflow-dependencies) while reviewing ⚠️ :

>Warning: Be mindful of the following when using caching with GitHub Actions:
>
> * We recommend that you don't store any sensitive information in the cache. For example, sensitive information can include access tokens or login credentials stored in a file in the cache path. Also, command line interface (CLI) programs like docker login can save access credentials in a configuration file. Anyone with read access can create a pull request on a repository and access the contents of a cache. Forks of a repository can also create pull requests on the base branch and access caches on the base branch.
>* When using self-hosted runners, caches from workflow runs are stored on GitHub-owned cloud storage. A customer-owned storage solution is only available with GitHub Enterprise Server.


### Results:
#### Before:
<img width="199" alt="image" src="https://user-images.githubusercontent.com/13005641/224453471-9c8dbf64-7196-4e8b-88f8-0d7110e14395.png">

#### After:
<img width="216" alt="image" src="https://user-images.githubusercontent.com/13005641/224455901-f84cfba6-9dbd-49ff-91d9-1c6c911fb539.png">



