### PR TITLE
pass the model answers through the Anonymizer

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -144,12 +144,13 @@ class Completions(APIView):
             raise ServiceUnavailable
         finally:
             duration = round((time.time() - start_time) * 1000, 2)
+            ano_predictions = anonymizer.anonymize_struct(predictions)
             event = {
                 "duration": duration,
                 "exception": exception is not None,
                 "problem": None if exception is None else exception.__class__.__name__,
                 "request": data,
-                "response": predictions,
+                "response": ano_predictions,
                 "suggestionId": str(payload.suggestionId),
             }
             send_segment_event(event, "wisdomServicePredictionsEvent", payload.userId)

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -284,7 +284,7 @@ ARI_RULES = [
     "W011",  # replace with_* loop with the modern loop:
     "W012",
     "W013",
-    "W014",
+    # "W014",  # anonymizer: already done by the ansible_wisdom app
     "W015",
     "W016",
     "W017",


### PR DESCRIPTION
This way remove the PII from the answer early during the process and
we avoid the Anonymizer call from ARI.
