### PR TITLE
users: rename the RH related attributes

### DIFF
--- a/ansible_wisdom/ai/api/data/data_model.py
+++ b/ansible_wisdom/ai/api/data/data_model.py
@@ -20,7 +20,7 @@ class ModelMeshData(TypedDict):
     prompt: str
     context: str
     userId: Union[str, None]
-    has_seat: bool
+    rh_user_has_seat: bool
     organization_id: Union[str, None]
     suggestionId: Union[str, None]
 

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -26,7 +26,7 @@ class WCAClient(ModelMeshClient):
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")
-        has_seat = model_input.get("instances", [{}])[0].get("has_seat", False)
+        rh_user_has_seat = model_input.get("instances", [{}])[0].get("rh_user_has_seat", False)
         organization_id = model_input.get("instances", [{}])[0].get("organization_id", None)
 
         data = {
@@ -38,7 +38,7 @@ class WCAClient(ModelMeshClient):
 
         try:
             # TODO: store token and only fetch a new one if it has expired
-            api_key = self.get_api_key(has_seat, organization_id)
+            api_key = self.get_api_key(rh_user_has_seat, organization_id)
             token = self.get_token(api_key)
             headers = {
                 "Content-Type": "application/json",
@@ -72,9 +72,9 @@ class WCAClient(ModelMeshClient):
         result.raise_for_status()
         return result.json()
 
-    def get_api_key(self, has_seat, organization_id):
+    def get_api_key(self, rh_user_has_seat, organization_id):
         # use the shared API Key if the user has no seat
-        if not has_seat or organization_id is None:
+        if not rh_user_has_seat or organization_id is None:
             return self._api_key
 
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()

--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -25,7 +25,7 @@ class IsOrganisationAdministrator(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        return user.is_org_admin
+        return user.rh_user_is_org_admin
 
 
 class IsOrganisationLightspeedSubscriber(permissions.BasePermission):
@@ -35,7 +35,7 @@ class IsOrganisationLightspeedSubscriber(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        return user.is_org_lightspeed_subscriber
+        return user.rh_org_has_subscription
 
 
 class IsWCAKeyApiFeatureFlagOn(permissions.BasePermission):

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -40,7 +40,7 @@ class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
 @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
 @patch.object(AcceptedTermsPermission, 'has_permission', return_value=True)
 class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
-    def test_user_is_org_admin(self, *args):
+    def test_user_rh_user_is_org_admin(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('wca_api_key'))
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -29,7 +29,9 @@ from test_utils import WisdomServiceLogAwareTestCase
 
 
 class DummyMeshClient(ModelMeshClient):
-    def __init__(self, test, payload, response_data, test_inference_match=True, has_seat=False):
+    def __init__(
+        self, test, payload, response_data, test_inference_match=True, rh_user_has_seat=False
+    ):
         super().__init__(inference_url='dummy inference url')
         self.test = test
         self.test_inference_match = test_inference_match
@@ -50,7 +52,7 @@ class DummyMeshClient(ModelMeshClient):
                             "context": data.get("context"),
                             "prompt": data.get("prompt"),
                             "userId": str(test.user.uuid),
-                            "has_seat": has_seat,
+                            "rh_user_has_seat": rh_user_has_seat,
                             "organization_id": None,
                             "suggestionId": payload.get("suggestionId"),
                         }
@@ -472,7 +474,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_full_payload_without_ansible_lint_with_commercial_user(self):
-        self.user.has_seat = True
+        self.user.rh_user_has_seat = True
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
@@ -482,7 +484,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data, has_seat=True),
+            DummyMeshClient(self, payload, response_data, rh_user_has_seat=True),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -494,7 +496,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_full_payload_with_ansible_lint_with_commercial_user(self):
-        self.user.has_seat = True
+        self.user.rh_user_has_seat = True
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
@@ -504,7 +506,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data, has_seat=True),
+            DummyMeshClient(self, payload, response_data, rh_user_has_seat=True),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -196,7 +196,7 @@ class Completions(APIView):
                     "prompt": payload.prompt,
                     "context": payload.context,
                     "userId": str(payload.userId) if payload.userId else None,
-                    "has_seat": request._request.user.has_seat,
+                    "rh_user_has_seat": request._request.user.rh_user_has_seat,
                     "organization_id": request._request.user.organization_id,
                     "suggestionId": str(payload.suggestionId),
                 }
