### PR TITLE
Skip AI search initialization when search host is not specified

### DIFF
--- a/ansible_wisdom/ai/tests/test_search.py
+++ b/ansible_wisdom/ai/tests/test_search.py
@@ -1,0 +1,96 @@
+from copy import copy
+from unittest.mock import patch
+
+import numpy as np
+from ai.search import initialize_OpenSearch, search
+from django.test import override_settings
+from opensearchpy import OpenSearch
+from rest_framework.test import APITestCase
+from sentence_transformers import SentenceTransformer
+
+
+class TestSearch(APITestCase):
+    DUMMY_AI_SEARCH_SETTINGS = {
+        'REGION': '*',
+        'KEY': '*',
+        'SECRET': '*',
+        'HOST': '*',
+        'PORT': '*',
+        'USE_SSL': False,
+        'VERIFY_CERTS': False,
+        'MODEL': '*',
+        'INDEX': '*',
+    }
+
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_HOST = copy(DUMMY_AI_SEARCH_SETTINGS)
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_HOST['HOST'] = ''
+
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_REGION = copy(DUMMY_AI_SEARCH_SETTINGS)
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_REGION['REGION'] = ''
+
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_REGION_AND_KEY = copy(
+        DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_REGION
+    )
+    DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_REGION_AND_KEY['KEY'] = ''
+
+    def nop(self, *args, **kwargs):
+        pass
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def search(self, index, body, _source):
+            return {
+                'hits': {
+                    'hits': [
+                        {
+                            'fields': {
+                                'repo_name': ['repo_name'],
+                                'repo_url': ['repo_url'],
+                                'path': ['path'],
+                                'license': ['license'],
+                                'data_source': ['data_source'],
+                                'type': ['ansible_type'],
+                            },
+                            '_score': 0,
+                        },
+                    ],
+                },
+            }
+
+    class DummySentenceTransformer:
+        def encode(self, input):
+            return input
+
+    @override_settings(ANSIBLE_AI_SEARCH=DUMMY_AI_SEARCH_SETTINGS)
+    def test_initialize_OpenSearch(self):
+        with patch.object(OpenSearch, '__init__', self.nop):
+            with patch.object(SentenceTransformer, '__init__', self.nop):
+                client, model = initialize_OpenSearch()
+                self.assertIsNotNone(client)
+                self.assertIsNotNone(model)
+
+        with patch('ai.search.client', self.DummyClient()):
+            with patch('ai.search.model', self.DummySentenceTransformer()):
+                ret = search(np.array(1))
+                self.assertIsNotNone(ret)
+
+    @override_settings(ANSIBLE_AI_SEARCH=DUMMY_AI_SEARCH_SETTINGS_WITH_EMPTY_HOST)
+    def test_skip_initializing_OpenSearch(self):
+        with patch.object(OpenSearch, '__init__', self.nop):
+            with patch.object(SentenceTransformer, '__init__', self.nop):
+                client, model = initialize_OpenSearch()
+                self.assertIsNone(client)
+                self.assertIsNone(model)
+
+    def test_search(self):
+        with patch('ai.search.client', self.DummyClient()):
+            with patch('ai.search.model', self.DummySentenceTransformer()):
+                ret = search(np.array(1))
+                self.assertIsNotNone(ret)
+
+    def test_search_with_none_client(self):
+        with patch('ai.search.client', None):
+            with self.assertRaises(Exception):
+                ret = search(np.array(1))


### PR DESCRIPTION
This is for [AAP-11725](https://issues.redhat.com/browse/AAP-11725).

We execute we run
```
venv/bin/python3 ansible_wisdom/manage.py cleartokens
```
using the wisdom-service docker image. Right now it took about 6 secs. It looks like the initialization of AI search, which is used in the Attributions API, takes some time. This PR is for skipping AI search initialization when the host name of AI search is empty.  The host name of AI search is set by the environment variable `ANSIBLE_AI_SEARCH_HOST`.

After this PR is merged, [the YAML file to generate the cronjob](https://github.com/ansible/ansible-wisdom-ops/blob/main/applications/wisdom-service/cronjob.yaml) will be updated to set an empy string to `ANSIBLE_AI_SEARCH_HOST` because the Attributions API is not used in the cronjob.