### PR TITLE
ari: enable W011 (with_* rewrite) by default

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -278,6 +278,7 @@ ARI_RULES = [
     "W008",
     "W009",
     "W010",
+    "W011",  # replace with_* loop with the modern loop:
     "W012",
     "W013",
     "W014",


### PR DESCRIPTION
Activate the rewrite of the with_* loops back default.

See: https://issues.redhat.com/browse/AAP-9380
