### PR TITLE
"predictions" and "postprocess" events need to reflect the correct model

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -62,7 +62,6 @@ class DummyMeshClient(ModelMeshClient):
                 pass
 
         self.response_data = response_data
-        self.response_data['model_id'] = settings.ANSIBLE_AI_MODEL_NAME
 
     def infer(self, data, model_id=None):
         if self.test_inference_match:
@@ -156,7 +155,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -177,9 +179,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "suggestionId": str(uuid.uuid4()),
         }
         response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
             "predictions": [
                 "- name:  Install Apache\n  ansible.builtin.apt:\n    name: apache2\n    state: latest\n- name:  start Apache\n  ansible.builtin.service:\n    name: apache2\n    state: started\n    enabled: yes\n"  # noqa: E501
-            ]
+            ],
         }
         self.user.rh_user_has_seat = True
         self.client.force_authenticate(user=self.user)
@@ -209,9 +212,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "suggestionId": str(uuid.uuid4()),
         }
         response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
             "predictions": [
                 "- name:  Install Apache\n  ansible.builtin.apt:\n    name: apache2\n    state: latest\n- name:  say hello fred@redhat.com\n  ansible.builtin.debug:\n    msg: Hello there olivia1@example.com\n"  # noqa: E501
-            ]
+            ],
         }
         self.user.rh_user_has_seat = True
         self.client.force_authenticate(user=self.user)
@@ -241,7 +245,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -261,7 +268,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         payload = {
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -279,7 +289,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         # self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -304,7 +317,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\nbecome: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -322,7 +338,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n  - name: [Setup]",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -340,7 +359,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n  - Name: [Setup]",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -360,7 +382,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -382,9 +407,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         }
         # quotation in the last line is not closed, but the truncate function can handle this.
         response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
             "predictions": [
                 "      ansible.builtin.apt:\n        name: apache2\n      register: \"test"
-            ]
+            ],
         }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger='root', level='INFO') as log:
@@ -407,7 +433,8 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         }
         # this prediction has indentation problem with the prompt above
         response_data = {
-            "predictions": ["      ansible.builtin.apt:\n garbage       name: apache2"]
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n garbage       name: apache2"],
         }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger='root', level='ERROR') as log:  # Suppress debug output
@@ -432,7 +459,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "suggestionId": str(uuid.uuid4()),
         }
         # module name in the prediction is ""
-        response_data = {"predictions": ["      \"\":\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      \"\":\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(
             logger='root', level='DEBUG'
@@ -464,7 +494,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger='root', level='WARN'):
             with patch.object(
@@ -483,7 +516,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -509,7 +545,10 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -524,13 +563,18 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
 
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
+    @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_full_payload_with_ansible_lint_with_commercial_user(self):
         self.user.rh_user_has_seat = True
+        dummy_model_id = "01234567-1234-5678-9abc-0123456789ab<|sepofid|>wisdom_codegen"
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": dummy_model_id,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -543,12 +587,22 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertIsNotNone(r.data['predictions'])
                 self.assertSegmentTimestamp(log)
 
+                segment_events = self.extractSegmentEventsFromLog(log)
+                self.assertTrue(len(segment_events) > 0)
+                for event in segment_events:
+                    properties = event['properties']
+                    self.assertTrue('modelName' in properties)
+                    self.assertEqual(properties['modelName'], dummy_model_id)
+
     def test_completions_pii_clean_up(self):
         payload = {
             "prompt": "- name: Create an account for foo@ansible.com \n",
             "suggestionId": str(uuid.uuid4()),
         }
-        response_data = {"predictions": [""]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": [""],
+        }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger='root', level='DEBUG') as log:
             with patch.object(
@@ -566,6 +620,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "suggestionId": str(uuid.uuid4()),
         }
         response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
             "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
         }
         self.client.force_authenticate(user=self.user)

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -230,6 +230,7 @@ class Completions(APIView):
         start_time = time.time()
         try:
             predictions = model_mesh_client.infer(data, model_id=model_id)
