### PR TITLE
test_health_check_http_error: ensure we use the write backend

### DIFF
--- a/ansible_wisdom/healthcheck/tests/test_healthcheck.py
+++ b/ansible_wisdom/healthcheck/tests/test_healthcheck.py
@@ -67,6 +67,7 @@ class TestHealthCheck(APITestCase):
         data = json.loads(r.content)
         self.assertEqual(timestamp, data['timestamp'])
 
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="http")
     @mock.patch('requests.get', side_effect=mocked_requests_http_fail)
     def test_health_check_http_error(self, _):
         cache.clear()


### PR DESCRIPTION
The test is designed work only if `ANSIBLE_AI_MODEL_MESH_API_TYPE` is `http` or `grpc`.
Which is fine since this is also the default value for the key.

But since people may also initialize their environment with a different environment
variables, it's better to clarify the requirement with an `override_settings()`.
