### PR TITLE
Allow for non-token users to interact with the API

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -38,10 +38,14 @@ class Completions(APIView):
 
     # OAUTH: remove the conditional
     if settings.OAUTH2_ENABLE:
-        from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope
+        from oauth2_provider.contrib.rest_framework import (
+            IsAuthenticatedOrTokenHasScope,
+        )
         from rest_framework import permissions
 
-        permission_classes = [permissions.IsAuthenticated, TokenHasReadWriteScope]
+        permission_classes = [permissions.IsAuthenticated, IsAuthenticatedOrTokenHasScope]
+        required_scopes = ['read', 'write']
+
     throttle_classes = [CompletionsUserRateThrottle]
 
     @extend_schema(
@@ -206,10 +210,13 @@ class Feedback(APIView):
 
     # OAUTH: remove the conditional
     if settings.OAUTH2_ENABLE:
-        from oauth2_provider.contrib.rest_framework import TokenHasReadWriteScope
+        from oauth2_provider.contrib.rest_framework import (
+            IsAuthenticatedOrTokenHasScope,
+        )
         from rest_framework import permissions
 
-        permission_classes = [permissions.IsAuthenticated, TokenHasReadWriteScope]
+        permission_classes = [permissions.IsAuthenticated, IsAuthenticatedOrTokenHasScope]
+        required_scopes = ['read', 'write']
 
     @extend_schema(
         request=FeedbackRequestSerializer,


### PR DESCRIPTION
This will allow (developer) users to continue to use the browseable API, and also should allow the Swagger UI interaction without having to come up with some workaround for the OAuth2 flow.

Ref: https://django-oauth-toolkit.readthedocs.io/en/latest/rest-framework/permissions.html#isauthenticatedortokenhasscope