### PR TITLE
requirements: bump social-auth-app-django/social-auth-core

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,8 +28,10 @@ PyYAML==6.0
 requests==2.31.0
 segment-analytics-python==2.2.2
 sentence-transformers==2.2.2
-social-auth-app-django==5.0.0
-social-auth-core[openidconnect]==4.3.0
+# Workaround until https://github.com/python-social-auth/social-app-django/pull/465
+# is released
+https://github.com/python-social-auth/social-app-django/archive/2415e073f52d50af53beb02f5e7f557c8e690371.tar.gz
+social-auth-core[openidconnect]==4.4.2
 tqdm==4.64.1
 uwsgi==2.0.22
 uwsgi-readiness-check==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,6 +92,7 @@ django==4.2.3
     #   django-oauth-toolkit
     #   djangorestframework
     #   drf-spectacular
+    #   social-auth-app-django
 django-allow-cidr==0.6.0
     # via -r requirements.in
 django-csp==3.7
@@ -384,9 +385,9 @@ smmap==5.0.0
     # via
     #   ansible-risk-insight
     #   gitdb
-social-auth-app-django==5.0.0
+social-auth-app-django @ https://github.com/python-social-auth/social-app-django/archive/2415e073f52d50af53beb02f5e7f557c8e690371.tar.gz
     # via -r requirements.in
-social-auth-core[openidconnect]==4.3.0
+social-auth-core[openidconnect]==4.4.2
     # via
     #   -r requirements.in
     #   social-auth-app-django


### PR DESCRIPTION
- Upgrade social-auth-app-django to a pre-release of 5.2.0 that include
  https://github.com/python-social-auth/social-app-django/pull/465
- Upgrade social-auth-core to match social-auth-app-django's requirements.
