### PR TITLE
Upgrade cryptography version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ click==8.1.3
     #   nltk
 cmake==3.27.2
     # via triton
-cryptography==41.0.3
+cryptography==41.0.4
     # via
     #   ansible-core
     #   jwcrypto


### PR DESCRIPTION
Upgrade `cryptography` library to address:
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
cryptography | 41.0.3 | GHSA-v8gr-m533-ghj9 | 41.0.4 | pyca/cryptography's wheels include a statically linked copy of OpenSSL...
```