### PR TITLE
Add underlines to a few headers

### DIFF
--- a/ansible_wisdom/users/templates/users/terms_of_service.html
+++ b/ansible_wisdom/users/templates/users/terms_of_service.html
@@ -51,7 +51,7 @@
                         </p>
                         <p>
 
-                            Suggestions by ECS: Based on your request, the ECS will provide suggested Ansible tasks and
+                            <span style="text-decoration: underline;">Suggestions by ECS:</span> Based on your request, the ECS will provide suggested Ansible tasks and
                             other Ansible materials (“Suggestions”). By using the ECS, you agree that any and all
                             Suggestions and any User data input into ECS may be used by International Business Machines
                             Corporation (“IBM”) and its affiliates including Red Hat, Inc. (“Red Hat”), for any purpose
@@ -74,13 +74,13 @@
                         </p>
                         <p>
 
-                            User Feedback on ECS: The ECS is a service IBM is developing and testing for release as a
+                            <span style="text-decoration: underline;">User Feedback on ECS:</span> The ECS is a service IBM is developing and testing for release as a
                             cloud service. User is authorized to use the ECS for the purpose of evaluating its
                             functionality and to provide feedback on the ECS to IBM and its affiliates, who may use the
                             feedback for any purpose without limitation.
                         </p>
                         <p>
-                            Code: Code is defined as the content User creates using the ECS, including User’s
+                            <span style="text-decoration: underline;">Code:</span> Code is defined as the content User creates using the ECS, including User’s
                             modifications to Suggestions. IBM does not claim any intellectual property rights with
                             respect to any Suggestions.
                         </p>


### PR DESCRIPTION
Add underline attributes to a few headers in IBM part of Terms of Service doc.  (for [AAP-10894](https://issues.redhat.com/browse/AAP-10894))

![image](https://user-images.githubusercontent.com/27698807/232131739-96aae7fb-09f2-4fa7-8032-d4eb53443160.png)
