### PR TITLE
PR comment from local to upstream

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -59,3 +59,4 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: ansible_wisdom/code-coverage-results.md
+      if: ${{ !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
trying to get the coverage comment added to the PR.

when a PR is coming from a fork to the upstream the ansible org permissions does not allow for the PR to run actions with write permissions (which are needed to add a comment).

it does allow us (anyone with write access) to open a PR directly to the upstream repo (like this one) which will then run the actions with write access.

with the current permissions limitations this is the only viable solution for getting the coverage comment added to our PRs 