### PR TITLE
Improve preprocess error handling

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -57,6 +57,10 @@ class AnsibleDumper(yaml.Dumper):
         return self.preferred_quote_
 
 
+class InvalidPromptException(Exception):
+    pass
+
+
 """
 Normalize by loading and re-serializing
 """
@@ -64,6 +68,8 @@ Normalize by loading and re-serializing
 
 def normalize_yaml(yaml_str):
     data = yaml.load(yaml_str, Loader=yaml.SafeLoader)
+    if data is None:
+        return None
     return yaml.dump(data, Dumper=AnsibleDumper, allow_unicode=True, sort_keys=False, width=10000)
 
 
@@ -73,23 +79,36 @@ def preprocess(context, prompt):
     Format and split off the last line as the prompt
     Append a newline to both context and prompt (as the model expects)
     """
-
     formatted = normalize_yaml(f'{context}\n{prompt}')
-    logger.debug(f'initial user input {context}\n{prompt}')
 
-    segs = formatted.rsplit('\n', 2)  # Last will be the final newline
-    if len(segs) == 3:
-        context = segs[0] + '\n'
-        prompt = segs[1]
-    elif len(segs) == 2:  # Context is empty
-        context = ""
-        prompt = segs[0]
-    else:
-        logger.warn(f"preprocess failed - too few new-lines in: {formatted}")
+    if formatted is not None:
+        logger.debug(f'initial user input {context}\n{prompt}')
 
-        logger.debug(f'preprocessed user input {context}\n{prompt}')
+        segs = formatted.rsplit('\n', 2)  # Last will be the final newline
+        if len(segs) == 3:
+            context = segs[0] + '\n'
+            prompt = segs[1]
+        elif len(segs) == 2:  # Context is empty
+            context = ""
+            prompt = segs[0]
+        else:
+            logger.warn(f"preprocess failed - too few new-lines in: {formatted}")
 
-    prompt = handle_spaces_and_casing(prompt)
+            logger.debug(f'preprocessed user input {context}\n{prompt}')
+
+        prompt = handle_spaces_and_casing(prompt)
+
+        # Make sure the prompt is in the form "  - name: a string description."
+        prompt_list = yaml.load(prompt, Loader=yaml.SafeLoader)
+        if (
+            not isinstance(prompt_list, list)
+            or len(prompt_list) != 1
+            or not isinstance(prompt_list[0], dict)
+            or len(prompt_list[0]) != 1
+            or 'name' not in prompt_list[0]
+            or not isinstance(prompt_list[0]['name'], str)
+        ):
+            raise InvalidPromptException()
 
     return context, prompt
 

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -149,6 +149,34 @@ class AnsibleDumperTestCase(TestCase):
         expected = "loop:\n  - ssh\n  - nginx"
         self.assertEqual(fmtr.adjust_indentation(original_yaml), expected)
 
+    def test_empty_yaml(self):
+        # make sure no preprocessing is performed against an empty input
+        context = "---"
+        prompt = ""
+        context_out, prompt_out = fmtr.preprocess(context, prompt)
+        self.assertEqual(context, context_out)
+        self.assertEqual(prompt, prompt_out)
+
+    def test_valid_prompt(self):
+        # make sure that no exception is thrown when the prompt contains a string as the name
+        context = "---"
+        prompt = "  - name: This is a string"
+        fmtr.preprocess(context, prompt)
+
+    def test_list_as_name(self):
+        # make sure that an exception is thrown when the prompt contains a list as the name
+        context = "---"
+        prompt = "  - name: [This is a list]"
+        with self.assertRaises(Exception) as cm:
+            fmtr.preprocess(context, prompt)
+
+    def test_dict_as_name(self):
+        # make sure that an exception is thrown when the prompt contains a dictionary as the name
+        context = "---"
+        prompt = "  - name: {This is a dict}"
+        with self.assertRaises(Exception) as cm:
+            fmtr.preprocess(context, prompt)
+
 
 if __name__ == "__main__":
     import yaml
@@ -162,3 +190,7 @@ if __name__ == "__main__":
     tests.test_restore_indentation()
     tests.test_casing_and_spacing_prompt()
     tests.test_adjust_indentation()
+    tests.test_empty_yaml()
+    tests.test_valid_prompt()
+    tests.test_list_as_name()
+    tests.test_dict_as_name()


### PR DESCRIPTION
For [AAP-11737](https://issues.redhat.com/browse/AAP-11737).

1. When context/prompt end up with an empty YAML. When an empty YAML , for example, context="---" and prompt="", yaml.load() returns None. In such cases, we should skip preprocessing.

2. When the prompt contains non-string data for name, for example - name: [Create a new user], preprocess code does not work as it assumes always a string for the name. Currently it causes a postprocess error. This is also an edge case, but it is more likely than the first case and is considered as an variation of [AAP-11812](https://issues.redhat.com/browse/AAP-11812). A new slightly different message (`Request contains invalid prompt`) is returned for the error instead of the default one (`Request contains invalid yaml`) because this is not an error in YAML syntax.

3. Though it is not a part of the preprosess code, I also added an error message (`Request contains invalid data`) to the 400 responses triggered by an error in serializer (there was no error message given before).