### PR TITLE
defer the loading of ARI and use ENABLE_ARI_POSTPROCESS

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -266,6 +266,7 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 self.assertIsNotNone(r.data['predictions'])
                 self.assertNotInLog('the recommendation_yaml is not a valid YAML', log.output)
 
+    @override_settings(ENABLE_ARI_POSTPROCESS=True)
     def test_completions_postprocessing_error(self):
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -165,7 +165,7 @@ class Completions(APIView):
         return context, prompt
 
     def postprocess(self, recommendation, prompt, context, user_id, suggestion_id, indent):
-        ari_caller = apps.get_app_config("ai").ari_caller
+        ari_caller = apps.get_app_config("ai").get_ari_caller()
         if not ari_caller:
             logger.warn('skipped ari post processing because ari was not initialized')
 

--- a/ansible_wisdom/ai/tests/test_apps.py
+++ b/ansible_wisdom/ai/tests/test_apps.py
@@ -29,10 +29,10 @@ class TestAiApp(APITestCase):
     def test_enable_ari(self):
         app_config = AppConfig.create('ai')
         app_config.ready()
-        self.assertIsNotNone(app_config.ari_caller)
+        self.assertIsNotNone(app_config.get_ari_caller())
 
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_disable_ari(self):
         app_config = AppConfig.create('ai')
         app_config.ready()
-        self.assertIsNone(app_config.ari_caller)
+        self.assertIsNone(app_config.get_ari_caller())

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -16,6 +16,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
         super().setUpClass()
         analytics.send = False  # do not send data to segment from unit tests
 
+    @override_settings(ENABLE_ARI_POSTPROCESS=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_full_payload(self):
         payload = {


### PR DESCRIPTION
Defer the loading of ARI and read the value of `ENABLE_ARI_POSTPROCESS` to know if ARI should be used. This allow us to:
- turn ARI on or off in the tests depending on the needs.
- have an implicit declaration of the dependency on the configuration key in the key in the test.