### PR TITLE
attribution API updates

### DIFF
--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -404,9 +404,12 @@ components:
       - repo_url
       - score
     Attributions:
-      type: array
-      items:
-        $ref: '#/components/schemas/Attribution'
+      type: object
+      properties:
+        attribution:
+        type: array
+        items:
+          $ref: '#/components/schemas/Attribution'
     AttributionRequest:
       type: object
       properties:

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -403,6 +403,10 @@ components:
       - repo_name
       - repo_url
       - score
+    Attributions:
+      type: array
+      items:
+        $ref: '#/components/schemas/Attribution'
     AttributionRequest:
       type: object
       properties:
@@ -422,7 +426,7 @@ components:
         attributions:
           type: array
           items:
-            $ref: '#/components/schemas/Attribution'
+            $ref: '#/components/schemas/Attributions'
       required:
       - attributions
     CompletionRequest:


### PR DESCRIPTION
⚠️ Updated:

Proposal: A NEW content matching API that will:
- Be served under a new API endpoint path (leaving the old attribution endpoint intact), named something that reflects that it's "content match" versus "attribution"  /v0/content-match etc.
-  Accept:
      - a single "`suggestion`, which is a block of text containing one or more tasks
     - a `suggestionId `which is the completion API request Id
     - a `model` string which is the model name used in the completion API request (format below)
- Return an array of arrays of objects (format below), where the outer array is 1:1 mapped to number of tasks and the inner (child) array is 1:1 mapped to "search hits". or content match search results per task

ℹ️ Updated to include @ganeshrn's comments

Request:
```json
{
  "suggestion": "string",
  "suggestionId": "string(uuid)",
  "model": "string"
}
```
ℹ️ NOTE: `suggestion` may contain substrings like "- name: string value\nmore content" so there shouldn't be restrictions/validations on value that will result in a failure in this case

Response:

~~⚠️ NOTE: we're considering removing multiple hits for each content match request, so the child array below (`attribution`) may be omitted in favor of a single top-level array `attributions`~~ (we've decided to keep multiple hits per content match to illustrate that the approach isn't perfect). 
```json
{
  "attributions": [
    {
      "attribution": [
        {
          "repo_name": "string",
          "repo_url": "string(uri)",
          "path": "string(path)",
          "license": "string",
          "data_source": "string",
          "ansible_type": "string",
          "score": "double"
        }
      ]
    }
  ]
}

```