### PR TITLE
add ability to export user term acceptance to csv

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "health_check.cache",
     "healthcheck",
     "oauth2_provider",
+    'import_export',
 ]
 
 

--- a/ansible_wisdom/users/admin.py
+++ b/ansible_wisdom/users/admin.py
@@ -1,10 +1,20 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from import_export import resources
+from import_export.admin import ExportMixin
 
 from .models import User
 
 
-class WisdomUserAdmin(UserAdmin):
+class UserTermsResource(resources.ModelResource):
+    class Meta:
+        model = User
+        fields = ['username', 'date_terms_accepted']
+        name = "Export only user terms"
+
+
+class WisdomUserAdmin(ExportMixin, UserAdmin):
+    resource_classes = [UserTermsResource]
     # add any additional fields you want to display in the User page
     list_display = ('username', 'is_staff', 'date_terms_accepted', 'uuid')
     fieldsets = UserAdmin.fieldsets + ((None, {'fields': ('date_terms_accepted',)}),)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ datasets==2.10.1
 tqdm==4.64.1
 Django==4.1.7
 django-extensions==3.2.1
+django-import-export==3.2.0
 django-oauth-toolkit==2.2.0
 djangorestframework==3.14.0
 grpcio==1.51.1


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-11324

Leverage django-import-export to easily export the list of users and when they accepted the terms. 

This PR adds an Export button to the Users page of the Admin UI, allowing you to create a csv that looks like this:

```
username,date_terms_accepted
admin,
robinbobbitt,2023-04-12 22:10:53
```