### PR TITLE
Give a larger rate limit to the feedback endpoint

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -419,6 +419,7 @@ class Feedback(APIView):
     required_scopes = ['read', 'write']
 
     throttle_cache_key_suffix = '_feedback'
+    throttle_cache_multiplier = 6.0
 
     @extend_schema(
         request=FeedbackRequestSerializer,

--- a/ansible_wisdom/users/tests/test_throttling.py
+++ b/ansible_wisdom/users/tests/test_throttling.py
@@ -1,5 +1,6 @@
 from ai.api.tests.test_views import WisdomServiceAPITestCaseBase
 from ai.api.views import Attributions, Completions, Feedback
+from django.conf import settings
 
 from ..throttling import GroupSpecificThrottle
 
@@ -24,3 +25,35 @@ class TestThrottling(WisdomServiceAPITestCaseBase):
         cache_key = throttling.get_cache_key(request, Feedback())
         expected = f'throttle_user_{self.user.pk}_feedback'
         self.assertEqual(expected, cache_key)
+
+    def test_format_rate(self):
+        num_requests = 60
+
+        rate = GroupSpecificThrottle.format_rate(num_requests, 1)
+        self.assertEqual(rate, '60/second')
+        rate = GroupSpecificThrottle.format_rate(num_requests, 60)
+        self.assertEqual(rate, '60/minute')
+        rate = GroupSpecificThrottle.format_rate(num_requests, 3600)
+        self.assertEqual(rate, '60/hour')
+        rate = GroupSpecificThrottle.format_rate(num_requests, 86400)
+        self.assertEqual(rate, '60/day')
+
+    def test_multiplier(self):
+        throttling = GroupSpecificThrottle()
+
+        user_rate_throttle = settings.COMPLETION_USER_RATE_THROTTLE
+
+        view = Completions()
+        multiplier = getattr(view, 'throttle_cache_multiplier', None)
+        self.assertIsNone(multiplier)
+        rate = throttling.get_rate(view)
+        self.assertEqual(rate, user_rate_throttle)
+
+        view = Feedback()
+        multiplier = getattr(view, 'throttle_cache_multiplier', None)
+        self.assertIsNotNone(multiplier)
+        self.assertEqual(multiplier, 6.0)
+        num_requests, duration = throttling.parse_rate(user_rate_throttle)
+        expected = GroupSpecificThrottle.format_rate(int(num_requests * multiplier), duration)
+        rate = throttling.get_rate(Feedback())
+        self.assertEqual(rate, expected)

--- a/ansible_wisdom/users/throttling.py
+++ b/ansible_wisdom/users/throttling.py
@@ -16,6 +16,9 @@ class GroupSpecificThrottle(UserRateThrottle):
     # The attribute name that may be defined in views to add a suffix to cache keys
     cache_key_suffix_attr = 'throttle_cache_key_suffix'
 
+    # The attribute name that may be definied in views to give a larger (or smaller) rate limit
+    cache_key_multipiler_attr = 'throttle_cache_multiplier'
+
     def __init__(self):
         # Override, since we can't decide what the scope and rate are
         # until we see the request.
@@ -32,7 +35,7 @@ class GroupSpecificThrottle(UserRateThrottle):
 
         # get_rate() will now pull the rate setting based on our dynamically set
         # scope value.
-        self.rate = self.get_rate()
+        self.rate = self.get_rate(view)
         self.num_requests, self.duration = self.parse_rate(self.rate)
 
         return super().allow_request(request, view)
@@ -44,3 +47,25 @@ class GroupSpecificThrottle(UserRateThrottle):
         if cache_key_suffix:
             cache_key += cache_key_suffix
         return cache_key
+
+    def get_rate(self, view):
+        rate = super().get_rate()
+
+        multipiler = getattr(view, self.cache_key_multipiler_attr, None)
+        # If a multiplier is defined in the view, modify the rate based on it
+        if multipiler:
+            num_requests, duration = self.parse_rate(rate)
+            rate = GroupSpecificThrottle.format_rate(
+                int(float(multipiler) * num_requests), duration
+            )
+        return rate
+
+    @staticmethod
+    def format_rate(num_requests, duration):
+        duration_unit = {
+            1: 'second',
+            60: 'minute',
+            3600: 'hour',
+            86400: 'day',
+        }[duration]
+        return f'{num_requests}/{duration_unit}'


### PR DESCRIPTION
For [AAP-13997](https://issues.redhat.com/browse/AAP-13997).

The new code will check if the attribute `throttle_cache_multiplier` is defined in the view class.  If it is defined, use it to modify the rate limit for the view.

I set 6.0 to the  `throttle_cache_multiplier` attribute of the `Feedback` view, i.e. `60/minute` will be set to the `Feedback` view by default.