### PR TITLE
AAP-15952: Console UI: Linting checks for TypeScript code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,6 @@ create-superuser: create-cachetable
 create-application: create-superuser
 	python ansible_wisdom/manage.py createapplication --name "Ansible Lightspeed for VS Code" --client-id Vu2gClkeR5qUJTUGHoFAePmBznd6RZjDdy5FW2wy  --redirect-uris "vscode://redhat.ansible"   public authorization-code
 
-.PHONY: create-application-ui-react
-create-application-ui-react:
-	npm --prefix ./ansible_wisdom_console_react run build
-
 .PHONY: test
 test:
 	python ansible_wisdom/manage.py test
@@ -131,3 +127,22 @@ code-coverage:
 	coverage run --rcfile=../setup.cfg manage.py test && \
 	coverage html && \
 	google-chrome htmlcov/index.html
+
+# ============================
+# Admin Portal related commands
+# ============================
+
+# Compile and bundle Admin Portal into Django application
+.PHONY: admin-portal-bundle
+admin-portal-bundle:
+	npm --prefix ./ansible_wisdom_console_react run build
+
+# Run tests for Admin Portal
+.PHONY: admin-portal-test
+admin-portal-test:
+	npm --prefix ./ansible_wisdom_console_react run test
+
+# Run lint checks for Admin Portal
+.PHONY: admin-portal-lint
+admin-portal-lint:
+	npm --prefix ./ansible_wisdom_console_react run lint

--- a/ansible_wisdom_console_react/README.md
+++ b/ansible_wisdom_console_react/README.md
@@ -28,7 +28,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 
 If you want to integrate the "Admin Portal" into the Django application launched with `manage.py runserver` you need to ensure the React/TypeScript code is compiled and linked to Django's path.
 
-This can be accomplished using `make create-application-ui-react`.
+This can be accomplished using `make admin-portal-bundle`.
 
 ## Packing into Docker images
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-15952

This PR adds the ability to checking `lint`'ing of the TypeScript code from the `makefile`.

It also adds a `makefile` entry to run TypeScript tests from the command line.

Finally, it renames the `makefile` commands to keep some form of consistency. 