### PR TITLE
list ansible-wisdom-anonymizor as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
 git+https://github.com/ansible/ansible-risk-insight#egg=ansible_risk_insight==0.1.0
+git+https://github.com/ansible/ansible-wisdom-anonymizor#egg=ansible-wisdom-anonymisor==0.1.0
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2
 pytz


### PR DESCRIPTION
ansible-wisdom-anonymizor is actually a new dependency of ari-metrics-for-wisdom
See: https://github.com/ansible/ari-metrics-for-wisdom/pull/26
This dependency will also be used to clean up the PII from the feedback and payload endpoints.