### PR TITLE
TEMPORARILY skip SSL certificate verification in status check with gRPC model server

### DIFF
--- a/ansible_wisdom/healthcheck/backends.py
+++ b/ansible_wisdom/healthcheck/backends.py
@@ -30,7 +30,7 @@ class ModelServerHealthCheck(BaseHealthCheckBackend):
                 # the gRPC model server in the Staging environment.  The verify
                 # option in the following line is just TEMPORARY and will be removed
                 # as soon as the certificate is replaced with a valid one.
-                res = requests.get(self.url, verify=(self.api_type != 'grpc')) # !!!!! TODO !!!!!
+                res = requests.get(self.url, verify=(self.api_type != 'grpc'))  # !!!!! TODO !!!!!
                 if res.status_code != 200:
                     raise Exception()
             else:


### PR DESCRIPTION
TEMPORARILY skip SSL certificate verification in status check with gRPC model server.

Following `SSLCertVerificationError` is thrown from the status check API with the gRPC model server currently running in the Stage cluster.  To workaround this issue, we'll TEMPORARILY skip SSL certificate verification  in status check with gRPC model server.
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1129)
```