### PR TITLE
fixing issue with long prompts breakign into multiple lines

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -63,7 +63,7 @@ Normalize by loading and re-serializing
 
 def normalize_yaml(yaml_str):
     data = yaml.load(yaml_str, Loader=yaml.SafeLoader)
-    return yaml.dump(data, Dumper=AnsibleDumper, allow_unicode=True, sort_keys=False)
+    return yaml.dump(data, Dumper=AnsibleDumper, allow_unicode=True, sort_keys=False, width=10000)
 
 
 def preprocess(context, prompt):


### PR DESCRIPTION
As discussed here https://redhat-internal.slack.com/archives/C04JV5M7S1E/p1679870584506039 this pre-processing fn was causing prompt to break into multiple lines 

`- name: Download https://mybackupserver.localdomain/backup.zip and extract to /tmp directory `
would be split into 
> it seems like the model is receiving context as - name: Download https://mybackupserver.localdomain/backup.zip and extract to /tmp and prompt as ` directory`.

in order to fix this, using a really large width to prevent breaking the line into multiple lines