### PR TITLE
Add support for jinja2 variables double quotes 

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -145,8 +145,8 @@ class AnsibleDumperTestCase(TestCase):
         """
         adjust list indentation as per ansible-lint default configuration
         """
-        original_yaml = "loop:\n- ssh\n- nginx"
-        expected = "loop:\n  - ssh\n  - nginx"
+        original_yaml = "loop:\n- 'ssh'\n- nginx\n- '{{ name }}'"
+        expected = "loop:\n  - ssh\n  - nginx\n  - \"{{ name }}\""
         self.assertEqual(fmtr.adjust_indentation(original_yaml), expected)
 
     def test_empty_yaml(self):


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-12175


Identify the predication has jinja2 variables and if yes add doubles quotes for the jinja2 variables