### PR TITLE
add nonce to inline script for auth redirect

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -398,3 +398,4 @@ WCA_SECRET_MANAGER_REPLICA_REGIONS = [
 
 CSP_DEFAULT_SRC = ("'self'", "data:")
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
+CSP_INCLUDE_NONCE_IN = ['script-src-elem']

--- a/ansible_wisdom/main/templates/oauth2_provider/authorize.html
+++ b/ansible_wisdom/main/templates/oauth2_provider/authorize.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block header %}
-<script>
+<script nonce="{{request.csp_nonce}}">
     function handleAuthorize() {
         setTimeout(() => { window.location.href = "/" }, 5000)
     }


### PR DESCRIPTION
Adds a nonce to the script element that handles redirect after logging in. The CSP header will then specifically allow a script with this nonce to be run. Nonces are created per request.

Verification:

1. Run the wisdom service and open the index page.
2. Log in with RHSSO (this should be a first login, otherwise you won't see the authorize page).
3. after accepting the scopes and clicking on `Authorize`, you should be redirected back to the home page.
