### PR TITLE
Fix relative path reference.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(ENVIRONMENT),development)
 	export ANSIBLE_AI_DATABASE_NAME := wisdom
 	export ANSIBLE_AI_DATABASE_PASSWORD := wisdom
 	export ANSIBLE_AI_DATABASE_USER := wisdom
-	export ARI_KB_PATH := ../ari/kb/
+	export ARI_KB_PATH := ./ari/kb/
 	export DJANGO_SETTINGS_MODULE := main.settings.development
 	export ENABLE_ARI_POSTPROCESS := True
 	export PYTHONUNBUFFERED := 1


### PR DESCRIPTION
This fixes the CI builds and local use of `make test` and `make code-coverage`.

I suspect https://github.com/ansible/ansible-wisdom-service/pull/463 broke it.

I further suspect @mabulgu has a `ansible-wisdom-service/venv` folder vs `ansible-wisdom-service/ansible-wisdom/venv` folder.

It seems the `venv` should more correctly be in the child folder. There have been other issues setting the `venv` in the root. 