### PR TITLE
Include Django group names in Segment events

### DIFF
--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -65,7 +65,6 @@ class SegmentMiddleware:
 
         if settings.SEGMENT_WRITE_KEY:
             if request.path == reverse('completions') and request.method == 'POST':
-                user_id = getattr(request.user, 'uuid', None)
                 suggestion_id = request_data.get('suggestionId')
                 context = request_data.get('context')
                 prompt = request_data.get('prompt')
@@ -96,7 +95,7 @@ class SegmentMiddleware:
                     "imageTags": version_info.image_tags,
                 }
 
-                send_segment_event(event, "completion", user_id)
+                send_segment_event(event, "completion", request.user)
 
         return response
 

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -68,6 +68,9 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 for event in segment_events:
                     self.assertTrue('modelName' in event)
                     self.assertTrue('imageTags' in event)
+                    self.assertTrue('groups' in event)
+                    self.assertTrue('Group 1' in event['groups'])
+                    self.assertTrue('Group 2' in event['groups'])
                     self.assertEqual(hostname, event['hostname'])
 
             with self.assertLogs(logger='root', level='DEBUG') as log:


### PR DESCRIPTION
For [AAP-11452](https://issues.redhat.com/browse/AAP-11452). This PR add a list of group names to segment events sent from Wisdom Service.  An example is shown as follows:

```json
{
  "duration": 100.3,
  "exception": false,
  "problem": null,
  "request": {
    "instances": [
      {
        "prompt": "    - name: install apache for james8@example.com",
        "context": "- hosts: all\n  become: true\n  tasks:\n",
        "userId": "e5ca8cf1-c55a-4e67-ac4f-f3c2d7d82ef4",
        "suggestionId": "17362417-7a2c-4d61-bfb1-362276b08676"
      }
    ]
  },
  "response": {
    "predictions": [
      "      ansible.builtin.apt:\n        name: apache2"
    ]
  },
  "suggestionId": "17362417-7a2c-4d61-bfb1-362276b08676",
  "modelName": "wisdom",
  "imageTags": "image-tags-not-defined",
  "hostname": "ttakamiy.remote.csb",
  "groups": [
    "Group 1",
    "Group 2"
  ]
}

```