### PR TITLE
bump ARI to 0.1.7 and KB data to v0.0.9

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.8
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.9
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.8
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.9
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 ansible_anonymizer==1.3.0
-ansible-risk-insight==0.1.6
+ansible-risk-insight==0.1.7
 boto3==1.26.84
 datasets==2.10.1
 Django==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ansible-anonymizer==1.3.0
     # via -r requirements.in
 ansible-core==2.15.0
     # via ansible
-ansible-risk-insight==0.1.6
+ansible-risk-insight==0.1.7
     # via -r requirements.in
 appnope==0.1.3
     # via ipython
@@ -111,6 +111,7 @@ executing==1.2.0
     # via stack-data
 filelock==3.12.0
     # via
+    #   ansible-risk-insight
     #   huggingface-hub
     #   torch
     #   transformers


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix for the issue [AAP-12397](https://issues.redhat.com/browse/AAP-12397)
  - Now ARI can throw an exception while rule evaluation only when it is required by a rule (then the exception is handled by ansible-wisdom-service)
- fix race condition issue while updating KB index data (this was a possible reason for the issue [AAP-12861](https://issues.redhat.com/browse/AAP-12861))