### PR TITLE
bump ARI to 0.1.5 and fix rules

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.6
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.7
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.6
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.7
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ uwsgi==2.0.21
 django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
-ansible-risk-insight==0.1.4
+ansible-risk-insight==0.1.5
 ansible_anonymizer==1.1.5
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- bump ARI to 0.1.5
  - support `module_defaults` ([AAP-9300](https://issues.redhat.com/browse/AAP-9300))
  - fix argument type check
- update KB data to `0.0.7`
  - no change for `data`
  - update `rules` for bug fixes ([AAP-11653](https://issues.redhat.com/browse/AAP-11653), [AAP-11565](https://issues.redhat.com/browse/AAP-11565))