### PR TITLE
Put the Python venv setup and package installation as early as possible

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -21,6 +21,12 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     dnf remove -y epel-release && \
     dnf clean all
 
+RUN /usr/bin/python3 -m pip --no-cache-dir install supervisor
+RUN /usr/bin/python3 -m venv /var/www/venv
+COPY requirements.txt /var/www/
+RUN /var/www/venv/bin/python3 -m pip --no-cache-dir install -r/var/www/requirements.txt
+RUN echo "/var/www/ansible_wisdom" > /var/www/venv/lib/python3.9/site-packages/project.pth
+
 COPY ansible_wisdom /var/www/ansible_wisdom
 COPY tools/scripts/launch-wisdom.sh /usr/bin/launch-wisdom.sh
 COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
@@ -31,7 +37,6 @@ COPY tools/configs/uwsgi.ini /etc/wisdom/uwsgi.ini
 COPY tools/configs/supervisord.conf /etc/supervisor/supervisord.conf
 COPY ari /etc/ari
 
-RUN /usr/bin/python3 -m pip --no-cache-dir install supervisor
 RUN for dir in \
       /var/log/supervisor \
       /var/run/supervisor \
@@ -42,10 +47,6 @@ RUN for dir in \
     do mkdir -p $dir ; chgrp -R 0 $dir; chmod -R g=u $dir ; done && \
     echo "\setenv PAGER 'less -SXF'" > /etc/psqlrc
 ENV ANSIBLE_HOME=/etc/ansible
-RUN /usr/bin/python3 -m venv /var/www/venv
-COPY requirements.txt /var/www/
-RUN /var/www/venv/bin/python3 -m pip --no-cache-dir install -r/var/www/requirements.txt
-RUN echo "/var/www/ansible_wisdom" > /var/www/venv/lib/python3.9/site-packages/project.pth
 WORKDIR /var/www
 
 USER 1000


### PR DESCRIPTION
This ought to allow the package installation steps to be avoided during builds unless the requirements file has actually changed.

Also, the ari file copy and permissions setting steps retain the same order they originally had, which ought to prevent the permissions problem we were briefly seeing.