### PR TITLE
nginx connect() failed errors in logs

### DIFF
--- a/tools/configs/nginx-wisdom.conf
+++ b/tools/configs/nginx-wisdom.conf
@@ -1,5 +1,5 @@
 upstream uwsgi {
-    server localhost:8050;
+    server 127.0.0.1:8050;
 }
 
 server {


### PR DESCRIPTION
For [AAP-10517](https://issues.redhat.com/browse/AAP-10517).

Reference: [A serverfault.com post](https://serverfault.com/questions/317393/connect-failed-111-connection-refused-while-connecting-to-upstream)