### PR TITLE
pip-audit: ignore GHSA-282v-666c-3fvg for now

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -27,3 +27,5 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.6
         with:
           virtual-environment: env/
+          ignore-vulns: |
+            GHSA-282v-666c-3fvg


### PR DESCRIPTION
Ignore GHSA-282v-666c-3fvg until a fix is available.
See: https://nvd.nist.gov/vuln/detail/CVE-2023-2800
