### PR TITLE
Create a new anonymized serializer field type

### DIFF
--- a/ansible_wisdom/ai/api/fields.py
+++ b/ansible_wisdom/ai/api/fields.py
@@ -1,0 +1,13 @@
+from ansible_anonymizer import anonymizer
+from rest_framework import serializers
+
+
+class AnonymizedFieldMixin:
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+        data = anonymizer.anonymize_struct(data)
+        return data
+
+
+class AnonymizedCharField(AnonymizedFieldMixin, serializers.CharField):
+    pass

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -13,12 +13,14 @@ from drf_spectacular.utils import (
 )
 from rest_framework import serializers
 
+from .fields import AnonymizedCharField
+
 
 class Metadata(serializers.Serializer):
     class Meta:
         fields = ['documentUri', 'activityId']
 
-    documentUri = serializers.CharField(required=False)
+    documentUri = AnonymizedCharField(required=False)
     activityId = serializers.UUIDField(
         format='hex_verbose',
         required=False,
@@ -45,7 +47,7 @@ class CompletionRequestSerializer(serializers.Serializer):
     class Meta:
         fields = ['prompt', 'suggestionId', 'metadata']
 
-    prompt = serializers.CharField(
+    prompt = AnonymizedCharField(
         trim_whitespace=False,
         required=True,
         label='Prompt',
@@ -133,9 +135,9 @@ class InlineSuggestionFeedback(serializers.Serializer):
 
     latency = serializers.FloatField(required=False)
     userActionTime = serializers.FloatField(required=False)
-    documentUri = serializers.CharField(required=False)
+    documentUri = AnonymizedCharField(required=False)
     action = serializers.ChoiceField(choices=USER_ACTION_CHOICES)
-    error = serializers.CharField(required=False)
+    error = AnonymizedCharField(required=False)
     suggestionId = serializers.UUIDField(
         format='hex_verbose',
         required=True,
@@ -156,13 +158,13 @@ class AnsibleContentFeedback(serializers.Serializer):
     class Meta:
         fields = ['content', 'documentUri', 'trigger', 'activityId']
 
-    content = serializers.CharField(
+    content = AnonymizedCharField(
         trim_whitespace=False,
         required=True,
         label='Ansible Content',
         help_text='Ansible file content.',
     )
-    documentUri = serializers.CharField()
+    documentUri = AnonymizedCharField()
     trigger = serializers.ChoiceField(choices=CONTENT_UPLOAD_TRIGGER)
     activityId = serializers.UUIDField(
         format='hex_verbose',

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -92,10 +92,10 @@ class WisdomServiceAPITestCaseBase(APITransactionTestCase):
         return events
 
     def assertInLog(self, s, logs):
-        self.assertTrue(self.searchInLogOutput(s, logs))
+        self.assertTrue(self.searchInLogOutput(s, logs), logs)
 
     def assertNotInLog(self, s, logs):
-        self.assertFalse(self.searchInLogOutput(s, logs))
+        self.assertFalse(self.searchInLogOutput(s, logs), logs)
 
     def login(self):
         self.client.login(username=self.username, password=self.password)


### PR DESCRIPTION
Some fields clearly should not be anonymized (e.g. the uuid fields) and others should, so let's define the serializers so that they automatically do that as part of validation (a field's to_internal_value is called from Field.run_validation).

I would have preferred if a plugin Validator could have been used, but Django Rest Framework doesn't allow for those to manipulate data.  So the options are either this, or define .validate_<fieldname> methods on our serializers.