### PR TITLE
Configurable timeout on Completions API

### DIFF
--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -6,7 +6,13 @@ from django.conf import settings
 class ModelMeshClient:
     def __init__(self, inference_url):
         self._inference_url = inference_url
+        i = settings.ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+        self._timeout = int(i) if i is not None else None
 
     @abstractmethod
-    def infer(self, model_input, model_name="wisdom"):
+    def infer(self, model_input, model_name="wisdom"):  # pragma: no cover
         pass
+
+    @property
+    def timeout(self):
+        return self._timeout

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -33,6 +33,7 @@ class GrpcClient(ModelMeshClient):
             response = self._inference_stub.AnsiblePredict(
                 request=common_service_pb2.AnsibleRequest(prompt=prompt, context=context),
                 metadata=[("mm-vmodel-id", model_name)],
+                timeout=self.timeout,
             )
 
             logger.debug(f"inference response: {response}")

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import requests
+from rest_framework import status
 from rest_framework.response import Response
 
 from .base import ModelMeshClient
@@ -17,5 +18,7 @@ class HttpClient(ModelMeshClient):
 
     def infer(self, model_input, model_name="wisdom") -> Response:
         self._prediction_url = f"{self._inference_url}/predictions/{model_name}"
-        result = self.session.post(self._prediction_url, headers=self.headers, json=model_input)
+        result = self.session.post(
+            self._prediction_url, headers=self.headers, json=model_input, timeout=self.timeout
+        )
         return Response(json.loads(result.text), status=result.status_code)

--- a/ansible_wisdom/ai/api/tests/test_api_timeout.py
+++ b/ansible_wisdom/ai/api/tests/test_api_timeout.py
@@ -1,0 +1,62 @@
+import uuid
+from http import HTTPStatus
+from unittest.mock import patch
+
+import grpc
+from ai.api.model_client.grpc_client import GrpcClient
+from ai.api.model_client.http_client import HttpClient
+from django.apps import apps
+from django.test import override_settings
+from django.urls import reverse
+from requests.exceptions import Timeout
+
+from .test_views import WisdomServiceAPITestCaseBase
+
+
+class TestApiTimeout(WisdomServiceAPITestCaseBase):
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
+    def test_timeout_settings_is_none(self):
+        model_client = HttpClient(inference_url='http://example.com/')
+        self.assertIsNone(model_client.timeout)
+
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=123)
+    def test_timeout_settings_is_not_none(self):
+        model_client = HttpClient(inference_url='http://example.com/')
+        self.assertEqual(123, model_client.timeout)
+
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
+    def test_timeout_settings_is_none_grpc(self):
+        model_client = GrpcClient(inference_url='http://example.com/')
+        self.assertIsNone(model_client.timeout)
+
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=123)
+    def test_timeout_settings_is_not_none_grpc(self):
+        model_client = GrpcClient(inference_url='http://example.com/')
+        self.assertEqual(123, model_client.timeout)
+
+    @patch("ai.api.model_client.http_client.HttpClient.infer", side_effect=Timeout())
+    def test_timeout_http_timeout(self, _):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
+            "suggestionId": str(uuid.uuid4()),
+        }
+        r = self.client.post(reverse('completions'), payload)
+        self.assertEqual(HTTPStatus.SERVICE_UNAVAILABLE, r.status_code)
+        self.assertEqual("Unable to complete the request", r.data)
+
+    @patch("grpc.UnaryUnaryMultiCallable.__call__", side_effect=grpc.RpcError())
+    def test_timeout_grpc_timeout(self, _):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
+            "suggestionId": str(uuid.uuid4()),
+        }
+        with patch.object(
+            apps.get_app_config('ai'),
+            'model_mesh_client',
+            GrpcClient(inference_url='http://example.com/'),
+        ):
+            r = self.client.post(reverse('completions'), payload)
+            self.assertEqual(HTTPStatus.SERVICE_UNAVAILABLE, r.status_code)
+            self.assertEqual("Unable to complete the request", r.data)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -5,6 +5,7 @@ import uuid
 from http import HTTPStatus
 from unittest.mock import patch
 
+from ai.api.model_client.base import ModelMeshClient
 from ai.api.serializers import CompletionRequestSerializer
 from ai.api.views import Completions
 from django.apps import apps
@@ -16,8 +17,9 @@ from rest_framework.response import Response
 from rest_framework.test import APITestCase
 
 
-class DummyMeshClient:
+class DummyMeshClient(ModelMeshClient):
     def __init__(self, test, payload, response_data):
+        super().__init__(inference_url='dummy inference url')
         self.test = test
 
         if "prompt" in payload:

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -194,6 +194,8 @@ DATABASES = {
     }
 }
 
+# Model API Timeout (in seconds). Default is None.
+ANSIBLE_AI_MODEL_MESH_API_TIMEOUT = os.getenv("ANSIBLE_AI_MODEL_MESH_API_TIMEOUT")
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -36,7 +36,7 @@ if DEBUG:
     SPECTACULAR_SETTINGS = {
         'TITLE': 'Ansible Wisdom Service',
         'DESCRIPTION': 'Equip the automation developer with Wisdom super powers.',
-        'VERSION': '0.0.4',
+        'VERSION': '0.0.5',
         'SERVE_INCLUDE_SCHEMA': False,
         # OTHER SETTINGS
         'TAGS': [

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Ansible Wisdom Service
-  version: 0.0.4
+  version: 0.0.5
   description: Equip the automation developer with Wisdom super powers.
 paths:
   /api/ai/completions/:
@@ -37,7 +37,9 @@ paths:
               $ref: '#/components/schemas/CompletionRequest'
         required: true
       security:
-      - tokenAuth: []
+      - oauth2:
+        - read
+        - write
       - cookieAuth: []
       responses:
         '200':
@@ -62,6 +64,8 @@ paths:
           description: Unauthorized
         '429':
           description: Request was throttled
+        '503':
+          description: Service Unavailable
   /api/ai/feedback/:
     post:
       operationId: ai_feedback_create
@@ -109,6 +113,7 @@ paths:
               $ref: '#/components/schemas/FeedbackRequest'
       security:
       - oauth2:
+        - read
         - write
       - cookieAuth: []
       responses:
@@ -124,7 +129,6 @@ paths:
       tags:
       - me
       security:
-      - tokenAuth: []
       - cookieAuth: []
       responses:
         '200':
@@ -303,9 +307,9 @@ components:
       type: apiKey
       in: cookie
       name: sessionid
-    tokenAuth:
-      type: http
-      scheme: bearer
+    oauth2:
+      type: oauth2
+      flows: {}
 tags:
 - name: ai
   description: AI-related operations


### PR DESCRIPTION
For [AAP-9609](https://issues.redhat.com/browse/AAP-9609) Set configurable timeout on post to model server.

~~**Note** Timeout for gRPC clients is not implemented yet.~~ ← It's implemented.

`ANSIBLE_AI_MODEL_MESH_API_TIMEOUT` is the new environment variable to set the timeout. Default is `None` (= no timeout). If a timeout occurs in a model server inference call (either in http or gRPC), it ended up with a 503 response.

