### PR TITLE
Add Prometheus monitoring to User model

### DIFF
--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -3,8 +3,9 @@ import uuid
 
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django_prometheus.models import ExportModelOperationsMixin
 
 
-class User(AbstractUser):
+class User(ExportModelOperationsMixin('user'), AbstractUser):
     uuid = models.UUIDField(unique=True, default=uuid.uuid4, editable=False)
     date_terms_accepted = models.DateTimeField(unique=False, default=None, null=True)


### PR DESCRIPTION
For [AAP-12342](https://issues.redhat.com/browse/AAP-12342).

It will add Prometheus metrics for user model like
```
# HELP django_model_inserts_total Number of insert operations by model.
# TYPE django_model_inserts_total counter
django_model_inserts_total{model="user"} 0.0
# HELP django_model_inserts_created Number of insert operations by model.
# TYPE django_model_inserts_created gauge
django_model_inserts_created{model="user"} 1.6863051966379366e+09
# HELP django_model_updates_total Number of update operations by model.
# TYPE django_model_updates_total counter
django_model_updates_total{model="user"} 0.0
# HELP django_model_updates_created Number of update operations by model.
# TYPE django_model_updates_created gauge
django_model_updates_created{model="user"} 1.6863051966379452e+09
# HELP django_model_deletes_total Number of delete operations by model.
# TYPE django_model_deletes_total counter
django_model_deletes_total{model="user"} 0.0
# HELP django_model_deletes_created Number of delete operations by model.
# TYPE django_model_deletes_created gauge
django_model_deletes_created{model="user"} 1.6863051966379507e+09
```

This uses a feature provided by `django-prometheus`.  Refer https://github.com/korfuri/django-prometheus#monitoring-your-models for more details.