### PR TITLE
Allow log level override

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -154,7 +154,7 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": "WARNING",
+        "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"),
     },
 }
 


### PR DESCRIPTION
This allows overriding log level from the default (=`WARNING`) in the way shown in [Django documentation](https://docs.djangoproject.com/en/4.2/topics/logging/#examples).

The motivation of this PR is to log outputs from `manage.py cleartokens` for [AAP-10355](https://issues.redhat.com/browse/AAP-10355).  Since `manage.py cleartokens` logs with the `INFO` level, nothing will be logged with the `WARNING` level.  

With the `INFO` level, outputs like

```
0 Revoked refresh tokens deleted
1 Expired refresh tokens deleted
1 Expired access tokens deleted
0 Expired grant tokens deleted
```
will show up in the log.  I am planning to set the log level to `INFO` in the cron job that executes `manage.py cleartokens`.