### PR TITLE
apply new ARI rules with the default settings

### DIFF
--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -133,6 +133,7 @@ class ARICaller:
                         rule_detail["description"] = _result.description
                     rule_detail["duration"] = _result.duration
                     rule_detail["matched"] = _result.matched
+                    rule_detail["error"] = _result.error
                 detail_data[rule_id] = rule_detail
 
         # return inference_output

--- a/tools/scripts/install-ari-rule-requirements.sh
+++ b/tools/scripts/install-ari-rule-requirements.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -o errexit
 
-if [ ! -z $ARI_KB_PATH ]; then
-    rules_dir="$ARI_KB_PATH/rules"
-    if [ -d $rules_dir ]; then
-        for requirements in `find $rules_dir -name '*requirements.txt'`; do
-            /var/www/venv/bin/python3 -m pip install --no-cache-dir -r $requirements
-        done
-    fi
+rules_dir=/etc/ari/kb/rules
+
+if [ -d $rules_dir ]; then
+    for requirements in `find $rules_dir -name '*requirements.txt'`; do
+        /var/www/venv/bin/python3 -m pip install --no-cache-dir -r $requirements
+    done
 fi

--- a/tools/scripts/launch-wisdom.sh
+++ b/tools/scripts/launch-wisdom.sh
@@ -22,9 +22,5 @@ done
 /var/www/venv/bin/python ansible_wisdom/manage.py migrate --noinput
 /var/www/venv/bin/python ansible_wisdom/manage.py collectstatic --noinput
 
-if [ $ENABLE_ARI_POSTPROCESS == "True" ]; then
-    /usr/bin/install-ari-rule-requirements.sh
-fi
-
 cd ansible_wisdom/
 /usr/local/bin/supervisord -n

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -56,6 +56,7 @@ RUN for dir in \
       /etc/ansible ; \
     do mkdir -p $dir ; chgrp -R 0 $dir; chmod -R g=u $dir ; done && \
     echo "\setenv PAGER 'less -SXF'" > /etc/psqlrc
+RUN /usr/bin/install-ari-rule-requirements.sh
 ENV ANSIBLE_HOME=/etc/ansible
 WORKDIR /var/www
 


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- apply new ARI rules with the default settings
- update to install some required packages for ARI rules if any
  - the packages are installed at the image build time
  - `<RULE_ID>-requirements.txt` should be placed in the rules directory as well as the rule itself if the rule has dependencies