@@ -304,7 +304,7 @@ class Completions(APIView):
         if not ari_caller:
             logger.warn('skipped ari post processing because ari was not initialized')
         # check for commercial users for lint processing
-        is_commercial = user.has_seat
+        is_commercial = user.rh_user_has_seat
         if is_commercial:
             ansible_lint_caller = apps.get_app_config("ai").get_ansible_lint_caller()
             if not ansible_lint_caller:

--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -149,7 +149,7 @@ class AMSCheck:
             logger.error("Unexpected subscription answer from AMS")
             return False
 
-    def is_org_admin(self, username: str, organization_id: str):
+    def rh_user_is_org_admin(self, username: str, organization_id: str):
         ams_org_id = self.get_ams_org(organization_id)
         params = {"search": f"account.username = '{username}' AND organization.id='{ams_org_id}'"}
         self.update_bearer_token()
@@ -178,7 +178,7 @@ class AMSCheck:
 
         return False
 
-    def is_org_lightspeed_subscriber(self, organization_id: str) -> bool:
+    def rh_org_has_subscription(self, organization_id: str) -> bool:
         ams_org_id = self.get_ams_org(organization_id)
         params = {"search": "sku = 'FakeAnsibleWisdom' AND sku_count > 0"}
         self.update_bearer_token()
@@ -215,10 +215,10 @@ class MockAlwaysTrueCheck:
     def check(self, _user_id: str, _username: str, _organization_id: str) -> bool:
         return True
 
-    def is_org_admin(self, _username: str, _organization_id: str) -> bool:
+    def rh_user_is_org_admin(self, _username: str, _organization_id: str) -> bool:
         return True
 
-    def is_org_lightspeed_subscriber(self, _organization_id: str) -> bool:
+    def rh_org_has_subscription(self, _organization_id: str) -> bool:
         return True
 
 
@@ -229,8 +229,8 @@ class MockAlwaysFalseCheck:
     def check(self, _user_id: str, _username: str, _organization_id: str) -> bool:
         return False
 
-    def is_org_admin(self, _username: str, _organization_id: str) -> bool:
+    def rh_user_is_org_admin(self, _username: str, _organization_id: str) -> bool:
         return False
 
-    def is_org_lightspeed_subscriber(self, _organization_id: str) -> bool:
+    def rh_org_has_subscription(self, _organization_id: str) -> bool:
         return False

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -26,7 +26,8 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         return True
 
     @cached_property
-    def has_seat(self) -> bool:
+    def rh_user_has_seat(self) -> bool:
+        """True if the user comes from RHSSO and has a Wisdom Seat."""
         # For dev/test purposes only:
         if self.groups.filter(name='Commercial').exists():
             return True
@@ -42,7 +43,8 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         return seat_checker.check(uid, self.sso_login(), rh_org_id)
 
     @cached_property
-    def is_org_admin(self) -> bool:
+    def rh_user_is_org_admin(self) -> bool:
+        """True if the user comes from RHSSO and is admin of the organization."""
         if not self.is_oidc_user():
             return False
 
@@ -50,10 +52,11 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         if not seat_checker:
             return False
         rh_org_id = self.organization_id
-        return seat_checker.is_org_admin(self.sso_login(), rh_org_id)
+        return seat_checker.rh_user_is_org_admin(self.sso_login(), rh_org_id)
 
     @cached_property
-    def is_org_lightspeed_subscriber(self) -> bool:
+    def rh_org_has_subscription(self) -> bool:
+        """True if the user comes from RHSSO and the associated org has access to Wisdom."""
         if not self.is_oidc_user():
             return False
 
@@ -61,7 +64,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         if not seat_checker:
             return False
         rh_org_id = self.organization_id
-        return seat_checker.is_org_lightspeed_subscriber(rh_org_id)
+        return seat_checker.rh_org_has_subscription(rh_org_id)
 
     def sso_login(self) -> str:
         try:

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -83,7 +83,7 @@ def _terms_of_service(strategy, user, backend, **kwargs):
     # commercial, there also needs to be the seat check when that gets
     # integrated.  When that happens, update this to include that
     # logic.  Possibly also remove the Commerical group?
