### PR TITLE
Suffixes enum values should not be tuples.

### DIFF
--- a/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
@@ -18,7 +18,7 @@ class TestWcaApiKeyClient(APITestCase, WisdomServiceLogAwareTestCase):
     def test_get_secret_name(self):
         self.assertEqual(
             WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY),
-            f'{SECRET_KEY_PREFIX}/{ORG_ID}/{Suffixes.API_KEY.value[0]}',
+            f'{SECRET_KEY_PREFIX}/{ORG_ID}/{Suffixes.API_KEY.value}',
         )
 
     def test_get_key(self):

--- a/ansible_wisdom/ai/api/aws/wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/wca_secret_manager.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class Suffixes(Enum):
-    API_KEY = ('api_key',)
-    MODEL_ID = ('model_id',)
+    API_KEY = 'api_key'
+    MODEL_ID = 'model_id'
 
 
 class WcaSecretManager:
@@ -37,7 +37,7 @@ class WcaSecretManager:
 
     @staticmethod
     def get_secret_id(org_id, suffix: Suffixes):
-        return f"{SECRET_KEY_PREFIX}/{org_id}/{suffix.value[0]}"
+        return f"{SECRET_KEY_PREFIX}/{org_id}/{suffix.value}"
 
     def save_secret(self, org_id, suffix: Suffixes, secret):
         """


### PR DESCRIPTION
Following https://github.com/ansible/ansible-wisdom-service/pull/478/files#r1307612837

Defining the `Statuses` enum values as `( <value>, )` made them tuples; necessitating the use of `[0]` when accessing them.

This however was a mistake.. I had originally put commas after each value as a mistake from using Java.

Our post commit hook _linter_ added the surrounding brackets and they became tuples.

This PR fixes their definition and removes the need to access the tuple members.