### PR TITLE
[draft] disable behavior that writes to shared files

### DIFF
--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -24,7 +24,12 @@ def time_activity(activity_name: str):
 
 class ARICaller:
     def __init__(self, config, silent) -> None:
-        self.ari_scanner = ARIScanner(config=config, silent=silent)
+        self.ari_scanner = ARIScanner(
+            config=config,
+            silent=silent,
+            write_ram=False,
+            read_ram=False,
+        )
 
     @classmethod
     def indent(cls, text, level):


### PR DESCRIPTION
This behavior enables later auditing and searching that we do not use. Since it writes to same-named files, it is not safe in our multiprocessing environment where multiple processes are reading and writing to the same files over and over. It ends up causing ARI to fail. See https://issues.redhat.com/browse/AAP-11004