### PR TITLE
WIP: allow faux commercial users with no org to specify a model id

### DIFF
--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -202,3 +202,16 @@ class TestWCAClient(WisdomServiceLogAwareTestCase):
         wca_client = WCAClient(inference_url='http://example.com/')
         with self.assertRaises(WcaBadRequest):
             wca_client.get_model_id(True, '123', None)
+
+    # Seated users with no org are test users in "Commercial" group
+    @override_settings(ANSIBLE_WCA_FREE_MODEL_ID='free')
+    def test_seated_with_no_org_get_free_model(self):
+        wca_client = WCAClient(inference_url='http://example.com/')
+        model_id = wca_client.get_model_id(True, None, None)
+        self.assertEqual(model_id, 'free')
+
+    # Seated users with no org are test users in "Commercial" group
+    def test_seated_with_no_org_can_pick_model(self):
+        wca_client = WCAClient(inference_url='http://example.com/')
+        model_id = wca_client.get_model_id(True, None, 'model-i-pick')
+        self.assertEqual(model_id, 'model-i-pick')

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -96,10 +96,10 @@ class WCAClient(ModelMeshClient):
         raise WcaSecretManagerError
 
     def get_model_id(self, rh_user_has_seat, organization_id, requested_model_id):
-        if not rh_user_has_seat or organization_id is None:
+        if not rh_user_has_seat:
             if requested_model_id:
                 err_message = "User is not entitled to customized model ID"
-                logger.error(err_message)
+                logger.info(err_message)
                 raise WcaBadRequest(err_message)
             return self.free_model_id
 
@@ -108,6 +108,10 @@ class WCAClient(ModelMeshClient):
             # requested_model_id defined: i.e. not None, not "", not {} etc
             # let them use what they ask for
             return requested_model_id
+
+        # Non-RHSSO users with faked seats ("Commercial" group) will not have an org
+        if organization_id is None:
+            return self.free_model_id
 
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
 


### PR DESCRIPTION
don't review yet... it gets even grosser if the fake commercial user is a RHSSO user.