### PR TITLE
wca/tests: break the coupling with the AWS API and boto3

### DIFF
--- a/ansible_wisdom/ai/api/aws/exceptions.py
+++ b/ansible_wisdom/ai/api/aws/exceptions.py
@@ -1,2 +1,6 @@
 class WcaSecretManagerError(Exception):
     """Request to AWS Secrets Manager failed"""
+
+
+class WcaSecretManagerMissingCredentialsError(WcaSecretManagerError):
+    """Cannot initialize the client because the credentials are not available"""

--- a/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
@@ -1,7 +1,9 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-import boto3
-from ai.api.aws.exceptions import WcaSecretManagerError
+from ai.api.aws.exceptions import (
+    WcaSecretManagerError,
+    WcaSecretManagerMissingCredentialsError,
+)
 from ai.api.aws.wca_secret_manager import SECRET_KEY_PREFIX, Suffixes, WcaSecretManager
 from botocore.exceptions import ClientError
 from rest_framework.test import APITestCase
@@ -11,9 +13,25 @@ ORG_ID = "org_123"
 SECRET_VALUE = "secret"
 
 
+class MockResourceNotFoundException(Exception):
+    pass
+
+
+class MockInvalidParameterException(Exception):
+    pass
+
+
 class TestWcaApiKeyClient(APITestCase, WisdomServiceLogAwareTestCase):
     def nop(self):
         pass
+
+    def setUp(self):
+        self.m_boto3_client = Mock()
+        self.m_boto3_client.exceptions.ResourceNotFoundException = MockResourceNotFoundException
+        self.m_boto3_client.exceptions.InvalidParameterException = MockInvalidParameterException
+
+        self.c = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
+        self.c._client = self.m_boto3_client
 
     def test_get_secret_name(self):
         self.assertEqual(
@@ -22,163 +40,94 @@ class TestWcaApiKeyClient(APITestCase, WisdomServiceLogAwareTestCase):
         )
 
     def test_get_key(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "GetSecretValue" and kwarg[
-                "SecretId"
-            ] == WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY):
-                return {"SecretString": SECRET_VALUE}
-            else:
-                raise ClientError({}, operation_name)
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            response = client.get_secret(ORG_ID, Suffixes.API_KEY)
-            self.assertEqual(response['SecretString'], SECRET_VALUE)
+        self.m_boto3_client.get_secret_value.return_value = {"SecretString": SECRET_VALUE}
+        response = self.c.get_secret(ORG_ID, Suffixes.API_KEY)
+        self.assertEqual(response['SecretString'], SECRET_VALUE)
 
     def test_get_key_error(self):
