### PR TITLE
Flush Segment library at the end of API call

### DIFF
--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -80,6 +80,10 @@ class SegmentMiddleware:
 
                 send_segment_event(event, "wisdomServiceCompletionEvent", user_id)
 
+            # If there are events on the client queue, flush & send them to Segment
+            if analytics.default_client is not None and analytics.default_client.queue.qsize() > 0:
+                analytics.flush()
+
         return response
 
 


### PR DESCRIPTION
For  [AAP-10114](https://issues.redhat.com/browse/AAP-10114).

With this PR, Wisdom Service will attempt to flush the internal queue within Segment Python library at every API call.  It will increase the # of calls made to Segment REST API interface, but still some events are grouped, e.g. for one completion API calls, 

- wisdomServicePreditionEvent
- wisdomServicePostprocessingEvent
- wisdomServiceCompletionEvent

will be sent to one REST API call.