### PR TITLE
settings: use default when COMPLETION_USER_RATE_THROTTLE is empty

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -245,12 +245,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 APPEND_SLASH = True
 
-# Depending on how env var is set, can end up with extraneous quotes.
-# this is defensive, we could just let it happen and
-# leave it to the operator who set the var to fix it
-COMPLETION_USER_RATE_THROTTLE = (
-    os.environ.get('COMPLETION_USER_RATE_THROTTLE', '10/minute').strip('"').strip("'")
-)
+COMPLETION_USER_RATE_THROTTLE = os.environ.get('COMPLETION_USER_RATE_THROTTLE') or '10/minute'
+
 MOCK_MODEL_RESPONSE_BODY = os.environ.get(
     'MOCK_MODEL_RESPONSE_BODY',
     (


### PR DESCRIPTION
This commit addresses a regression introduced in 73aa92eb5154b5549e7747984af9a74aa8be7e63.

Failback on the default `10/minute` if the `COMPLETION_USER_RATE_THROTTLE` environment variable is defined but also empty.

Also, remove the `strip()` calls that clean up `COMPLETION_USER_RATE_THROTTLE` and the associated comment.