### PR TITLE
remove unnecessary CSRF configuration

### DIFF
--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -32,5 +32,3 @@ CACHES = {
         "LOCATION": os.environ["ANSIBLE_AI_CACHE_URI"],
     }
 }
-
-CSRF_TRUSTED_ORIGINS = list(map(lambda x: f"https://{x}", ALLOWED_HOSTS))


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-wisdom-ops/pull/79

The root cause of the CSRF issue we saw appears to have been caused by a mismatch between the edge protocol scheme and the origin protocol scheme (a CDN misconfiguration).

This PR removes the unnecessary configuration change.