### PR TITLE
api/formatter: accept dup YAML keys

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -147,6 +147,7 @@ def adjust_indentation(yaml):
     stream = StringIO()
     with stream as fp:
         yaml_obj = YAML()
+        yaml_obj.allow_duplicate_keys = True
         yaml_obj.indent(offset=2, sequence=4)
         loaded_data = yaml_obj.load(output)
         loaded_data = handle_jinja2_variable_quotes(loaded_data)


### PR DESCRIPTION
If we prediction comes with duplicate keys, `ruamel.yaml` won't load it
and raise the follwing exception instead:

```
ERROR 2023-06-02 22:51:30,970 views.py:post error postprocessing prediction for suggestion 4bb7ea69-848e-4b32-8354-f03dae445324
Traceback (most recent call last):
  File "/var/www/ansible_wisdom/./ai/api/views.py", line 218, in post
    postprocessed_predictions = self.postprocess(
  File "/var/www/ansible_wisdom/./ai/api/views.py", line 348, in postprocess
    indented_yaml = fmtr.adjust_indentation(recommendation["predictions"][i])
  File "/var/www/ansible_wisdom/./ai/api/formatter.py", line 151, in adjust_indentation
    loaded_data = yaml_obj.load(output)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/main.py", line 426, in load
    return constructor.get_single_data()
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 113, in get_single_data
    return self.construct_document(node)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 122, in construct_document
    for _dummy in generator:
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 1473, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 1362, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 144, in construct_object
    data = self.construct_non_recursive_object(node)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 185, in construct_non_recursive_object
    for _dummy in generator:
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 1473, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 1363, in construct_mapping
    if self.check_mapping_key(node, key_node, maptyp, key, value):
  File "/var/www/venv/lib64/python3.9/site-packages/ruamel/yaml/constructor.py", line 275, in check_mapping_key
    raise DuplicateKeyError(*args)
ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
  in "<unicode string>", line 2, column 5:
        name: my-instance
        ^ (line: 2)
found duplicate key "aws_access_key" with value "{{ aws_access_key }}" (original value: "{{ aws_access_key }}")
  in "<unicode string>", line 14, column 5:
        aws_access_key: "{{ aws_access_k ...
        ^ (line: 14)
```

See: http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
