### PR TITLE
drop lint warning down to debug

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -324,7 +324,7 @@ class Completions(APIView):
                 )
         else:
             ansible_lint_caller = None
-            logger.warn(
+            logger.debug(
                 'skipped ansible lint post processing as lint processing is allowed for'
                 ' Commercial Users only!'
             )


### PR DESCRIPTION
The warning about linter being commercial-only in postprocess is unnecessarily noisy in the production logs.
```
WARNING 2023-09-22 03:37:42,664 views.py:postprocess skipped ansible lint post processing as lint processing is allowed for Commercial Users only!
```