### PR TITLE
comment out documentation link from home page

### DIFF
--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -10,8 +10,7 @@
           {% if user.is_authenticated %}
             <div class="pf-c-empty-state__body">
               <p>You are signed in as {{user.username}}.</p>
-              <p>Access the <a href={{pilot_docs_url}} target="_blank">documentation</a> to begin.</p>
-              <!-- <p><b>Authentication Token:</b> {{drf_token}}</p> -->
+              <!-- <p>Access the <a href={{pilot_docs_url}} target="_blank">documentation</a> to begin.</p> -->
               <br><br>
             </div>
             <a class="pf-c-button pf-m-primary" type="button" href="{% url 'logout' %}">Logout</a>


### PR DESCRIPTION
We will not have any public documentation for the closed beta. Docs will be pdfed and emailed. For now, we will comment out the doc link from the home page.