### PR TITLE
upgrade to Django 4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ipython==8.10.0
 boto3==1.26.84
 datasets==2.10.1
 tqdm==4.64.1
-Django==4.1.7
+Django==4.2
 django-extensions==3.2.1
 django-oauth-toolkit==2.2.0
 djangorestframework==3.14.0
@@ -12,7 +12,7 @@ social-auth-core==4.3.0
 opensearch-py==2.1.1
 protobuf==4.22.1
 pydantic==1.10.2
-psycopg2-binary==2.9.5
+psycopg[binary]==3.1.8
 redis==4.5.4
 requests==2.28.1
 sentence-transformers==2.2.2


### PR DESCRIPTION
Upgrade to psycopg3
-------------------------------

Psycopg2 will be deprecated in the the future. By upgrading now we avoid the hassle of a upgrade of a service when we will be in production [^1].

[^1]: https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support

Backwards incompatible changes
-------------------------------------------------

None, we run PostgreSQL 14+ in production and we don't have any custom `save()` functions.

Features deprecated in 4.2
---------------------------------------

None of them impact us.