### PR TITLE
uwsgi: don't call the atexit() during the process teardown

### DIFF
--- a/tools/configs/uwsgi.ini
+++ b/tools/configs/uwsgi.ini
@@ -5,7 +5,8 @@ listen = 100                         ; This is limited by net.core.somaxconn
 master = true
 vacuum = true
 no-orphans = true
-;lazy-apps = true
+lazy-apps = true
+skip-atexit = true
 manage-script-name = true
 mount = /=main.wsgi:application
 


### PR DESCRIPTION
Despite the `lazy-apps = true`, the isolation of the processes in partial. The way uwsgi triggers the `atexit()` is a source of problem with the native libraries. In our context, this impacts Pytorch and Segments.

By turning it off, we:

- speed up the destruction of the old process
- avoid the exceptions in our log

See:
- aac296bd9392ad2154ff908dd670b5fff17b6596
- https://github.com/unbit/uwsgi/issues/1969
- https://github.com/pytorch/pytorch/issues/42125#issuecomment-772397319