### PR TITLE
Add play keyword to identify playbook

### DIFF
--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -67,7 +67,10 @@ class ARICaller:
         if context:
             try:
                 context_data = yaml.safe_load(context)
-                if isinstance(context_data, list) and "tasks" in context_data[0]:
+                if isinstance(context_data, list) and any(
+                    play_keyword in context_data[0]
+                    for play_keyword in ["tasks", "pre_tasks", "post_tasks", "handlers"]
+                ):
                     is_playbook = True
             except Exception:
                 logger.exception('the received context could not be loaded as a YAML')


### PR DESCRIPTION
Attempts to fix https://issues.redhat.com/browse/AAP-10814

*  In addition to `tasks` there are other play level keywords like `pre_tasks`, `post_tasks` and `handlers` that are used for task completion