### PR TITLE
enable the anonymizor on the user prompt/context/feedback

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -186,6 +186,22 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
         r = self.client.post(reverse('feedback'), payload, format="json")
         self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
+    def test_anonymize(self):
+        payload = {
+            "ansibleContent": {
+                "content": "---\n- hosts: all\n  become: yes\n\n  "
+                "tasks:\n    - name: Install Apache\n",
+                "documentUri": "file:///home/jean-pierre/ansible.yaml",
+                "trigger": "0",
+            }
+        }
+        self.client.force_authenticate(user=self.user)
+        with self.assertLogs(logger='root', level='DEBUG') as log:
+            r = self.client.post(reverse('feedback'), payload, format="json")
+            print(log.output)
+            self.assertNotInLog('file:///home/user/ansible.yaml', log.output)
+            self.assertInLog('file:///home/ano-user/ansible.yaml', log.output)
+
     def test_authentication_error(self):
         payload = {
             "ansibleContent": {
@@ -281,3 +297,19 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 self.assertEqual(HTTPStatus.NO_CONTENT, r.status_code)
                 self.assertEqual(None, r.data)
                 self.assertInLog('error postprocessing prediction for suggestion', log.output)
+
+    def test_completions_pii_clean_up(self):
+        payload = {
+            "prompt": "- name: Create an account for foo@ansible.com \n",
+            "suggestionId": str(uuid.uuid4()),
+        }
+        response_data = {"predictions": [""]}
+        self.client.force_authenticate(user=self.user)
+        with self.assertLogs(logger='root', level='DEBUG') as log:
+            with patch.object(
+                apps.get_app_config('ai'),
+                'model_mesh_client',
+                DummyMeshClient(self, payload, response_data),
+            ):
+                r = self.client.post(reverse('completions'), payload)
+                self.assertInLog('Create an account for james8@example.com', log.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,9 @@ django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
 ansible-risk-insight==0.1.0
+# NOTE: To remove once ARI ruleset v0.0.4 is released
 git+https://github.com/goneri/ansible-wisdom-anonymizor#egg=ansible-wisdom-anonymisor==0.1.0
+ansible_anonymizer==1.0.0
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2
 pytz


### PR DESCRIPTION
This will change the behaviour of some requests in some few cases. For instance,

`Authorize the /home/erwan/.ssh/id_rsa.pub SSH key` will be transformed
to `Authorize the /home/ano-user/.ssh/id_rsa.pub SSH key` before being send to
the model-server.
