### PR TITLE
Allow normal authentication on the healthcheck views

### DIFF
--- a/ansible_wisdom/healthcheck/views.py
+++ b/ansible_wisdom/healthcheck/views.py
@@ -62,7 +62,6 @@ class WisdomServiceHealthView(APIView):
     """
 
     permission_classes = [permissions.AllowAny]
-    authentication_classes = []
 
     def __init__(self):
         super().__init__()
@@ -110,7 +109,6 @@ class WisdomServiceLivenessProbeView(APIView):
     """
 
     permission_classes = [permissions.AllowAny]
-    authentication_classes = []
 
     @extend_schema(
         responses={


### PR DESCRIPTION
Setting `authentication_classes = []` was making all calls to these endpoints show up as using AnonymousUser, causing the throttling to kick in very quickly.