### PR TITLE
Ensure permission check exceptions are mapped correctly.

### DIFF
--- a/ansible_wisdom/main/base_views.py
+++ b/ansible_wisdom/main/base_views.py
@@ -45,7 +45,14 @@ class ProtectedTemplateView(TemplateView):
         except Exception as exc:
             # Map _internal_ errors to a generic PermissionDenied error
             # for which Django handles rendering a default view to Users
-            if isinstance(exc, (exceptions.NotAuthenticated, exceptions.AuthenticationFailed)):
+            if isinstance(
+                exc,
+                (
+                    exceptions.NotAuthenticated,
+                    exceptions.AuthenticationFailed,
+                    exceptions.PermissionDenied,
+                ),
+            ):
                 raise core_exceptions.PermissionDenied()
             else:
                 raise exc

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -15,21 +15,32 @@ from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScop
 from rest_framework.permissions import IsAuthenticated
 
 
-@override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-@patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
-@patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
-@patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
-@patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
 class TestConsoleView(WisdomServiceAPITestCaseBase):
     def test_authentication_error(self, *args):
         # self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('console'))
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
+    @patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
+    @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
+    @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
     def test_get_when_authenticated(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('console'))
         self.assertEqual(r.status_code, HTTPStatus.OK)
+
+    # Mock Permissions not being satisfied
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=False)
+    @patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=False)
+    @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=False)
+    @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=False)
+    def test_get_when_authenticated_missing_permission(self, *args):
+        self.client.force_authenticate(user=self.user)
+        r = self.client.get(reverse('console'))
+        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
     def test_permission_classes(self, *args):
         url = reverse('console')


### PR DESCRIPTION
If the permission checks fail a `rest_framework.exceptions.PermissionDenied` exception is thrown. This was not being mapped to `core.exceptions.PermissionDenied` and Django's default exception mapping mechanism return a HTTP500 instead of a HTTP403. This PR ensures `rest_framework.exceptions.PermissionDenied` is mapped to `core.exceptions.PermissionDenied` to invoke the expected behaviour.

