### PR TITLE
allow empty fields in content matching response

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -362,8 +362,8 @@ class EnumField(serializers.Field):
 class AttributionSerializer(serializers.Serializer):
     repo_name = serializers.CharField()
     repo_url = serializers.URLField()
-    path = serializers.CharField(required=False)
-    license = serializers.CharField(required=False)
+    path = serializers.CharField(allow_blank=True)
+    license = serializers.CharField()
     data_source = EnumField(choices=DataSource)
     ansible_type = EnumField(choices=AnsibleType)
     score = serializers.FloatField()


### PR DESCRIPTION
⚠️ In discussion; this is a proposed workaround to prevent malformed content matching responses while the IBM team works on populating all fields in the content matching dataset:

Before:
<img width="491" alt="image" src="https://github.com/ansible/ansible-wisdom-service/assets/13005641/fbd687ba-93f1-4aae-b701-38704bce5beb">

After:
<img width="487" alt="image" src="https://github.com/ansible/ansible-wisdom-service/assets/13005641/7aa43afa-550c-4dcc-8dbe-10dfce9b36bb">

