### PR TITLE
Capture Segment errors in log

### DIFF
--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -12,9 +12,6 @@ def send_segment_event(event: Dict[str, Any], event_name: str, user_id: Union[st
         logger.info("segment write key not set, skipping event")
         return
 
-    analytics.write_key = settings.SEGMENT_WRITE_KEY
-    analytics.debug = settings.DEBUG
-    analytics.send = True
     analytics.track(
         str(user_id) if user_id else 'unknown',
         event_name,


### PR DESCRIPTION
This is for collecting information about errors that occur in sending data to Segment for [AAP-10114](https://issues.redhat.com/browse/AAP-10114).

It uses [the `on_error` hook provided by Segment Python library](https://segment.com/docs/connections/sources/catalog/libraries/server/python/#detecting-errors).