+            model_id = predictions.get("model_id", model_id)
         except ModelTimeoutError as exc:
             exception = exc
             logger.warn(
@@ -256,6 +257,7 @@ class Completions(APIView):
             event = {
                 "duration": duration,
                 "exception": exception is not None,
+                "modelName": model_id,
                 "problem": None if exception is None else exception.__class__.__name__,
                 "request": data,
                 "response": ano_predictions,
@@ -276,6 +278,7 @@ class Completions(APIView):
                 request.user,
                 payload.suggestionId,
                 indent=original_indent,
+                model_id=model_id,
             )
         except Exception:
             process_error_count.labels(stage='post-processing').inc()
@@ -337,24 +340,12 @@ class Completions(APIView):
 
         return context, prompt, original_indent
 
-    def postprocess(self, recommendation, prompt, context, user, suggestion_id, indent):
+    def postprocess(self, recommendation, prompt, context, user, suggestion_id, indent, model_id):
         ari_caller = apps.get_app_config("ai").get_ari_caller()
         if not ari_caller:
             logger.warn('skipped ari post processing because ari was not initialized')
-        # check for commercial users for lint processing
-        is_commercial = user.rh_user_has_seat
-        if is_commercial:
-            ansible_lint_caller = apps.get_app_config("ai").get_ansible_lint_caller()
-            if not ansible_lint_caller:
-                logger.warn(
-                    'skipped ansible lint post processing because ansible lint was not initialized'
-                )
-        else:
-            ansible_lint_caller = None
-            logger.debug(
-                'skipped ansible lint post processing as lint processing is allowed for'
-                ' Commercial Users only!'
-            )
+
+        ansible_lint_caller = self.get_ansible_lint_caller(user)
 
         exception = None
 
@@ -368,10 +359,7 @@ class Completions(APIView):
         recommendation_problem = None
         truncated_yaml = None
         postprocessed_yaml = None
-        tasks = []
-        task_names = fmtr.get_task_names_from_prompt(prompt)
-        for task_name in task_names:
-            tasks.append({"name": task_name})
+        tasks = [{"name": task_name} for task_name in fmtr.get_task_names_from_prompt(prompt)]
         ari_results = None
 
         # check if the recommendation_yaml is a valid YAML
@@ -446,6 +434,7 @@ class Completions(APIView):
                     exception,
                     start_time,
                     "ARI",
+                    model_id,
                 )
                 if exception:
                     raise exception
@@ -481,6 +470,7 @@ class Completions(APIView):
                     exception,
                     start_time,
                     "ansible-lint",
+                    model_id,
                 )
                 if exception:
                     raise exception
@@ -512,6 +502,23 @@ class Completions(APIView):
 
         return recommendation, tasks
 
+    def get_ansible_lint_caller(self, user):
+        """check for commercial users for lint processing"""
+        is_commercial = user.rh_user_has_seat
+        if is_commercial:
+            ansible_lint_caller = apps.get_app_config("ai").get_ansible_lint_caller()
+            if not ansible_lint_caller:
+                logger.warn(
+                    'skipped ansible lint post processing because ansible lint was not initialized'
+                )
+        else:
+            ansible_lint_caller = None
+            logger.debug(
+                'skipped ansible lint post processing as lint processing is allowed for'
+                ' Commercial Users only!'
+            )
+        return ansible_lint_caller
+
     def write_to_segment(
         self,
         user,
@@ -523,6 +530,7 @@ class Completions(APIView):
         exception,
         start_time,
         event_type,
+        model_id,
     ):
         duration = round((time.time() - start_time) * 1000, 2)
         problem = (
@@ -533,6 +541,7 @@ class Completions(APIView):
             else exception.__class__.__name__
         )
         if event_type == "ARI":
+            event_name = "postprocess"
             event = {
                 "exception": exception is not None,
                 "problem": problem,
@@ -543,8 +552,8 @@ class Completions(APIView):
                 "details": postprocess_detail,
                 "suggestionId": str(suggestion_id) if suggestion_id else None,
             }
-            send_segment_event(event, "postprocess", user)
         if event_type == "ansible-lint":
+            event_name = "postprocessLint"
             event = {
                 "exception": exception is not None,
                 "problem": problem,
@@ -553,7 +562,10 @@ class Completions(APIView):
                 "postprocessed": postprocessed_yaml,
                 "suggestionId": str(suggestion_id) if suggestion_id else None,
             }
-            send_segment_event(event, "postprocessLint", user)
+
+        if model_id:
+            event["modelName"] = model_id
+        send_segment_event(event, event_name, user)
 
 
 class Feedback(APIView):

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -38,7 +38,10 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 "activityId": activityId,
             },
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
         with patch.object(
             apps.get_app_config('ai'),
@@ -138,7 +141,10 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 "activityId": str(uuid.uuid4()),
             },
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
 
         # Override properties of Segment client to cause an error
@@ -207,7 +213,10 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 "activityId": str(uuid.uuid4()),
             },
         }
-        response_data = {"predictions": ["      ansible.builtin.apt:\n        name: apache2"]}
+        response_data = {
+            "model_id": settings.ANSIBLE_AI_MODEL_NAME,
+            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+        }
         self.client.force_authenticate(user=self.user)
 
         with patch.object(


### PR DESCRIPTION
For [AAP-16371](https://issues.redhat.com/browse/AAP-16371). While the original problem was for the  "predictions" events only, this PR also contains the changes for the "postprocess" and "postprocessLint" events as well.