### PR TITLE
return 204 on model timeout and postprocess failure

### DIFF
--- a/ansible_wisdom/ai/api/model_client/exceptions.py
+++ b/ansible_wisdom/ai/api/model_client/exceptions.py
@@ -1,0 +1,2 @@
+class ModelTimeoutError(Exception):
+    """The model server did not provide a prediction in the allotted time."""

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from .base import ModelMeshClient
+from .exceptions import ModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +17,14 @@ class HttpClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_name="wisdom") -> Response:
+    def infer(self, model_input, model_name="wisdom"):
         self._prediction_url = f"{self._inference_url}/predictions/{model_name}"
-        result = self.session.post(
-            self._prediction_url, headers=self.headers, json=model_input, timeout=self.timeout
-        )
-        return Response(json.loads(result.text), status=result.status_code)
+
+        try:
+            result = self.session.post(
+                self._prediction_url, headers=self.headers, json=model_input, timeout=self.timeout
+            )
+            result.raise_for_status()
+            return json.loads(result.text)
+        except requests.exceptions.ReadTimeout:
+            raise ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/mock_client.py
+++ b/ansible_wisdom/ai/api/model_client/mock_client.py
@@ -18,9 +18,9 @@ class MockClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_name="wisdom") -> Response:
+    def infer(self, model_input, model_name="wisdom"):
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'mock' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
         jitter = random.random() if settings.MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER else 1
         time.sleep((settings.MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter) / 1000)
-        return Response(json.loads(settings.MOCK_MODEL_RESPONSE_BODY))
+        return json.loads(settings.MOCK_MODEL_RESPONSE_BODY)

--- a/ansible_wisdom/healthcheck/tests/test_healthcheck.py
+++ b/ansible_wisdom/healthcheck/tests/test_healthcheck.py
@@ -24,6 +24,7 @@ class TestHealthCheck(APITestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertJSONEqual(r.content, {"status": "ok"})
 
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
     def test_health_check(self):
         cache.clear()
         r = self.client.get(reverse('health_check'))

--- a/ansible_wisdom/main/exception_handler.py
+++ b/ansible_wisdom/main/exception_handler.py
@@ -1,0 +1,17 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+def exception_handler_with_error_type(exc, context):
+    # Call the default exception handler first
+    response = exception_handler(exc, context)
+
+    if exc.status_code == 204:
+        response.data = None
+
+    # Add error type if specified
+    if hasattr(exc, 'error_type'):
+        response.error_type = exc.error_type
+
+    return response

--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -48,8 +48,12 @@ class SegmentMiddleware:
                 prompt = request_data.get('prompt')
                 metadata = request_data.get('metadata', {})
 
+                predictions = None
+                message = None
                 response_data = getattr(response, 'data', {})
-                predictions = response_data.get('predictions')
+                if type(response_data) == dict:
+                    predictions = response_data.get('predictions')
+                    message = response_data.get('message')
 
                 duration = round((time.time() - start_time) * 1000, 2)
                 event = {
@@ -57,6 +61,8 @@ class SegmentMiddleware:
                     "request": {"context": context, "prompt": prompt},
                     "response": {
                         "exception": getattr(response, 'exception', None),
+                        "error_type": getattr(response, 'error_type', None),
+                        "message": message,
                         "predictions": predictions,
                         "status_code": response.status_code,
                         "status_text": getattr(response, 'status_text', None),

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -137,6 +137,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'EXCEPTION_HANDLER': 'main.exception_handler.exception_handler_with_error_type',
 }
 # OAUTH: fold into above
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'][:0] = [


### PR DESCRIPTION
Returns a 204 No Content when the model server either does not respond fast enough or returns a prediction we can't successfully postprocess. Leverages a custom exception handler in order to easily pass extra info to the segment middleware.
https://issues.redhat.com/browse/AAP-10333
Also fixes https://issues.redhat.com/browse/AAP-10489