### PR TITLE
force compose to use linux/x86_64

### DIFF
--- a/tools/docker-compose/pip-compile.yaml
+++ b/tools/docker-compose/pip-compile.yaml
@@ -1,6 +1,7 @@
 version: "3.8"
 services:
   pip-compile:
+    platform: linux/x86_64
     image: registry.access.redhat.com/ubi9/ubi:latest
     volumes:
       - $PWD:/var/www/wisdom


### PR DESCRIPTION
This patch combined w/ https://gist.github.com/gebhardtr/b9b281ac79cc0ebce5aeb1a7190dc945 worked for me on: `xnu-8796.121.2~5/RELEASE_ARM64_T6000 arm64`