### PR TITLE
remove pii gathered by django social auth

### DIFF
--- a/ansible_wisdom/main/pipeline.py
+++ b/ansible_wisdom/main/pipeline.py
@@ -1,0 +1,5 @@
+def remove_pii(strategy, details, backend, user=None, *args, **kwargs):
+    details.pop('email', None)
+    details.pop('fullname', None)
+    details.pop('first_name', None)
+    details.pop('last_name', None)

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -105,6 +105,17 @@ SOCIAL_AUTH_GITHUB_TEAM_SECRET = os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_SECRET'
 SOCIAL_AUTH_GITHUB_TEAM_ID = os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_ID', 7188893)
 SOCIAL_AUTH_GITHUB_TEAM_SCOPE = ["read:org"]
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/unauthorized/'
+SOCIAL_AUTH_PIPELINE = [
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'main.pipeline.remove_pii',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.user.user_details',
+]
 
 # Wisdom Eng Team:
 # gh api -H "Accept: application/vnd.github+json" /orgs/ansible/teams/wisdom-contrib

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -9,7 +9,7 @@
           <h1 class="pf-c-title pf-m-lg">Thank you for participating in the Project Wisdom closed beta.</h1>
           {% if user.is_authenticated %}
             <div class="pf-c-empty-state__body">
-              <p>You are signed in as {{user.username}}{% if user.email %} ({{user.email}}){% endif %}.</p>
+              <p>You are signed in as {{user.username}}.</p>
               <p>Access the <a href={{pilot_docs_url}} target="_blank">documentation</a> to begin.</p>
               <!-- <p><b>Authentication Token:</b> {{drf_token}}</p> -->
               <br><br>

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -15,7 +15,7 @@ class TestUsers(WisdomServiceAPITestCaseBase):
         self.login()
         r = self.client.get(reverse('home'))
         self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertIn(f'You are signed in as {self.username} ({self.email}).', str(r.content))
+        self.assertIn(f'You are signed in as {self.username}.', str(r.content))
 
     def test_home_view_without_login(self):
         r = self.client.get(reverse('home'))


### PR DESCRIPTION
Add a custom pipeline function to exclude user details we don't want to save in our db.