### PR TITLE
refactor inline event handler

### DIFF
--- a/ansible_wisdom/main/templates/oauth2_provider/authorize.html
+++ b/ansible_wisdom/main/templates/oauth2_provider/authorize.html
@@ -2,9 +2,11 @@
 
 {% block header %}
 <script nonce="{{request.csp_nonce}}">
-    function handleAuthorize() {
-        setTimeout(() => { window.location.href = "/" }, 5000)
-    }
+    window.addEventListener('load', function () {
+        document.querySelector("button[type=submit]").addEventListener('click', function () {
+            setTimeout(() => { window.location.href = "/" }, 5000)
+        });
+    })
 </script>
 {% endblock %}
 
@@ -40,7 +42,7 @@
                         <footer class="pf-c-modal-box__footer">
                             <div class="control-group">
                                 <div class="controls">
-                                    <button type="submit" class="pf-c-button pf-m-primary" name="allow" value="Authorize" onClick="handleAuthorize()">
+                                    <button type="submit" class="pf-c-button pf-m-primary" name="allow" value="Authorize">
                                         Authorize
                                     </button>
                                     <button type="submit" class="pf-c-button pf-m-link" value="Cancel">Cancel</button>


### PR DESCRIPTION
CSP does not allow JavaScript to be called from in-line event handlers, even when that JavaScript is inside a script tag. See for example: https://stackoverflow.com/questions/56399872/content-security-policy-nonce-does-not-apply-to-event-handler-attributes

The solution is to register a global event handler and not rely on `<button onClick=...>`.