### PR TITLE
Disable managing Applications API

### DIFF
--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -24,6 +24,7 @@ from drf_spectacular.views import (
 )
 from healthcheck.views import WisdomServiceHealthView, WisdomServiceLivenessProbeView
 from main.views import ConsoleView, LoginView
+from oauth2_provider.urls import app_name, base_urlpatterns
 from users.views import CurrentUserView, HomeView, TermsOfService, UnauthorizedView
 
 WISDOM_API_VERSION = "v0"
@@ -45,7 +46,7 @@ urlpatterns = [
         TermsOfService.as_view(template_name='users/community-terms.html'),
         name='community_terms',
     ),
-    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path('o/', include((base_urlpatterns, app_name), namespace='oauth2_provider')),
     path(
         'login/',
         LoginView.as_view(


### PR DESCRIPTION
We don't need to expose applications we are not currently using.

Disabled all unused applications, and remains only used one.

### Remains active
* authorize
* token
* revoke_token
* introspect

### Disabled applications
* applications _(not used)_
* applications/register/ _(not used)_
* authorized_tokens _(not used)_
* userinfo _(wasn't even configured)_