### PR TITLE
bump ARI to 0.1.6 and update KB data version

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.7
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.8
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.7
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.8
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -308,6 +308,7 @@ ARI_RULES = [
     "W024",
     "W025",
     "W026",
+    "W027",
 ]
 if 'ARI_RULES' in os.environ:
     ARI_RULES = os.environ['ARI_RULES'].split(',')

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ uwsgi==2.0.21
 django_prometheus==2.2.0
 drf-spectacular==0.25.1
 PyYAML==6.0
-ansible-risk-insight==0.1.5
+ansible-risk-insight==0.1.6
 ansible_anonymizer==1.1.5
 uwsgi-readiness-check==0.2.0
 segment-analytics-python==2.2.2


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- bump ARI to 0.1.6
  - support module_defaults with `group/xxx` ([AAP-9300](https://issues.redhat.com/browse/AAP-9300?jql=assignee%20in%20(currentUser()%2C%20rkudo%2C%20yujwatan)%20AND%20text%20~%20%22module_defaults%22))
- update KB data version to `v0.0.8`
  - add a rule W027 to remove duplicate keys appeared in module_defaults ([AAP-9300](https://issues.redhat.com/browse/AAP-9300?jql=assignee%20in%20(currentUser()%2C%20rkudo%2C%20yujwatan)%20AND%20text%20~%20%22module_defaults%22))
  - fix bugs of several rules