### PR TITLE
Validation error rework

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -89,8 +89,9 @@ class Completions(APIView):
         request_serializer = CompletionRequestSerializer(data=request.data)
         try:
             request_serializer.is_valid(raise_exception=True)
-        except Exception:
-            return Response({'message': 'Request contains invalid data'}, status=400)
+        except Exception as exc:
+            logger.error(f'failed to validate request:\nException:\n{exc}')
+            raise exc
         payload = APIPayload(**request_serializer.validated_data)
         payload.userId = request.user.uuid
         model_name = payload.model_name

--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -76,6 +76,8 @@ class SegmentMiddleware:
                 if isinstance(response_data, dict):
                     predictions = response_data.get('predictions')
                     message = response_data.get('message')
+                elif response.status_code >= 400 and getattr(response, 'content', None):
+                    message = str(response.content)
 
                 duration = round((time.time() - start_time) * 1000, 2)
                 event = {


### PR DESCRIPTION
Rework of #324 ([ref](https://redhat-internal.slack.com/archives/C04G3TZBGHJ/p1683820350247149))
- Revert the change made for validation error. Sanity test failures should be resolved by this.
- Generate the message in Segment data based on the exception thrown by serializer instead of "Request contains invalid data"
- Add error logging as well