### PR TITLE
allow override of django cache backend

### DIFF
--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -38,7 +38,9 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "BACKEND": os.getenv(
+            "ANSIBLE_AI_CACHE_BACKEND", "django.core.cache.backends.redis.RedisCache"
+        ),
         "LOCATION": os.getenv("ANSIBLE_AI_CACHE_URI", "redis://redis:6379"),
     }
 }

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -45,7 +45,7 @@ CACHES = {
         # we cannot use the standard driver and we need instead to use Redis-Py's
         # new RedisCluster client. This is what main.redis.CustomRedisCluster is
         # for.
-        "BACKEND": "main.redis.CustomRedisCluster",
+        "BACKEND": os.getenv("ANSIBLE_AI_CACHE_BACKEND", "main.redis.CustomRedisCluster"),
         # NOTE: Use ',' to seperate the different servers
         "LOCATION": os.environ["ANSIBLE_AI_CACHE_URI"],
     }


### PR DESCRIPTION
Pilot cluster is "production" but doesn't have a RedisCluster.