### PR TITLE
Fix the Grafana container's directory permission error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,5 @@ db_data
 ari/kb/data/
 ari/kb/rules/
 
-# Grafana db files
-grafana/*.db
+# Generated Grafana files
+grafana/*

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ db_data
 # Ansible Risk Insight
 ari/kb/data/
 ari/kb/rules/
+
+# Grafana db files
+grafana/*.db

--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -36,6 +36,7 @@ services:
       - $PWD/grafana:/var/lib/grafana
     networks:
       - dbnet
+    user: "$UID:$GID"
 
 networks:
   dbnet:

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -89,6 +89,7 @@ services:
       - $PWD/grafana:/var/lib/grafana
     networks:
       - dbnet
+    user: "$UID:$GID"
 
 networks:
   dbnet:


### PR DESCRIPTION
I've faced the following issue while running the backends for setting up my environment:

```GF_PATHS_DATA='/var/lib/grafana' is not writable.
�You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later
service init failed: failed to check table existence: unable to open database file: permission denied
```

As a workaround, I found a solution here: https://github.com/grafana/grafana/issues/51931#issuecomment-1183390857

This solution works on a MacOS environment with Podman and Podman Compose (both latest releases). Thought we might want to use this as the `compose-backends` is used for development purposes.

