### PR TITLE
dial back exceptions

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -72,7 +72,7 @@ class Completions(APIView):
             payload.context, payload.prompt = self.preprocess(payload.context, payload.prompt)
         except Exception:
             # return the original prompt, context
-            logger.exception(f'failed to preprocess {payload.context}{payload.prompt}')
+            logger.info(f'failed to preprocess {payload.context}{payload.prompt}')
             return Response({'message': 'Request contains invalid yaml'}, status=400)
         model_mesh_payload = ModelMeshPayload(
             instances=[
@@ -138,7 +138,7 @@ class Completions(APIView):
                     else:
                         recommendation_problem = exc
                     if recommendation_problem:
-                        logger.exception(
+                        logger.error(
                             f'the recommendation_yaml is not a valid YAML: '
                             f'\n{recommendation_yaml}'
                         )
@@ -177,7 +177,7 @@ class Completions(APIView):
                 except Exception as exc:
                     exception = exc
                     # return the original recommendation if we failed to postprocess
-                    logger.exception(
+                    logger.error(
                         f'failed to postprocess recommendation with prompt {prompt} '
                         f'context {context} and model recommendation {recommendation}'
                     )


### PR DESCRIPTION
current logger.exception in postprocess cause a lot of noise in the logs... dialing back to error.
changed the logger.exception in preprocess to an info (though probably can go to debug in short order) as this implies the user sent invalid yaml.