### PR TITLE
Add uuid to list view and allow editing term accepted date on Admin UI

### DIFF
--- a/ansible_wisdom/users/admin.py
+++ b/ansible_wisdom/users/admin.py
@@ -6,7 +6,8 @@ from .models import User
 
 class WisdomUserAdmin(UserAdmin):
     # add any additional fields you want to display in the User page
-    list_display = ('username', 'is_staff', 'date_terms_accepted')
+    list_display = ('username', 'is_staff', 'date_terms_accepted', 'uuid')
+    fieldsets = UserAdmin.fieldsets + ((None, {'fields': ('date_terms_accepted',)}),)
 
 
 admin.site.register(User, WisdomUserAdmin)


### PR DESCRIPTION
This will add uuid to the list view of Users on and also allow editing the term accepted date on Admin UI.
I want to have them for development purpose. Though I think it is ok to enable them on Admin UI both in development and in production environments, I will add `if settings.DEBUG:` block, if these are considered as the features that should be enabled in development environment only.

![Screenshot from 2023-03-24 11-03-53](https://user-images.githubusercontent.com/27698807/227565931-60d9cb84-47d5-48c8-b7f0-e14963f4d6e9.png)
![Screenshot from 2023-03-24 11-03-24](https://user-images.githubusercontent.com/27698807/227565944-d1499eb7-ec1d-4f89-a943-f45bb8687fe4.png)
