### PR TITLE
Add log for exceptions from feedback API

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -423,6 +423,7 @@ class Feedback(APIView):
             return Response({"message": str(exc)}, status=exc.status_code)
         except Exception as exc:
             exception = exc
+            logger.exception(f"An exception {exc.__class__} occurred in sending a feedback")
             return Response(
                 {"message": "Failed to send feedback"},
                 status=rest_framework_status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
For [AAP-12778](https://issues.redhat.com/browse/AAP-12778). This PR add a log entry when an exception was thrown from the feedback API.