### PR TITLE
SSO: store the original login in as an extra_data

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -106,6 +106,7 @@ SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = os.environ.get('SOCIAL_AUTH_OIDC_OIDC_ENDPOINT'
 SOCIAL_AUTH_OIDC_KEY = os.environ.get('SOCIAL_AUTH_OIDC_KEY')
 SOCIAL_AUTH_OIDC_SECRET = os.environ.get('SOCIAL_AUTH_OIDC_SECRET')
 SOCIAL_AUTH_OIDC_SCOPE = ['id.idp', 'id.organization']
+SOCIAL_AUTH_OIDC_EXTRA_DATA = [('preferred_username', 'login')]
 
 AUTHZ_BACKEND_TYPE = os.environ.get("AUTHZ_BACKEND_TYPE")
 AUTHZ_SSO_CLIENT_ID = os.environ.get("AUTHZ_SSO_CLIENT_ID")
@@ -138,6 +139,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.user.user_details',
     'users.pipeline.terms_of_service',
+    'users.pipeline.load_extra_data',
 )
 
 # Wisdom Eng Team:

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import uuid
 
@@ -6,6 +7,8 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.utils.functional import cached_property
 from django_prometheus.models import ExportModelOperationsMixin
+
+logger = logging.getLogger(__name__)
 
 
 class User(ExportModelOperationsMixin('user'), AbstractUser):
@@ -36,7 +39,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
             return False
         uid = self.social_auth.values()[0]["uid"]
         rh_org_id = self.organization_id
-        return seat_checker.check(uid, self.username, rh_org_id)
+        return seat_checker.check(uid, self.sso_login(), rh_org_id)
 
     @cached_property
     def is_org_admin(self) -> bool:
@@ -47,7 +50,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         if not seat_checker:
             return False
         rh_org_id = self.organization_id
-        return seat_checker.is_org_admin(self.username, rh_org_id)
+        return seat_checker.is_org_admin(self.sso_login(), rh_org_id)
 
     @cached_property
     def is_org_lightspeed_subscriber(self) -> bool:
@@ -59,3 +62,13 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
             return False
         rh_org_id = self.organization_id
         return seat_checker.is_org_lightspeed_subscriber(rh_org_id)
+
+    def sso_login(self) -> str:
+        try:
+            extra_data = self.social_auth.values()[0].get('extra_data') or {}
+            if not isinstance(extra_data, dict):
+                logger.error("Unexpected extra_data=`%s', user=`%s'", extra_data, self.username)
+                raise ValueError
+        except (KeyError, AttributeError, IndexError, ValueError):
+            extra_data = {}
+        return extra_data.get('login', '')

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -111,3 +111,15 @@ def _terms_of_service(strategy, user, backend, **kwargs):
 @partial
 def terms_of_service(strategy, details, backend, user=None, is_new=False, *args, **kwargs):
     return _terms_of_service(strategy, user, backend, **kwargs)
+
+
+def load_extra_data(backend, details, response, uid, user, *args, **kwargs):
+    """Similar to the original load_extra_data, but with a filter on the fields to keep"""
+    accepted_extra_data = ["login"]
+    social = kwargs.get("social") or backend.strategy.storage.user.get_social_auth(
+        backend.name, uid
+    )
+    if social:
+        extra_data = backend.extra_data(user, uid, response, details, *args, **kwargs)
+        extra_data = {k: v for k, v in extra_data.items() if k in accepted_extra_data}
+        social.set_extra_data(extra_data)

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from social_django.models import UserSocialAuth
+from test_utils import WisdomServiceLogAwareTestCase
+from users.pipeline import load_extra_data
+
+
+class TestExtraData(WisdomServiceLogAwareTestCase):
+    def setUp(self):
+        self.sso_user = get_user_model().objects.create_user(
+            username="sso-user",
+            email="sso@user.nowhere",
+            password="bar",
+        )
+        self.usa = UserSocialAuth.objects.create(
+            user=self.sso_user, provider="oidc", uid=str(uuid4())
+        )
+
+    def tearDown(self):
+        self.sso_user.delete()
+
+    def test_load_extra_data(self):
+        class DummyBackend:
+            def extra_data(*args, **kwargs):
+                return {
+                    "id": "1231243",
+                    "login": "my-login",
+                    "id_token": "some-string",
+                    "token_type": "Bearer",
+                }
+
+        load_extra_data(
+            backend=DummyBackend(),
+            details=None,
+            response=None,
+            uid=None,
+            user=self.sso_user,
+            social=self.usa,
+        )
+        assert self.usa.extra_data == {"login": "my-login"}


### PR DESCRIPTION
We don't control the Django user login name and the user login may change. With
this change we now store the current login when the user log in.

Dependings on the provider, the field comes from the `preferred_username` (RHOSSS) or `login` (Github) fields.
The key is internally standardized in the `extra_data` as `login`.

The commit also uses this login key with AMS.
