### PR TITLE
Add grafana to compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ containers, you may need to set the permissions on the
 ```bash
 chcon -t container_file_t -R ansible_wisdom/
 chcon -t container_file_t -R prometheus/
+chcon -t container_file_t -R grafana/
 chcon -t container_file_t -R ari/
 ```
 Also run `chmod` against the `ari/` directory so that ARI can

--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -32,10 +32,14 @@ services:
       - "9090:9090"
     networks:
       - dbnet
-  prom-pushgateway:
-    image: docker.io/prom/pushgateway
+  grafana:
+    image: docker.io/grafana/grafana:7.5.17
+    environment:
+      - GF_LOG_LEVEL=warn
     ports:
-      - "9091:9091"
+      - "3000:3000"
+    volumes:
+      - $PWD/grafana:/var/lib/grafana
     networks:
       - dbnet
 

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -78,6 +78,16 @@ services:
       - "9090:9090"
     networks:
       - dbnet
+  grafana:
+    image: docker.io/grafana/grafana:7.5.17
+    environment:
+      - GF_LOG_LEVEL=warn
+    ports:
+      - "3000:3000"
+    volumes:
+      - $PWD/grafana:/var/lib/grafana
+    networks:
+      - dbnet
 
 networks:
   dbnet:


### PR DESCRIPTION
Add grafana, which was previously included, back to compose files (compose.yaml and compose-backends.yaml)