### PR TITLE
bump ARI to 0.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ uwsgi==2.0.21
 django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
-ansible-risk-insight==0.1.1
+ansible-risk-insight==0.1.2
 ansible_anonymizer==1.1.3
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- bump ARI version to 0.1.2
- this update includes the fixes for the following issues
  - multiple ARI instances by uWSGI could corrupt KB files
  - slow ARI initialization


