### PR TITLE
set csp to report-only in dev

### DIFF
--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -57,3 +57,5 @@ if DEBUG:
             "social_django.middleware.SocialAuthExceptionMiddleware"
         )
         MIDDLEWARE[index] = "main.middleware.WisdomSocialAuthExceptionMiddleware"  # noqa: F405
+
+CSP_REPORT_ONLY = True

--- a/ansible_wisdom/main/tests/test_urls.py
+++ b/ansible_wisdom/main/tests/test_urls.py
@@ -21,6 +21,7 @@ class TestUrls(TestCase):
         )
         self.assertCountEqual(routes, patterns)
 
+    @override_settings(CSP_REPORT_ONLY=False)
     def test_headers(self):
         client = Client()
         response = client.get("/")


### PR DESCRIPTION
The current CSP policy breaks swagger and redoc. Those URLs are only enabled when the `settings.DEBUG` is enabled. So I'm proposing to set CSP to report-only for development.

This will print out all the resources CSP would block, but not actually block them.