### PR TITLE
tools/authz/validate_ams: read use the service's envvar

### DIFF
--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 
-from uuid import uuid4
-
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase
 from main.views import LoginView
-from social_django.models import UserSocialAuth
 
 
 class AlreadyAuth(TestCase):

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-from datetime import datetime
 
 from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect

--- a/ansible_wisdom/users/management/commands/fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/management/commands/fix_users_with_two_sso_providers.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import datetime
-
 from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from social_django.models import UserSocialAuth
 
 User = get_user_model()

--- a/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
@@ -24,7 +24,6 @@ class TestFixUsersWithTwoSSOProviders(WisdomServiceLogAwareTestCase):
 
     def test_without_fix_paramter(self):
         base = Mock()
-        User = get_user_model()
         before = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
         Command.handle(base, fix=False)
         after = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
@@ -35,7 +34,6 @@ class TestFixUsersWithTwoSSOProviders(WisdomServiceLogAwareTestCase):
 
     def test_with_fix_paramter(self):
         base = Mock()
-        User = get_user_model()
         Command.handle(base, fix=True)
         counter = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
         self.assertEqual(counter, 1)

--- a/tools/authz/validate_ams.py
+++ b/tools/authz/validate_ams.py
@@ -14,7 +14,6 @@ class Token:
         self._client_secret = client_secret
         self.expiration_date = datetime.fromtimestamp(0)
         self.access_token: str = ""
-        self.server = "sso.redhat.com"
 
     def refresh(self) -> None:
         data = {
@@ -25,7 +24,8 @@ class Token:
         }
 
         r = requests.post(
-            f"https://{self.server}/auth/realms/redhat-external/protocol/openid-connect/token",
+            os.environ['AUTHZ_SSO_SERVER']
+            + "/auth/realms/redhat-external/protocol/openid-connect/token",
             data=data,
         )
         data = r.json()
@@ -39,14 +39,14 @@ class Token:
         return self.access_token
 
 
-my_token = Token(os.environ["CLIENT_ID"], os.environ["CLIENT_SECRET"])
+my_token = Token(os.environ["AUTHZ_SSO_CLIENT_ID"], os.environ["AUTHZ_SSO_CLIENT_SECRET"])
 
 
 def get_ams_org(rh_org_id: str) -> str:
     params = {"search": f"external_id='{rh_org_id}'"}
 
     r = requests.get(
-        "https://api.openshift.com/api/accounts_mgmt/v1/organizations",
+        f"{os.environ['AUTHZ_API_SERVER']}/api/accounts_mgmt/v1/organizations",
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {my_token.get()}",
@@ -101,6 +101,7 @@ def rh_user_is_org_admin(username: str, organization_id: str) -> bool:
     return False
 
 
-# assert check("ansiblewisdomtesting1", "17233726") is True
+assert os.environ["AUTHZ_BACKEND_TYPE"] == "ams"
+assert check("ansiblewisdomtesting1", "17233726") is True
 assert rh_user_is_org_admin("ansiblewisdomtesting1", "17233726") is True
 print("Success")


### PR DESCRIPTION
The names of the environment variables now match those we use for the Wisdom Service.
