### PR TITLE
Remove the restart directive from our docker-compose files

### DIFF
--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -2,7 +2,6 @@ version: "3.8"
 services:
   redis:
     image: docker.io/library/redis:alpine
-    restart: always
     networks:
       - dbnet
     ports:
@@ -13,7 +12,6 @@ services:
       - POSTGRES_PASSWORD=wisdom
       - POSTGRES_DB=wisdom
       - POSTGRES_USER=wisdom
-    restart: always
     networks:
       - dbnet
 # Disabled because this doesn't work properly on MacOS.
@@ -30,7 +28,6 @@ services:
       - --web.enable-lifecycle
     volumes:
       - $PWD/prometheus/prometheus.yaml:/opt/prometheus/prometheus.yaml
-    restart: unless-stopped
     ports:
       - "9090:9090"
     networks:
@@ -43,7 +40,6 @@ services:
       - "3000:3000"
     volumes:
       - $PWD/grafana:/opt/grafana
-    restart: unless-stopped
     networks:
       - dbnet
 

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -8,7 +8,6 @@ services:
     depends_on:
       - redis
       - db
-    restart: always
     volumes:
       - $PWD/ansible_wisdom:/var/www/ansible_wisdom
       - $PWD/ari/kb:/etc/ari/kb
@@ -41,7 +40,6 @@ services:
       - dbnet
   redis:
     image: docker.io/library/redis:alpine
-    restart: always
     networks:
       - dbnet
     ports:
@@ -52,7 +50,6 @@ services:
       - POSTGRES_PASSWORD=wisdom
       - POSTGRES_DB=wisdom
       - POSTGRES_USER=wisdom
-    restart: always
     networks:
       - dbnet
 # Disabled because this doesn't work properly on MacOS.
@@ -69,7 +66,6 @@ services:
       - --web.enable-lifecycle
     volumes:
       - $PWD/prometheus/prometheus.yaml:/opt/prometheus/prometheus.yaml
-    restart: unless-stopped
     ports:
       - "9090:9090"
     networks:
@@ -82,7 +78,6 @@ services:
       - "3000:3000"
     volumes:
       - $PWD/grafana:/opt/grafana
-    restart: unless-stopped
     networks:
       - dbnet
 


### PR DESCRIPTION
`restart: always` causes our containers to come up when the docker daemon restarts (e.g. when we boot our laptops in the morning).  I wouldn't have noticed it necessarily, except that during a meeting just now I started getting system notifications that uwsgi was crashing, and I hadn't explicitly started my containers yet.

`restart: unless-stopped` behaves very similarly.

The default is `restart: no`, which seems sane to me.

ref: https://docs.docker.com/config/containers/start-containers-automatically/