### PR TITLE
Fix YAML formatting of default predictions used by MockClient

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -306,8 +306,8 @@ APPEND_SLASH = True
 MOCK_MODEL_RESPONSE_BODY = os.environ.get(
     'MOCK_MODEL_RESPONSE_BODY',
     (
-        '{"predictions":["  ansible.builtin.apt:\\n    name: nginx\\n'
-        'update_cache: true\\n    state: present\\n"]}'
+        '{"predictions":["ansible.builtin.apt:\\n  name: nginx\\n'
+        '  update_cache: true\\n  state: present\\n"]}'
     ),
 )
 MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC = int(os.environ.get('MOCK_MODEL_RESPONSE_LATENCY_MSEC', 3000))


### PR DESCRIPTION
The formatting of the default prediction used by `MockClient` was found to be wrong during onboarding.