### PR TITLE
anonymizor: use a copy during the package renaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
 git+https://github.com/ansible/ansible-risk-insight#egg=ansible_risk_insight==0.1.0
-git+https://github.com/ansible/ansible-wisdom-anonymizor#egg=ansible-wisdom-anonymisor==0.1.0
+git+https://github.com/goneri/ansible-wisdom-anonymizor#egg=ansible-wisdom-anonymisor==0.1.0
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2
 pytz


### PR DESCRIPTION
The package will be renamed from ansible-wisdom-anonymisor to ansible-anonymizer.
To avoid any disruption during the transition, we pull the module from a fork.
