### PR TITLE
bump ARI version to 0.1.1

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.4
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.5
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -131,6 +131,9 @@ class ARICaller:
                 if _result:
                     if "description" not in rule_detail:
                         rule_detail["description"] = _result.description
+                    if _result.rule:
+                        rule_detail["version"] = _result.rule.version
+                        rule_detail["commit_id"] = _result.rule.commit_id
                     rule_detail["duration"] = _result.duration
                     rule_detail["matched"] = _result.matched
                     rule_detail["error"] = _result.error

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ uwsgi==2.0.21
 django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
-ansible-risk-insight==0.1.0
+ansible-risk-insight==0.1.1
 ansible_anonymizer==1.0.1
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- bump ARI version to 0.1.1
  - update ARI to `0.1.1` and KB data/rules to `v0.0.5`
  - [AAP-10583](https://issues.redhat.com/browse/AAP-10583) has been resolved by ARI's update
  - [AAP-10550](https://issues.redhat.com/browse/AAP-10550) has been resolved by updates in the rules & in the postprocess code
