### PR TITLE
AMS: avoid an exception if an org cannot be found

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -118,7 +118,7 @@ class AMSCheck:
 
         try:
             return data["items"][0]["id"]
-        except (KeyError, ValueError):
+        except (IndexError, KeyError, ValueError):
             logger.error("Unexpected organization answer from AMS")
             return ""
 


### PR DESCRIPTION
This happens when the user comes from the RHSSO but the associated org cannot be found.
