### PR TITLE
Fix list element indentation

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -1,7 +1,8 @@
 import logging
-import sys
+from io import StringIO
 
 import yaml
+from ruamel.yaml import YAML
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,18 @@ def handle_spaces_and_casing(prompt):
         # return the prompt as is if failed to process
 
     return prompt
+
+
+def adjust_indentation(yaml):
+    output = yaml
+    stream = StringIO()
+    with stream as fp:
+        yaml_obj = YAML()
+        yaml_obj.indent(offset=2, sequence=4)
+        loaded_data = yaml_obj.load(output)
+        yaml_obj.dump(loaded_data, fp)
+        output = fp.getvalue()
+    return output.rstrip()
 
 
 def restore_indentation(yaml, original_indent):

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -141,6 +141,14 @@ class AnsibleDumperTestCase(TestCase):
             '    - name:install nginx        on rhel', fmtr.handle_spaces_and_casing(prompt)
         )
 
+    def test_adjust_indentation(self):
+        """
+        adjust list indentation as per ansible-lint default configuration
+        """
+        original_yaml = "loop:\n- ssh\n- nginx"
+        expected = "loop:\n  - ssh\n  - nginx"
+        self.assertEqual(fmtr.adjust_indentation(original_yaml), expected)
+
 
 if __name__ == "__main__":
     import yaml
@@ -153,3 +161,4 @@ if __name__ == "__main__":
     tests.test_prompt_and_context()
     tests.test_restore_indentation()
     tests.test_casing_and_spacing_prompt()
+    tests.test_adjust_indentation()

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -272,8 +272,12 @@ class Completions(APIView):
                     )
                     if exception:
                         raise exception
+
+            # adjust indentation as per default ansible-lint configuration
+            indented_yaml = fmtr.adjust_indentation(recommendation["predictions"][i])
+
             # restore original indentation
-            indented_yaml = fmtr.restore_indentation(recommendation["predictions"][i], indent)
+            indented_yaml = fmtr.restore_indentation(indented_yaml, indent)
             recommendation["predictions"][i] = indented_yaml
             logger.debug(
                 f"suggestion id: {suggestion_id}, " f"indented recommendation: \n{indented_yaml}"


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-10563
Use the default ansible-lint configuration while
formatting the prediction to indent list elements
2 spaces with respect to it's parent