### PR TITLE
fix ari permission issue

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -21,6 +21,16 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     dnf remove -y epel-release && \
     dnf clean all
 
+COPY ansible_wisdom /var/www/ansible_wisdom
+COPY tools/scripts/launch-wisdom.sh /usr/bin/launch-wisdom.sh
+COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
+COPY tools/configs/nginx.conf /etc/nginx/nginx.conf
+COPY tools/configs/nginx-wisdom.conf /etc/nginx/conf.d/wisdom.conf
+COPY tools/scripts/wisdom-manage /usr/bin/wisdom-manage
+COPY tools/configs/uwsgi.ini /etc/wisdom/uwsgi.ini
+COPY tools/configs/supervisord.conf /etc/supervisor/supervisord.conf
+COPY ari /etc/ari
+
 RUN /usr/bin/python3 -m pip --no-cache-dir install supervisor
 RUN for dir in \
       /var/log/supervisor \
@@ -37,16 +47,6 @@ COPY requirements.txt /var/www/
 RUN /var/www/venv/bin/python3 -m pip --no-cache-dir install -r/var/www/requirements.txt
 RUN echo "/var/www/ansible_wisdom" > /var/www/venv/lib/python3.9/site-packages/project.pth
 WORKDIR /var/www
-
-COPY ansible_wisdom /var/www/ansible_wisdom
-COPY tools/scripts/launch-wisdom.sh /usr/bin/launch-wisdom.sh
-COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
-COPY tools/configs/nginx.conf /etc/nginx/nginx.conf
-COPY tools/configs/nginx-wisdom.conf /etc/nginx/conf.d/wisdom.conf
-COPY tools/scripts/wisdom-manage /usr/bin/wisdom-manage
-COPY tools/configs/uwsgi.ini /etc/wisdom/uwsgi.ini
-COPY tools/configs/supervisord.conf /etc/supervisor/supervisord.conf
-COPY ari /etc/ari
 
 USER 1000
 EXPOSE 8000


### PR DESCRIPTION
Per James:
"""
that was so that changes to the wisdom files didnt rerun all the container steps
i.e. it can reuses the layers if the checksum does not change
so the requirements.txt and install is doe before the copy of the wisdom files
meaning the install will not have to happen again unlesss the requirements.txt changes
"""

Good idea but we need to look at which files need these permission changes and update accordingly. For now, revert to original ordering to fix ARI.