### PR TITLE
Add more logs to Terms of Service page 500 error

### DIFF
--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.forms import Form
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.urls import reverse
 from django.views.generic import TemplateView
 from rest_framework.generics import RetrieveAPIView
@@ -44,17 +45,26 @@ class TermsOfService(TemplateView):
     def get(self, request, *args, **kwargs):
         partial_token = request.GET.get('partial_token')
         self.extra_context['partial_token'] = partial_token
+        if partial_token is None:
+            logger.error('GET /terms_of_service/ was invoked without partial_token')
+            return HttpResponseForbidden()
         return super().get(request, args, kwargs)
 
     def post(self, request, *args, **kwargs):
         form = Form(request.POST)
         form.is_valid()
         partial_token = form.data.get('partial_token')
+        if partial_token is None:
+            logger.error('POST /terms_of_service/ was invoked without partial_token')
+            return HttpResponseBadRequest()
 
         accepted = request.POST.get('accepted') == 'True'
 
         strategy = load_strategy()
         partial = strategy.partial_load(partial_token)
+        if partial is None:
+            logger.error('strategy.partial_load(partial_token) returned None')
+            return HttpResponseBadRequest()
         backend = partial.backend
 
         if accepted:


### PR DESCRIPTION
For [AAP-12784](https://issues.redhat.com/browse/AAP-12784).

- Add more logs for collecting more information on the 500 status codes when `POST /terms_of_service/` endpoint is called.
- Modified code to return 400 (Bad Request) when such errors occurred.
- Also disallow accessing to the Terms of Service page directly typing in the URL in browser (return 403 Forbidden for such cases)