### PR TITLE
install ARI from pypi instead of github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ uwsgi==2.0.21
 django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
-git+https://github.com/ansible/ansible-risk-insight#egg=ansible_risk_insight==0.1.0
+ansible-risk-insight==0.1.0
 git+https://github.com/goneri/ansible-wisdom-anonymizor#egg=ansible-wisdom-anonymisor==0.1.0
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- install ARI from PyPI as a package instead of github

Issue: [AAP-9635](https://issues.redhat.com/browse/AAP-9635)