### PR TITLE
don't lower() the prompt before sending it

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -115,8 +115,6 @@ def preprocess(context, prompt):
 
 def handle_spaces_and_casing(prompt):
     try:
-        prompt = prompt.lower()  # lowercasing the prompt always to ensure consistent results
-
         # before can be any leading space that might be present in `- name:` eg `      - name: `
         before, sep, after = prompt.partition('- name: ')  # keep the space at the end
         text = " ".join(after.split())  # remove additional spaces in the prompt


### PR DESCRIPTION
Doing a `lower()` on the prompt string reduce the quality of the
predictions. eg:

`create an aws s3 bucket called foo without any policy`

Will returns:

```
    purestorage.flasharray.purefa_s3:
      api_token: e31060a7-21fc-e277-6240-25983c6c4592
      bucket: foo
      fa_url: 10.10.10.84
      mode: create
```

However if the S3 and AWS words are in the original upper case, the
result becomes correct:

```
    amazon.aws.s3_bucket:
      name: foo
      state: present
```
 the result becomes
