### PR TITLE
fix url when querying resource_quota

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -187,7 +187,7 @@ class AMSCheck:
             r = self._session.get(
                 (
                     f"{self._api_server}"
-                    f"/api/accounts_mgmt/v1/subscriptions/{ams_org_id}/resource_quota"
+                    f"/api/accounts_mgmt/v1/organizations/{ams_org_id}/resource_quota"
                 ),
                 params=params,
                 timeout=0.8,

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -203,7 +203,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
-                '/api/accounts_mgmt/v1/subscriptions/rdgdfhbrdb/resource_quota'
+                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/resource_quota'
             ),
             params={"search": "sku = 'FakeAnsibleWisdom' AND sku_count > 0"},
             timeout=0.8,
@@ -226,7 +226,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
-                '/api/accounts_mgmt/v1/subscriptions/rdgdfhbrdb/resource_quota'
+                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/resource_quota'
             ),
             params={"search": "sku = 'FakeAnsibleWisdom' AND sku_count > 0"},
             timeout=0.8,


### PR DESCRIPTION
The wrong path was used when querying the quota in `is_org_lightspeed_subscriber`. The correct path according to swagger: https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/get_api_accounts_mgmt_v1_organizations__orgId__resource_quota