### PR TITLE
Add comment to a commit not to a PR

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -15,6 +15,9 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-20.04
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v3
 
@@ -82,11 +85,22 @@ jobs:
         CLAMAV_DB_IMAGE: quay.io/redhat-appstudio/clamav-db:latest
         CLAMAV_DB_DIR: /var/lib/clamav
 
-    - name: Add Malware Scanning PR Comment
-      uses: thollander/actions-comment-pull-request@v2
-      with:
-        filePath: ./clamav.md
+    - name: Get Comment Body
+      id: get-comment-body
+      # https://github.com/marketplace/actions/commit-comment#setting-the-comment-body-from-a-file
       if: ${{ github.event_name == 'push' }}
+      run: |
+        body="$(cat clamav.md)"
+        delimiter="$(openssl rand -hex 8)"
+        echo "body<<$delimiter" >> $GITHUB_OUTPUT
+        echo "$body" >> $GITHUB_OUTPUT
+        echo "$delimiter" >> $GITHUB_OUTPUT
+
+    - name: Add Malware Scanning Commit Comment
+      if: ${{ github.event_name == 'push' }}
+      uses: peter-evans/commit-comment@v2
+      with:
+        body: ${{ steps.get-comment-body.outputs.body }}
 
     - name: Push To quay.io
       id: push-to-quay


### PR DESCRIPTION
This will fix [the error](https://github.com/ansible/ansible-wisdom-service/actions/runs/5510068164/jobs/10043712953) in found in merging #404 to main.

The original action was written to post a comment to a PR, but since the action was executed when pushing the PR to the main branch, it should have been added to a commit, not a PR.

Because the action is executed when the PR is merged to the main branch, this code itself was not tested, but the action used here ([Commit Comment](https://github.com/marketplace/actions/commit-comment#setting-the-comment-body-from-a-file)) was tested in my own personal repo with [this code](https://github.com/TamiTakamiya/github-action-sample/blob/main/.github/workflows/post_comment.yaml).