### PR TITLE
SSO: redirect auth user to the main page

### DIFF
--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory, TestCase
+from main.views import LoginView
+from social_django.models import UserSocialAuth
+
+
+class AlreadyAuth(TestCase):
+    def test_login(self):
+        request = RequestFactory().get("/login")
+        request.user = AnonymousUser()
+        response = LoginView.as_view()(request)
+        response.render()
+        self.assertIn("You are currently not logged in.", response.content.decode())
+
+    def test_no_login_for_auth_user(self):
+        class MockUser:
+            is_authenticated = True
+
+        request = RequestFactory().get("/login")
+        request.user = MockUser()
+        response = LoginView.as_view()(request)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(response.url, "/")

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -23,6 +23,7 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 from healthcheck.views import WisdomServiceHealthView, WisdomServiceLivenessProbeView
+from main.views import LoginView
 from users.views import CurrentUserView, HomeView, TermsOfService, UnauthorizedView
 
 WISDOM_API_VERSION = "v0"
@@ -52,12 +53,12 @@ urlpatterns = [
     path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path(
         'login/',
-        auth_views.LoginView.as_view(
+        LoginView.as_view(
             extra_context={
                 'pilot_contact': settings.PILOT_CONTACT,
                 'use_github_team': settings.USE_GITHUB_TEAM,
                 'use_redhat_sso': bool(settings.SOCIAL_AUTH_OIDC_OIDC_ENDPOINT),
-            }
+            },
         ),
         name='login',
     ),

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import logging
+from datetime import datetime
+
+from django.contrib.auth import views as auth_views
+from django.http import HttpResponseRedirect
+
+logger = logging.getLogger(__name__)
+
+
+class LoginView(auth_views.LoginView):
+    def dispatch(self, request, *args, **kwargs):
+        if self.request.user.is_authenticated:
+            return HttpResponseRedirect("/")
+        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
We don't use `redirect_authenticated_user` to avoid giving other websites the ability to build a "social media fingerprint".

```
If you enable redirect_authenticated_user, other websites will be able to determine
if their visitors are authenticated on your site by requesting redirect URLs to
image files on your website.
```

https://docs.djangoproject.com/en/4.2/topics/auth/default/#django.contrib.auth.views.LoginView.redirect_authenticated_user
