### PR TITLE
Replace protobuf 4.22.1 with 4.22.0 for AAP-10114

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ grpcio==1.51.1
 social-auth-app-django==5.0.0
 social-auth-core==4.3.0
 opensearch-py==2.1.1
-protobuf==4.22.1
+protobuf==4.22.0
 pydantic==1.10.2
 psycopg2-binary==2.9.5
 redis==4.5.1


### PR DESCRIPTION
This PR is for testing protobuf 4.22.0 for [AAP-10114](https://issues.redhat.com/browse/AAP-10114) SSL error when attempting to send events to segment. This will be deployed only in the stage environment and will be reverted soon after the test is completed.