### PR TITLE
CVE-2023-30589: embed aiohttp 3.8.5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,8 @@
+# pin aiohttp on 3.8.5 to address CVE-2023-30589
+# remove this once datasets or fsspec is updated
+# to properly pull a version of aiohttp > 3.8.4.
+aiohttp==3.8.5  # Pin on 3.8.5 to
+
 ansible_anonymizer==1.4.1
 ansible-risk-insight==0.1.7
 boto3==1.26.84

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@
 #
 #    pip-compile requirements.in
 #
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
+    #   -r requirements.in
     #   datasets
     #   fsspec
 aiosignal==1.3.1


### PR DESCRIPTION
Pin the aiohttp version to 3.8.5 to be sure we've got a version that addresses
CVE-2023-30589.
