### PR TITLE
fix wca url pattern and secret name generation

### DIFF
--- a/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
@@ -18,7 +18,7 @@ class TestWcaApiKeyClient(APITestCase, WisdomServiceLogAwareTestCase):
     def test_get_secret_name(self):
         self.assertEqual(
             WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY),
-            f'{SECRET_KEY_PREFIX}/{ORG_ID}/{Suffixes.API_KEY.value}',
+            f'{SECRET_KEY_PREFIX}/{ORG_ID}/{Suffixes.API_KEY.value[0]}',
         )
 
     def test_get_key(self):

--- a/ansible_wisdom/ai/api/aws/wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/wca_secret_manager.py
@@ -37,7 +37,7 @@ class WcaSecretManager:
 
     @staticmethod
     def get_secret_id(org_id, suffix: Suffixes):
-        return f"{SECRET_KEY_PREFIX}/{org_id}/{suffix.value}"
+        return f"{SECRET_KEY_PREFIX}/{org_id}/{suffix.value[0]}"
 
     def save_secret(self, org_id, suffix: Suffixes, secret):
         """

--- a/ansible_wisdom/ai/api/wca/urls.py
+++ b/ansible_wisdom/ai/api/wca/urls.py
@@ -3,6 +3,6 @@ from ai.api.wca.model_id_views import WCAModelIdView
 from django.urls import path
 
 urlpatterns = [
-    path('<str:org_id>/apikey', WCAApiKeyView.as_view(), name='wca_api_key'),
-    path('<str:org_id>/modelid', WCAModelIdView.as_view(), name='wca_model_id'),
+    path('<str:org_id>/apikey/', WCAApiKeyView.as_view(), name='wca_api_key'),
+    path('<str:org_id>/modelid/', WCAModelIdView.as_view(), name='wca_model_id'),
 ]


### PR DESCRIPTION
Adds a trailing slash to the WCA Urls. All (most?) other URL patterns end with a trailing slash, so probably good to add it here too.

Also, fixes an issue with how the name of the secret is generated. `suffix.value` in this case is a tuple and is printed as `wca/<org_id>/('api_key',)` in the string. We want the first item of this tuple: `wca/<org_id>/api_key`;