### PR TITLE
Add suffixes defined in views throttle cache keys

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -121,6 +121,8 @@ class Completions(APIView):
     ]
     required_scopes = ['read', 'write']
 
+    throttle_cache_key_suffix = '_completions'
+
     @extend_schema(
         request=CompletionRequestSerializer,
         responses={
@@ -416,6 +418,8 @@ class Feedback(APIView):
     ]
     required_scopes = ['read', 'write']
 
+    throttle_cache_key_suffix = '_feedback'
+
     @extend_schema(
         request=FeedbackRequestSerializer,
         responses={
@@ -574,6 +578,8 @@ class Attributions(GenericAPIView):
         AcceptedTermsPermission,
     ]
     required_scopes = ['read', 'write']
+
+    throttle_cache_key_suffix = '_attributions'
 
     @extend_schema(
         request=AttributionRequestSerializer,

--- a/ansible_wisdom/users/tests/test_throttling.py
+++ b/ansible_wisdom/users/tests/test_throttling.py
@@ -1,5 +1,5 @@
 from ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ai.api.views import Completions
+from ai.api.views import Attributions, Completions, Feedback
 
 from ..throttling import GroupSpecificThrottle
 
@@ -7,17 +7,20 @@ from ..throttling import GroupSpecificThrottle
 class TestThrottling(WisdomServiceAPITestCaseBase):
     def test_get_cache_key(self):
         class DummyRequest:
-            def __init__(self, user, method, path):
+            def __init__(self, user):
                 self.user = user
-                self.method = method
-                self.path = path
 
         throttling = GroupSpecificThrottle()
-        method = 'POST'
-        path = '/api/v0/ai/completions/'
-        request = DummyRequest(self.user, method, path)
-        view = Completions()
+        request = DummyRequest(self.user)
 
-        cache_key = throttling.get_cache_key(request, view)
-        expected = f'throttle_user_{self.user.pk}_{method}_{path}'
-        self.assertIsNotNone(expected, cache_key)
+        cache_key = throttling.get_cache_key(request, Completions())
+        expected = f'throttle_user_{self.user.pk}_completions'
+        self.assertEqual(expected, cache_key)
+
+        cache_key = throttling.get_cache_key(request, Attributions())
+        expected = f'throttle_user_{self.user.pk}_attributions'
+        self.assertEqual(expected, cache_key)
+
+        cache_key = throttling.get_cache_key(request, Feedback())
+        expected = f'throttle_user_{self.user.pk}_feedback'
+        self.assertEqual(expected, cache_key)

--- a/ansible_wisdom/users/throttling.py
+++ b/ansible_wisdom/users/throttling.py
@@ -13,6 +13,9 @@ class GroupSpecificThrottle(UserRateThrottle):
 
     GROUPS = settings.SPECIAL_THROTTLING_GROUPS
 
+    # The attribute name that may be defined in views to add a suffix to cache keys
+    cache_key_suffix_attr = 'throttle_cache_key_suffix'
+
     def __init__(self):
         # Override, since we can't decide what the scope and rate are
         # until we see the request.
@@ -36,8 +39,8 @@ class GroupSpecificThrottle(UserRateThrottle):
 
     def get_cache_key(self, request, view):
         cache_key = super().get_cache_key(request, view)
-        # Append request.method and request.path to cache_key
-        # so that a separate throttle is given per endpoint
-        if request.method and request.path:
-            cache_key += f'_{request.method}_{request.path}'
+        # If a cache key suffix is defined in the view, append it to the key
+        cache_key_suffix = getattr(view, self.cache_key_suffix_attr, None)
+        if cache_key_suffix:
+            cache_key += cache_key_suffix
         return cache_key


### PR DESCRIPTION
For [AAP-13681](https://issues.redhat.com/browse/AAP-13681).

This PR will suffixes defined in views to throttling cache keys so that each endpoint has its own throttles.

Suffixes are defined in the `throttle_cache_key_suffix` attribute like:

```
    throttle_cache_key_suffix = '_completions'
```

If it is not defined in a view, no suffix will be added.