-    is_commercial = user.has_seat
+    is_commercial = user.rh_user_has_seat
     terms_type = 'commercial' if backend.name == 'oidc' and is_commercial else 'community'
     field_name = f'{terms_type}_terms_accepted'
     view_name = f'{terms_type}_terms'

--- a/ansible_wisdom/users/serializers.py
+++ b/ansible_wisdom/users/serializers.py
@@ -8,8 +8,8 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
-            'has_seat',
-            'is_org_admin',
-            'is_org_lightspeed_subscriber',
+            'rh_org_has_subscription',
+            'rh_user_has_seat',
+            'rh_user_is_org_admin',
             'username',
         ]

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -91,7 +91,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
             timeout=0.8,
         )
 
-    def test_is_org_admin(self):
+    def test_rh_user_is_org_admin(self):
         m_r = Mock()
         m_r.json.side_effect = [
             {"items": [{"id": "123"}]},
@@ -104,7 +104,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertTrue(checker.is_org_admin("user", "123"))
+        self.assertTrue(checker.rh_user_is_org_admin("user", "123"))
         checker._session.get.assert_called_with(
             'https://some-api.server.host/api/accounts_mgmt/v1/role_bindings',
             params={"search": "account.username = 'user' AND organization.id='123'"},
@@ -124,7 +124,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertFalse(checker.is_org_admin("user", "123"))
+        self.assertFalse(checker.rh_user_is_org_admin("user", "123"))
         checker._session.get.assert_called_with(
             'https://some-api.server.host/api/accounts_mgmt/v1/role_bindings',
             params={"search": "account.username = 'user' AND organization.id='123'"},
@@ -143,7 +143,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertFalse(checker.is_org_admin("user", "123"))
+        self.assertFalse(checker.rh_user_is_org_admin("user", "123"))
 
     def test_role_has_no_id(self):
         m_r = Mock()
@@ -157,9 +157,9 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertFalse(checker.is_org_admin("user", "123"))
+        self.assertFalse(checker.rh_user_is_org_admin("user", "123"))
 
-    def test_is_org_admin_timeout(self):
+    def test_rh_user_is_org_admin_timeout(self):
         def side_effect(*args, **kwargs):
             raise requests.exceptions.Timeout()
 
@@ -168,10 +168,10 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.side_effect = side_effect
         with self.assertLogs(logger='root', level='ERROR') as log:
-            self.assertFalse(checker.is_org_admin("user", "123"))
+            self.assertFalse(checker.rh_user_is_org_admin("user", "123"))
             self.assertInLog(AMSCheck.ERROR_AMS_CONNECTION_TIMEOUT, log)
 
-    def test_is_org_admin_network_error(self):
+    def test_rh_user_is_org_admin_network_error(self):
         m_r = Mock()
         m_r.status_code = 500
 
@@ -181,12 +181,12 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.return_value = m_r
 
         with self.assertLogs(logger='root', level='ERROR') as log:
-            self.assertFalse(checker.is_org_admin("user", "123"))
+            self.assertFalse(checker.rh_user_is_org_admin("user", "123"))
             self.assertInLog(
                 "Unexpected error code returned by AMS backend when listing role bindings", log
             )
 
-    def test_is_org_lightspeed_subscriber(self):
+    def test_rh_org_has_subscription(self):
         m_r = Mock()
         m_r.json.side_effect = [
             {"items": [{"id": "rdgdfhbrdb"}]},
@@ -199,7 +199,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertTrue(checker.is_org_lightspeed_subscriber("123"))
+        self.assertTrue(checker.rh_org_has_subscription("123"))
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
@@ -222,7 +222,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        self.assertFalse(checker.is_org_lightspeed_subscriber("123"))
+        self.assertFalse(checker.rh_org_has_subscription("123"))
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
@@ -232,7 +232,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
             timeout=0.8,
         )
 
-    def test_is_org_lightspeed_subscriber_timeout(self):
+    def test_rh_org_has_subscription_timeout(self):
         def side_effect(*args, **kwargs):
             raise requests.exceptions.Timeout()
 
@@ -241,10 +241,10 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.side_effect = side_effect
         with self.assertLogs(logger='root', level='ERROR') as log:
-            self.assertFalse(checker.is_org_lightspeed_subscriber("123"))
+            self.assertFalse(checker.rh_org_has_subscription("123"))
             self.assertInLog(AMSCheck.ERROR_AMS_CONNECTION_TIMEOUT, log)
 
-    def test_is_org_lightspeed_subscriber_network_error(self):
+    def test_rh_org_has_subscription_network_error(self):
         m_r = Mock()
         m_r.status_code = 500
 
@@ -254,12 +254,12 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.return_value = m_r
 
         with self.assertLogs(logger='root', level='ERROR') as log:
-            self.assertFalse(checker.is_org_lightspeed_subscriber("123"))
+            self.assertFalse(checker.rh_org_has_subscription("123"))
             self.assertInLog(
                 "Unexpected error code returned by AMS backend when listing resource_quota", log
             )
 
-    def test_is_org_lightspeed_subscriber_wrong_output(self):
+    def test_rh_org_has_subscription_wrong_output(self):
         m_r = Mock()
         m_r.json.side_effect = [
             {"items": [{"id": "rdgdfhbrdb"}]},
@@ -273,5 +273,5 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.return_value = m_r
 
         with self.assertLogs(logger='root', level='ERROR') as log:
-            self.assertFalse(checker.is_org_lightspeed_subscriber("123"))
+            self.assertFalse(checker.rh_org_has_subscription("123"))
             self.assertInLog("Unexpected resource_quota answer from AMS", log)

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -104,7 +104,7 @@ class TestTermsAndConditions(WisdomServiceLogAwareTestCase):
         self.strategy.session = self.request.session
         self.partial = SimpleNamespace(token='token')
         self.user = Mock(
-            community_terms_accepted=None, commercial_terms_accepted=None, has_seat=False
+            community_terms_accepted=None, commercial_terms_accepted=None, rh_user_has_seat=False
         )
 
     def test_terms_of_service_first_call(self):
@@ -124,7 +124,7 @@ class TestTermsAndConditions(WisdomServiceLogAwareTestCase):
     def test_terms_of_service_first_commercial(self):
         # We must be using the Red Hat SSO and be a member of the Community placeholder group
         self.backend.name = 'oidc'
-        self.user.has_seat = True
+        self.user.rh_user_has_seat = True
 
         _terms_of_service(
             self.strategy,
@@ -243,49 +243,49 @@ class TestTermsAndConditions(WisdomServiceLogAwareTestCase):
 
 
 class TestUserSeat(TestCase):
-    def test_has_seat_with_no_rhsso_user(self):
+    def test_rh_user_has_seat_with_no_rhsso_user(self):
         user = create_user(provider_name="github")
-        self.assertFalse(user.has_seat)
+        self.assertFalse(user.rh_user_has_seat)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_false")
-    def test_has_seat_with_rhsso_user_no_seat(self):
+    def test_rh_user_has_seat_with_rhsso_user_no_seat(self):
         user = create_user(provider_name="oidc")
-        self.assertFalse(user.has_seat)
+        self.assertFalse(user.rh_user_has_seat)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_true")
-    def test_has_seat_with_rhsso_user_with_seat(self):
+    def test_rh_user_has_seat_with_rhsso_user_with_seat(self):
         user = create_user(provider_name="oidc")
-        self.assertTrue(user.has_seat)
+        self.assertTrue(user.rh_user_has_seat)
 
-    def test_has_seat_with_no_seat_checker(self):
+    def test_rh_user_has_seat_with_no_seat_checker(self):
         with patch.object(apps.get_app_config('ai'), 'get_seat_checker', lambda: None):
             user = create_user(provider_name="oidc")
-            self.assertFalse(user.has_seat)
+            self.assertFalse(user.rh_user_has_seat)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_false")
-    def test_has_seat_with_commercial_group(self):
+    def test_rh_user_has_seat_with_commercial_group(self):
         user = create_user(provider_name="github")
 
         commercial_group = Group.objects.create(name='Commercial')
         user.groups.add(commercial_group)
 
-        self.assertTrue(user.has_seat)
+        self.assertTrue(user.rh_user_has_seat)
 
 
 class TestOrgAdmin(TestCase):
-    def test_is_org_admin_with_no_rhsso_user(self):
+    def test_rh_user_is_org_admin_with_no_rhsso_user(self):
         user = create_user(provider_name="github")
-        self.assertFalse(user.is_org_admin)
+        self.assertFalse(user.rh_user_is_org_admin)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_true")
-    def test_is_org_admin_with_admin_rhsso_user(self):
+    def test_rh_user_is_org_admin_with_admin_rhsso_user(self):
         user = create_user(provider_name="oidc")
-        self.assertTrue(user.is_org_admin)
+        self.assertTrue(user.rh_user_is_org_admin)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_false")
-    def test_is_org_admin_with_non_admin_rhsso_user(self):
+    def test_rh_user_is_org_admin_with_non_admin_rhsso_user(self):
         user = create_user(provider_name="oidc")
-        self.assertFalse(user.is_org_admin)
+        self.assertFalse(user.rh_user_is_org_admin)
 
 
 class TestUsername(WisdomServiceLogAwareTestCase):
@@ -330,19 +330,19 @@ class TestUsername(WisdomServiceLogAwareTestCase):
 
 
 class TestIsOrgLightspeedSubscriber(TestCase):
-    def test_is_org_lightspeed_subscriber_with_no_rhsso_user(self):
+    def test_rh_org_has_subscription_with_no_rhsso_user(self):
         user = create_user(provider_name="github")
-        self.assertFalse(user.is_org_lightspeed_subscriber)
+        self.assertFalse(user.rh_org_has_subscription)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_true")
-    def test_is_org_lightspeed_subscriber_with_subscribed_user(self):
+    def test_rh_org_has_subscription_with_subscribed_user(self):
         user = create_user(provider_name="oidc")
-        self.assertTrue(user.is_org_lightspeed_subscriber)
+        self.assertTrue(user.rh_org_has_subscription)
 
     @override_settings(AUTHZ_BACKEND_TYPE="mock_false")
-    def test_is_org_lightspeed_subscriber_with_non_subscribed_user(self):
+    def test_rh_org_has_subscription_with_non_subscribed_user(self):
         user = create_user(provider_name="oidc")
-        self.assertFalse(user.is_org_lightspeed_subscriber)
+        self.assertFalse(user.rh_org_has_subscription)
 
 
 class TestUserModelMetrics(APITransactionTestCase):

--- a/tools/authz/validate_ams.py
+++ b/tools/authz/validate_ams.py
@@ -78,7 +78,7 @@ def check(username: str, organization_id: str) -> bool:
     return len(items) == 1
 
 
-def is_org_admin(username: str, organization_id: str) -> bool:
+def rh_user_is_org_admin(username: str, organization_id: str) -> bool:
     ams_org_id = get_ams_org(organization_id)
     params = {"search": f"account.username = '{username}' AND organization.id='{ams_org_id}'"}
     r = requests.get(
@@ -103,5 +103,5 @@ def is_org_admin(username: str, organization_id: str) -> bool:
 
 
 # assert check("ansiblewisdomtesting1", "17233726") is True
-assert is_org_admin("ansiblewisdomtesting1", "17233726") is True
+assert rh_user_is_org_admin("ansiblewisdomtesting1", "17233726") is True
 print("Success")

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -588,13 +588,13 @@ components:
     User:
       type: object
       properties:
-        has_seat:
+        rh_org_has_subscription:
           type: boolean
           readOnly: true
-        is_org_admin:
+        rh_user_has_seat:
           type: boolean
           readOnly: true
-        is_org_lightspeed_subscriber:
+        rh_user_is_org_admin:
           type: boolean
           readOnly: true
         username:
@@ -604,9 +604,9 @@ components:
           pattern: ^[\w.@+-]+$
           maxLength: 150
       required:
-      - has_seat
-      - is_org_admin
-      - is_org_lightspeed_subscriber
+      - rh_org_has_subscription
+      - rh_user_has_seat
+      - rh_user_is_org_admin
       - username
     WcaKeyRequest:
       type: object


### PR DESCRIPTION
- `has_seat`                     → `rh_user_has_seat`
- `is_org_admin`                 → `rh_user_is_org_admin`
- `is_org_lightspeed_subscriber` → `rh_org_has_subscription`
