### PR TITLE
Disable the django rest framework browsable API

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -185,6 +185,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'EXCEPTION_HANDLER': 'main.exception_handler.exception_handler_with_error_type',
+    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
 }
 
 ROOT_URLCONF = "main.urls"


### PR DESCRIPTION
REST API switched from browsable API to JSON responses.

**How it was:**
<img width="556" alt="image" src="https://github.com/ansible/ansible-wisdom-service/assets/1477262/7e56e640-25c8-46ca-bfeb-0729e4930b26">

**How it is now**
<img width="432" alt="image" src="https://github.com/ansible/ansible-wisdom-service/assets/1477262/c4abea85-6b31-46f7-8ec4-0f74e5acb52b">
