### PR TITLE
Run the backends in the daemon mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ docker-compose:
 run-backends:
 	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml up --remove-orphans -d
 
+# An alias for run-backends for consistency with the `stop` command
+start-backends: run-backends
+
 # Stop backend services
 stop-backends:
 	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml down


### PR DESCRIPTION
This PR is for running the backends in the daemon mode to make the stop easier without a CRTL+C before doing a `make stop-backends`.

Edit: Also added an alias for `run-backends` as `start-backends`