### PR TITLE
Bypass the terms of service page if the user has previously accepted

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -113,6 +113,9 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = [
+    'terms_accepted',
+]
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',
@@ -125,7 +128,6 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.user.user_details',
     'users.pipeline.terms_of_service',
-    'users.pipeline.add_date_accepted',
 )
 
 # Wisdom Eng Team:

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -55,18 +55,16 @@ class TermsOfService(TemplateView):
             logger.error('POST /terms_of_service/ was invoked without partial_token')
             return HttpResponseBadRequest()
 
-        accepted = request.POST.get('accepted') == 'True'
-
         strategy = load_strategy()
         partial = strategy.partial_load(partial_token)
         if partial is None:
             logger.error('strategy.partial_load(partial_token) returned None')
             return HttpResponseBadRequest()
+
+        accepted = request.POST.get('accepted') == 'True'
+        request.session['terms_accepted'] = accepted
+        request.session.save()
+
         backend = partial.backend
-
-        if accepted:
-            request.session['ts_date_terms_accepted'] = datetime.utcnow().timestamp()
-            request.session.save()
-
         complete = reverse("social:complete", kwargs={"backend": backend})
         return strategy.redirect(complete + f"?partial_token={partial.token}")


### PR DESCRIPTION
This also involved pushing the pipeline item down to the bottom, so that the Django `User` object has already been created, with the `date_terms_accepted` field either populated or null depending on whether they've gone through the acceptance previously.