### PR TITLE
requirements.txt: upgrade Django and Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ipython==8.10.0
 boto3==1.26.84
 datasets==2.10.1
 tqdm==4.64.1
-Django==4.1.3
+Django==4.1.7
 django-extensions==3.2.1
 django-oauth-toolkit==2.2.0
 djangorestframework==3.14.0
@@ -13,7 +13,7 @@ opensearch-py==2.1.1
 protobuf==4.22.1
 pydantic==1.10.2
 psycopg2-binary==2.9.5
-redis==4.5.1
+redis==4.5.4
 requests==2.28.1
 sentence-transformers==2.2.2
 uwsgi==2.0.21


### PR DESCRIPTION
Upgrade Django from 4.1.3 to 4.1.7 to address the following CVE:

- https://nvd.nist.gov/vuln/detail/CVE-2023-23969
- https://nvd.nist.gov/vuln/detail/CVE-2023-24580

Upgrade redis from 4.5.1 to 4.5.4 to address the following CVE:

- https://nvd.nist.gov/vuln/detail/CVE-2023-28858
- https://nvd.nist.gov/vuln/detail/CVE-2023-28859