-        def mock_api_call(_, operation_name, kwarg):
-            raise ClientError({}, operation_name)
+        self.m_boto3_client.get_secret_value.side_effect = ClientError({}, "raah")
 
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            with self.assertRaises(WcaSecretManagerError):
-                with self.assertLogs(logger='root', level='ERROR') as log:
-                    client.get_secret(ORG_ID, Suffixes.API_KEY)
-                    self.assertInLog(f"Error reading secret for org_id '{ORG_ID}'", log)
+        with self.assertRaises(WcaSecretManagerError):
+            with self.assertLogs(logger='root', level='ERROR') as log:
+                self.c.get_secret(ORG_ID, Suffixes.API_KEY)
+                self.assertInLog(f"Error reading secret for org_id '{ORG_ID}'", log)
 
     def test_key_exist(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "GetSecretValue" and kwarg[
-                "SecretId"
-            ] == WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY):
-                return {"SecretString": SECRET_VALUE}
-            else:
-                c = boto3.client('secretsmanager', region_name="eu-central-1")
-                raise c.exceptions.ResourceNotFoundException({}, operation_name)
+        self.m_boto3_client.get_secret_value.return_value = "foo"
+        self.assertEqual(self.c.secret_exists(ORG_ID, Suffixes.API_KEY), True)
 
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            self.assertEqual(client.secret_exists(ORG_ID, Suffixes.API_KEY), True)
-            self.assertEqual(client.secret_exists('does_not_exist', Suffixes.API_KEY), False)
+    def test_key_doesnt_exist(self):
+        self.m_boto3_client.get_secret_value.return_value = None
+        self.assertEqual(self.c.secret_exists('does_not_exist', Suffixes.API_KEY), False)
 
     def test_save_new_key(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "GetSecretValue":
-                c = boto3.client('secretsmanager', region_name="eu-central-1")
-                raise c.exceptions.ResourceNotFoundException({}, operation_name)
-            elif operation_name == "CreateSecret" and kwarg[
-                "Name"
-            ] == WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY):
-                return kwarg
-            else:
-                raise ClientError({}, operation_name)
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            response = client.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
-            self.assertEqual(response, client.get_secret_id(ORG_ID, Suffixes.API_KEY))
+        self.m_boto3_client.get_secret_value.return_value = None
+        self.m_boto3_client.create_secret.return_value = {"Name": "wisdom"}
+        self.c.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
+        self.m_boto3_client.create_secret.assert_called()
 
     def test_update_key(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "GetSecretValue":
-                return {'SecretString': kwarg['SecretId']}
-            elif operation_name == "PutSecretValue" and kwarg[
-                "SecretId"
-            ] == WcaSecretManager.get_secret_id(ORG_ID, Suffixes.API_KEY):
-                return {"Name": kwarg["SecretId"]}
-            else:
-                raise ClientError({}, operation_name)
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            response = client.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
-            self.assertEqual(response, client.get_secret_id(ORG_ID, Suffixes.API_KEY))
+        self.m_boto3_client.put_secret_value.return_value = {"Name": "wisdom"}
+        self.m_boto3_client.get_secret_value.return_value = "exists"
+        self.c.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
+        self.m_boto3_client.put_secret_value.assert_called()
 
     def test_save_new_key_fails(self):
-        with patch("boto3.client"):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            client._client.create_secret = Mock(side_effect=ClientError({}, "nop"))
-            client.secret_exists = Mock(return_value=False)
-            with self.assertRaises(WcaSecretManagerError):
-                client.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
+        self.m_boto3_client.get_secret_value.return_value = None
+        self.m_boto3_client.create_secret.side_effect = ClientError({}, "nop")
+        with self.assertRaises(WcaSecretManagerError):
+            self.c.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
 
     def test_save_key_fails(self):
-        with patch("boto3.client"):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            client._client.put_secret_value = Mock(side_effect=ClientError({}, "nop"))
-            client.secret_exists = Mock(return_value=True)
-            with self.assertRaises(WcaSecretManagerError):
-                client.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
+        self.m_boto3_client.get_secret.return_value = True
+        self.m_boto3_client.put_secret_value.side_effect = ClientError({}, "nop")
+        with self.assertRaises(WcaSecretManagerError):
+            self.c.save_secret(ORG_ID, Suffixes.API_KEY, SECRET_VALUE)
 
     def test_delete_key(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "RemoveRegionsFromReplication":
-                return None
-            if operation_name == "DeleteSecret" and kwarg["SecretId"] == client.get_secret_id(
-                ORG_ID, Suffixes.API_KEY
-            ):
-                return None
-            raise ClientError({}, operation_name)
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            self.assertIsNone(client.delete_secret(ORG_ID, Suffixes.API_KEY))
-
-    def test_delete_key_remove_invalid_region(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "RemoveRegionsFromReplication":
-                c = boto3.client('secretsmanager', region_name="eu-central-1")
-                raise c.exceptions.InvalidParameterException({}, operation_name)
-            return None
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            with self.assertLogs(logger='root', level='ERROR') as log:
-                client.delete_secret(ORG_ID, Suffixes.API_KEY)
-                self.assertInLog(
-                    f"Error removing replica regions, invalid region(s) for org_id '{ORG_ID}'", log
-                )
+        self.assertIsNone(self.c.delete_secret(ORG_ID, Suffixes.API_KEY))
+        self.m_boto3_client.delete_secret.assert_called()
 
     def test_delete_key_remove_regions_not_found(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "RemoveRegionsFromReplication":
-                c = boto3.client('secretsmanager', region_name="eu-central-1")
-                raise c.exceptions.ResourceNotFoundException({}, operation_name)
-            return None
+        self.m_boto3_client.remove_regions_from_replication.side_effect = (
+            MockResourceNotFoundException
+        )
+        with self.assertLogs(logger='root', level='ERROR') as log:
+            self.c.delete_secret(ORG_ID, Suffixes.API_KEY)
+            self.assertInLog(
+                f"Error removing replica regions, Secret does not exist for org_id '{ORG_ID}'",
+                log,
+            )
 
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            with self.assertLogs(logger='root', level='ERROR') as log:
-                client.delete_secret(ORG_ID, Suffixes.API_KEY)
-                self.assertInLog(
-                    f"Error removing replica regions, Secret does not exist for org_id '{ORG_ID}'",
-                    log,
-                )
+    def test_delete_key_remove_invalid_region(self):
+        self.m_boto3_client.remove_regions_from_replication.side_effect = (
+            MockInvalidParameterException
+        )
+        with self.assertLogs(logger='root', level='ERROR') as log:
+            self.c.delete_secret(ORG_ID, Suffixes.API_KEY)
+            self.assertInLog(
+                f"Error removing replica regions, invalid region(s) for org_id '{ORG_ID}'", log
+            )
 
     def test_delete_key_remove_regions_client_error(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "RemoveRegionsFromReplication":
-                raise ClientError({}, operation_name)
-            return None
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            with self.assertLogs(logger='root', level='ERROR') as log:
-                client.delete_secret(ORG_ID, Suffixes.API_KEY)
-                self.assertInLog(
-                    "An error occurred",
-                    log,
-                )
+        self.m_boto3_client.remove_regions_from_replication.side_effect = ClientError(
+            {}, "An error occurred"
+        )
+        with self.assertLogs(logger='root', level='ERROR') as log:
+            self.c.delete_secret(ORG_ID, Suffixes.API_KEY)
+            self.assertInLog(
+                "An error occurred",
+                log,
+            )
 
     def test_delete_key_client_error(self):
-        def mock_api_call(_, operation_name, kwarg):
-            if operation_name == "DeleteSecret":
-                raise ClientError({}, operation_name)
-            return None
+        self.m_boto3_client.delete_secret.side_effect = ClientError({}, "An error occurred")
+        with self.assertRaises(WcaSecretManagerError):
+            with self.assertLogs(logger='root', level='ERROR') as log:
+                self.c.delete_secret(ORG_ID, Suffixes.API_KEY)
+                self.assertInLog(f"Error removing Secret for org_id '{ORG_ID}'", log)
 
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_api_call):
-            client = WcaSecretManager('dummy', 'dummy', 'dummy', 'dummy', [])
-            with self.assertRaises(WcaSecretManagerError):
-                with self.assertLogs(logger='root', level='ERROR') as log:
-                    client.delete_secret(ORG_ID, Suffixes.API_KEY)
-                    self.assertInLog(f"Error removing secret for org_id '{ORG_ID}'", log)
+    def test_missing_creds_exception(self):
+        c = WcaSecretManager('dummy', None, 'dummy', 'dummy', [])
+        with self.assertRaises(WcaSecretManagerMissingCredentialsError):
+            c.get_client()

--- a/ansible_wisdom/ai/api/aws/wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/wca_secret_manager.py
@@ -4,7 +4,7 @@ from enum import Enum
 import boto3
 from botocore.exceptions import ClientError
 
-from .exceptions import WcaSecretManagerError
+from .exceptions import WcaSecretManagerError, WcaSecretManagerMissingCredentialsError
 
 SECRET_KEY_PREFIX = 'wca'
 
@@ -19,20 +19,32 @@ class Suffixes(Enum):
 class WcaSecretManager:
     def __init__(
         self,
-        access_key,
-        secret_access_key,
+        aws_access_key_id,
+        aws_secret_access_key,
         kms_secret_id,
         primary_region,
         replica_regions: list[str],
     ):
         self.replica_regions = replica_regions
         self.kms_secret_id = kms_secret_id
-        self._client = boto3.client(
-            'secretsmanager',
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_access_key,
-            region_name=primary_region,
-        )
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.primary_region = primary_region
+        self._client = None
+
+    def get_client(self):
+        if not self._client:
+            if not all([self.aws_access_key_id, self.aws_secret_access_key, self.primary_region]):
+                logger.error("Cannot load the ssm client, credentials are missing.")
+                raise WcaSecretManagerMissingCredentialsError
+
+            self._client = boto3.client(
+                'secretsmanager',
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                region_name=self.primary_region,
+            )
+        return self._client
 
     @staticmethod
     def get_secret_id(org_id, suffix: Suffixes):
@@ -46,7 +58,9 @@ class WcaSecretManager:
 
         if self.secret_exists(org_id, suffix):
             try:
-                response = self._client.put_secret_value(SecretId=secret_id, SecretString=secret)
+                response = self.get_client().put_secret_value(
+                    SecretId=secret_id, SecretString=secret
+                )
             except ClientError as e:
                 raise WcaSecretManagerError(e)
 
@@ -56,7 +70,7 @@ class WcaSecretManager:
                 for region in self.replica_regions
             ]
             try:
-                response = self._client.create_secret(
+                response = self.get_client().create_secret(
                     Name=secret_id,
                     KmsKeyId=self.kms_secret_id,
                     SecretString=secret,
@@ -75,17 +89,17 @@ class WcaSecretManager:
         try:
             # we need to remove the replica(s) first.
             # If this fails, we still try to delete the secret.
-            _ = self._client.remove_regions_from_replication(
+            _ = self.get_client().remove_regions_from_replication(
                 SecretId=secret_id, RemoveReplicaRegions=self.replica_regions
             )
-        except self._client.exceptions.ResourceNotFoundException:
+        except self.get_client().exceptions.ResourceNotFoundException:
             logger.error(
                 "Error removing replica regions, "
                 "Secret does not exist for org_id '%s' with suffix '%s'.",
                 org_id,
                 suffix,
             )
-        except self._client.exceptions.InvalidParameterException:
+        except self.get_client().exceptions.InvalidParameterException:
             logger.error(
                 "Error removing replica regions, "
                 "invalid region(s) for org_id '%s' with suffix '%s'.",
@@ -96,7 +110,7 @@ class WcaSecretManager:
             logger.error(e)
 
         try:
-            _ = self._client.delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)
+            _ = self.get_client().delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)
         except ClientError as e:
             logger.error("Error removing Secret for org_id '%s' with suffix '%s'.", org_id, suffix)
             raise WcaSecretManagerError(e)
@@ -107,8 +121,8 @@ class WcaSecretManager:
         """
         secret_id = self.get_secret_id(org_id, suffix)
         try:
-            return self._client.get_secret_value(SecretId=secret_id)
-        except self._client.exceptions.ResourceNotFoundException:
+            return self.get_client().get_secret_value(SecretId=secret_id)
+        except self.get_client().exceptions.ResourceNotFoundException:
             logger.info("No Secret exists for org with id '%s' and suffix '%s'.", org_id, suffix)
             return None
         except ClientError as e:


### PR DESCRIPTION
Allow the execution of the WCA tests offline and don't create the boto3
client in the WcaSecretManager class to simplify the mocking in the tests.
Also expose a new `WcaSecretManagerMissingCredentialsError` that will
help us to avoid the large boto3 exceptions in the log and get a better
understanding of the problem if the AWS creds are missing.
