### PR TITLE
allow inline css, scripts and data urls

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -396,4 +396,5 @@ WCA_SECRET_MANAGER_REPLICA_REGIONS = [
     c.strip() for c in os.getenv('WCA_SECRET_MANAGER_REPLICA_REGIONS', '').split(',') if c
 ]
 
-CSP_DEFAULT_SRC = ("'self'", "'unsafe-inline'", "data:")
+CSP_DEFAULT_SRC = ("'self'", "data:")
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")

--- a/ansible_wisdom/main/tests/test_urls.py
+++ b/ansible_wisdom/main/tests/test_urls.py
@@ -25,4 +25,7 @@ class TestUrls(TestCase):
     def test_headers(self):
         client = Client()
         response = client.get("/")
-        self.assertIn("'self'", response.headers.get('Content-Security-Policy'))
+        self.assertIn(
+            "style-src 'self' 'unsafe-inline'", response.headers.get('Content-Security-Policy')
+        )
+        self.assertIn("default-src 'self' data:", response.headers.get('Content-Security-Policy'))


### PR DESCRIPTION
Allow inline CSS and Scripts as well as data URLs, because we use them in several templates.

There are two possible solutions:

1. use `unsafe-inline` to allow inline scripts and css (this PR).
2. move all inline css into a file loaded from the static resources to conform with CSP.

The disadvantage of option one is that this potentially opens the door for script injection (as the browser will run script tags). Probably not a huge risk since we don't have too many forms that accept user input.

Option 2 requires some refactoring of existing forms (especially the commercial and community terms), but fully conforms with CSP.