### PR TITLE
consolidate seat checks

### DIFF
--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -24,6 +24,10 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
 
     @cached_property
     def has_seat(self) -> bool:
+        # For dev/test purposes only:
+        if self.groups.filter(name='Commercial').exists():
+            return True
+
         if not self.is_oidc_user():
             return False
 

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -83,7 +83,7 @@ def _terms_of_service(strategy, user, backend, **kwargs):
     # commercial, there also needs to be the seat check when that gets
     # integrated.  When that happens, update this to include that
     # logic.  Possibly also remove the Commerical group?
-    is_commercial = user.groups.filter(name='Commercial').exists()
+    is_commercial = user.has_seat
     terms_type = 'commercial' if backend.name == 'oidc' and is_commercial else 'community'
     field_name = f'{terms_type}_terms_accepted'
     view_name = f'{terms_type}_terms'


### PR DESCRIPTION
- all seat checks in the code base should use has_seat
- "Community" group can be used for easy dev/testing purposes but will not be leveraged in prod for actual commercial users