### PR TITLE
Ensure GitHub Users have permissions in development.

### DIFF
--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -58,4 +58,11 @@ if DEBUG:
         )
         MIDDLEWARE[index] = "main.middleware.WisdomSocialAuthExceptionMiddleware"  # noqa: F405
 
+    SOCIAL_AUTH_PIPELINE = SOCIAL_AUTH_PIPELINE + (  # noqa: F405
+        # This ensures GitHub Users used during local development
+        # have both an organization_id and seat. Both are required
+        # to use the WCA API Key and Model ID APIs from the Admin Portal.
+        'users.pipeline.redhat_organization_for_github_users',
+    )
+
 CSP_REPORT_ONLY = True

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -4,9 +4,11 @@
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import override_settings
 from social_django.models import UserSocialAuth
 from test_utils import WisdomServiceLogAwareTestCase
-from users.pipeline import load_extra_data
+from users.pipeline import load_extra_data, redhat_organization_for_github_users
 
 
 class TestExtraData(WisdomServiceLogAwareTestCase):
@@ -42,3 +44,27 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
             social=self.usa,
         )
         assert self.usa.extra_data == {"login": "my-login"}
+
+
+class TestGitHubTeamOrganisationInDevelopment(WisdomServiceLogAwareTestCase):
+    def setUp(self):
+        self.gh_user = get_user_model().objects.create_user(
+            username="github-user",
+            email="github@user.nowhere",
+            password="bar",
+        )
+
+    def tearDown(self):
+        self.gh_user.delete()
+        Group.objects.get(name='Commercial').delete()
+
+    @override_settings(DEBUG=True)
+    def test_redhat_organization_for_github_users(self):
+        class DummyBackend:
+            name = 'github-team'
+
+        redhat_organization_for_github_users(
+            backend=DummyBackend(), response=None, user=self.gh_user
+        )
+        assert self.gh_user.organization_id == '123'
+        assert self.gh_user.groups.filter(name='Commercial').exists()


### PR DESCRIPTION
The permissions to use the WCA Key API have hardened.

When running the Admin Portal locally Users authenticated with GitHub fail the checks.

This PR adds an extra step to the Django PIPELINE to ensure they are able to use the API.