### PR TITLE
Fix segment event name for feedback errors

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -454,7 +454,7 @@ class Feedback(APIView):
             event_type = (
                 "inlineSuggestionFeedback"
                 if ("inlineSuggestion" in request_data)
-                else "inlineSuggestionFeedback"
+                else "ansibleContentFeedback"
             )
             event = {
                 "data": request_data,

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -66,12 +66,13 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 self.assertTrue(len(segment_events) > 0)
                 hostname = platform.node()
                 for event in segment_events:
-                    self.assertTrue('modelName' in event)
-                    self.assertTrue('imageTags' in event)
-                    self.assertTrue('groups' in event)
-                    self.assertTrue('Group 1' in event['groups'])
-                    self.assertTrue('Group 2' in event['groups'])
-                    self.assertEqual(hostname, event['hostname'])
+                    properties = event['properties']
+                    self.assertTrue('modelName' in properties)
+                    self.assertTrue('imageTags' in properties)
+                    self.assertTrue('groups' in properties)
+                    self.assertTrue('Group 1' in properties['groups'])
+                    self.assertTrue('Group 2' in properties['groups'])
+                    self.assertEqual(hostname, properties['hostname'])
 
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(
@@ -196,6 +197,6 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 events = self.extractSegmentEventsFromLog(log.output)
                 n = len(events)
                 self.assertTrue(n > 0)
-                self.assertEqual(events[n - 1]['error_type'], 'event_exceeds_limit')
-                self.assertIsNotNone(events[n - 1]['details']['event_name'])
-                self.assertIsNotNone(events[n - 1]['details']['msg_len'] > 32 * 1024)
+                self.assertEqual(events[n - 1]['properties']['error_type'], 'event_exceeds_limit')
+                self.assertIsNotNone(events[n - 1]['properties']['details']['event_name'])
+                self.assertIsNotNone(events[n - 1]['properties']['details']['msg_len'] > 32 * 1024)


### PR DESCRIPTION
For [AAP-12324](https://issues.redhat.com/browse/AAP-12324).  This is the fix for a bug caused by #330. 

The test code for Segment events was updated in this PR because it was not written for allowing event name check.