### PR TITLE
requirements: upgrade cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ click==8.1.3
     # via nltk
 cmake==3.26.4
     # via triton
-cryptography==41.0.2
+cryptography==41.0.3
     # via
     #   ansible-core
     #   jwcrypto


### PR DESCRIPTION
This to address the following `pip-audit` warning:

```
 Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
cryptography | 41.0.2 | GHSA-jm77-qphf-c4w8 | 41.0.3 | pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 0.8-41.0.2 are vulnerable to several security issues. More details about the vulnerabilities themselves can be found in https://www.openssl.org/news/secadv/20230731.txt, https://www.openssl.org/news/secadv/20230719.txt, and https://www.openssl.org/news/secadv/20230714.txt.  If you are building cryptography source ("sdist") then you are responsible for upgrading your copy of OpenSSL. Only users installing from wheels built by the cryptography project (i.e., those distributed on PyPI) need to update their cryptography versions.
```
