### PR TITLE
SSO: prevent an auth user to log in again

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -127,6 +127,7 @@ SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = [
     'terms_accepted',
 ]
 SOCIAL_AUTH_PIPELINE = (
+    'users.pipeline.block_auth_users',
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',
     'social_core.pipeline.social_auth.social_user',

--- a/ansible_wisdom/main/templates/registration/login.html
+++ b/ansible_wisdom/main/templates/registration/login.html
@@ -15,7 +15,6 @@
                     <h1 class="pf-c-title pf-m-lg">Log in to Ansible Lightspeed with Watson Code Assistant</h1>
                     {% if not user.is_authenticated %}
                     <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using one of the buttons below.</div>
-                    {% endif %}
 
                     <div style="margin-top: 25px">
                     {% if use_redhat_sso %}
@@ -32,6 +31,7 @@
                         with GitHub</a>
                     {% endif %}
                     </div>
+                    {% endif %}
 
           <div class="pf-l-level" style="margin-top: 60px">
             <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank"><span class="fas fa-solid fa-comments"></span> Chat</a>

--- a/ansible_wisdom/users/management/commands/fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/management/commands/fix_users_with_two_sso_providers.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from social_django.models import UserSocialAuth
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Ensure no user has 2 different SSO providers"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--fix", action="store_true", help="Modify the DB")
+
+    def handle(self, fix, *args, **options):
+        cpt = 0
+        if not fix:
+            self.stdout.write("NOTE: Won't change the DB unless --fix is passed as a parameter")
+        for u in User.objects.all():
+            # order_by to get the oidc entry first
+            usa_entries = UserSocialAuth.objects.all().order_by("-provider").filter(user=u)
+            count = usa_entries.count()
+            if count < 2:
+                continue
+            self.stdout.write(f"user={u.username}")
+            for e in usa_entries[1:]:
+                self.stdout.write(f"  provider={e.provider}")
+                if fix:
+                    e.delete()
+                    cpt += 1
+
+        self.stdout.write(f"{cpt} SSO association removed.")

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
-from social_core.exceptions import AuthCanceled
+from social_core.exceptions import AuthCanceled, AuthException
 from social_core.pipeline.partial import partial
 from social_core.pipeline.user import get_username
 from social_django.models import UserSocialAuth
@@ -123,3 +123,14 @@ def load_extra_data(backend, details, response, uid, user, *args, **kwargs):
         extra_data = backend.extra_data(user, uid, response, details, *args, **kwargs)
         extra_data = {k: v for k, v in extra_data.items() if k in accepted_extra_data}
         social.set_extra_data(extra_data)
+
+
+class AuthAlreadyLoggedIn(AuthException):
+    def __str__(self):
+        return "User already logged in"
+
+
+def block_auth_users(backend=None, details=None, response=None, user=None, *args, **kwargs):
+    """Safeguard to be sure user won't get multiple providers"""
+    if user:
+        raise AuthAlreadyLoggedIn(backend)

--- a/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+from unittest.mock import Mock
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from social_django.models import UserSocialAuth
+from test_utils import WisdomServiceLogAwareTestCase
+from users.management.commands.fix_users_with_two_sso_providers import Command
+
+
+class TestFixUsersWithTwoSSOProviders(WisdomServiceLogAwareTestCase):
+    def setUp(self):
+        self.sso_user = get_user_model().objects.create_user(
+            username="sso-user",
+            email="sso@user.nowhere",
+            password="bar",
+        )
+        for i in ["a", "b", "c", "oidc", "d"]:
+            UserSocialAuth.objects.create(user=self.sso_user, provider=i, uid=str(uuid4()))
+
+    def tearDown(self):
+        self.sso_user.delete()
+
+    def test_without_fix_paramter(self):
+        base = Mock()
+        User = get_user_model()
+        before = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
+        Command.handle(base, fix=False)
+        after = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
+        self.assertEqual(before, after)
+        base.stdout.write.assert_any_call(
+            "NOTE: Won't change the DB unless --fix is passed as a parameter"
+        )
+
+    def test_with_fix_paramter(self):
+        base = Mock()
+        User = get_user_model()
+        Command.handle(base, fix=True)
+        counter = UserSocialAuth.objects.all().filter(user=self.sso_user).count()
+        self.assertEqual(counter, 1)
+        base.stdout.write.assert_called_with("4 SSO association removed.")
+        remaining_provider = UserSocialAuth.objects.get(user=self.sso_user).provider
+        self.assertEqual(remaining_provider, "oidc")


### PR DESCRIPTION
We don't want to let our users use more than one SSO provider.

Also add a CLI command to clean up the DB. When a user has several SSO
association, we only keep one. "oidc" is the peferred provider.
