### PR TITLE
adjust data source enum to match dataset

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -244,11 +244,11 @@ class DataSource(models.IntegerChoices):
         "Ansible Galaxy collections",
     )
     GALAXY_ME = (
-        5,
+        7,
         "Ansible Galaxy documentation",
     )
     GALAXY_R = (
-        10,
+        14,
         "Ansible Galaxy roles",
     )
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AAP-13045

this is a temporary workaround; ultimately, we will use the description from the dataset (and then update it again when we internationalize). Currently, the description isn't user-friendly.