### PR TITLE
manage.py cleartokens does not clear expired tokens

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -118,10 +118,10 @@ OAUTH2_PROVIDER = {
         'write': "Request ansible content suggestions",
     },
     'ALLOWED_REDIRECT_URI_SCHEMES': ['http', 'https', 'vscode'],
+    # ACCESS_TOKEN_EXPIRE_SECONDS = 36_000  # = 10 hours, default value
+    'REFRESH_TOKEN_EXPIRE_SECONDS': 1_209_600,  # = 2 weeks
 }
 
-# ACCESS_TOKEN_EXPIRE_SECONDS = 36_000  # = 10 hours, default value
-REFRESH_TOKEN_EXPIRE_SECONDS = 1_209_600  # = 2 weeks
 
 # OAUTH: todo
 # - remove ansible_wisdom/users/auth.py module

--- a/ansible_wisdom/main/tests/test_settings.py
+++ b/ansible_wisdom/main/tests/test_settings.py
@@ -1,0 +1,8 @@
+from django.test import SimpleTestCase
+from oauth2_provider.settings import oauth2_settings
+
+
+class TestSettings(SimpleTestCase):
+    def test_oauth2(self):
+        REFRESH_TOKEN_EXPIRE_SECONDS = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+        self.assertGreater(REFRESH_TOKEN_EXPIRE_SECONDS, 0)


### PR DESCRIPTION
For [AAP-11336](https://issues.redhat.com/browse/AAP-11336).

In the current (as of 2023-04-18) code, REFRESH_TOKEN_EXPIRE_SECONDS is set as settings.REFRESH_TOKEN_EXPIRE_SECONDS in the code, but it should have been settings.OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS']. As the result, refresh tokens never expire and access tokens are not cleared with manage.py cleartokens.  This PR is for fixing that issue.