### PR TITLE
requirements.txt: upgrade certifi to 2023.7.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ botocore==1.29.143
     # via
     #   boto3
     #   s3transfer
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   launchdarkly-server-sdk
     #   opensearch-py


### PR DESCRIPTION
This to address the following `pip-audit` error:

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
certifi | 2023.5.7 | GHSA-xqr8-7jwr-rhp7 | 2023.7.22 | Certifi 2023.07.22
removes root certificates from "e-Tugra" from the root store. These are in
the process of being removed from Mozilla's trust store.   e-Tugra's root
certificates are being removed pursuant to an investigation prompted by
reporting of security issues in their systems. Conclusions of Mozilla's
investigation can be found [here](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A).
```
