### PR TITLE
remove featureflags for wca api-key/model-id api

### DIFF
--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -1,8 +1,4 @@
-from ai.feature_flags import FeatureFlags, WisdomFlags
-from django.conf import settings
 from rest_framework import permissions
-
-feature_flags = FeatureFlags()
 
 
 class AcceptedTermsPermission(permissions.BasePermission):
@@ -36,25 +32,3 @@ class IsOrganisationLightspeedSubscriber(permissions.BasePermission):
     def has_permission(self, request, view):
         user = request.user
         return user.rh_org_has_subscription
-
-
-class IsWCAKeyApiFeatureFlagOn(permissions.BasePermission):
-    """
-    Allow access only to users allowed by feature flag
-    """
-
-    def has_permission(self, request, view):
-        if settings.LAUNCHDARKLY_SDK_KEY:
-            return feature_flags.get(WisdomFlags.WCA_KEY_API, request.user, "")
-        return False
-
-
-class IsWCAModelIdApiFeatureFlagOn(permissions.BasePermission):
-    """
-    Allow access only to users allowed by feature flag
-    """
-
-    def has_permission(self, request, view):
-        if settings.LAUNCHDARKLY_SDK_KEY:
-            return feature_flags.get(WisdomFlags.WCA_MODEL_ID_API, request.user, "")
-        return False

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from ..permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAKeyApiFeatureFlagOn,
 )
 from .test_views import WisdomServiceAPITestCaseBase
 
@@ -59,7 +58,6 @@ class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
 
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=False)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
-@patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
 class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
     def test_user_rh_user_is_org_admin(self, *args):
         self.client.force_authenticate(user=self.user)
@@ -69,7 +67,6 @@ class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
 
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=False)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=False)
-@patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
 class TestIfOrgIsLightspeedSubscriber(WisdomServiceAPITestCaseBase):
     def test_user_is_lightspeed_subscriber_admin(self, *args):
         self.client.force_authenticate(user=self.user)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -150,7 +150,6 @@ class TestCompletionWCAView(WisdomServiceAPITestCaseBase):
 
 
 @modify_settings()
-@override_settings(LAUNCHDARKLY_SDK_KEY=None)
 class TestCompletionView(WisdomServiceAPITestCaseBase):
     def test_full_payload(self):
         payload = {

--- a/ansible_wisdom/ai/api/wca/api_key_views.py
+++ b/ansible_wisdom/ai/api/wca/api_key_views.py
@@ -6,7 +6,6 @@ from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAKeyApiFeatureFlagOn,
 )
 from ai.api.serializers import WcaKeyRequestSerializer
 from ai.api.wca.utils import is_org_id_valid
@@ -29,7 +28,6 @@ from rest_framework.status import (
 logger = logging.getLogger(__name__)
 
 PERMISSION_CLASSES = [
-    IsWCAKeyApiFeatureFlagOn,
     IsAuthenticated,
     IsAuthenticatedOrTokenHasScope,
     IsOrganisationAdministrator,

--- a/ansible_wisdom/ai/api/wca/model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/model_id_views.py
@@ -6,7 +6,6 @@ from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAModelIdApiFeatureFlagOn,
 )
 from ai.api.serializers import WcaModelIdRequestSerializer
 from ai.api.wca.utils import is_org_id_valid
@@ -28,7 +27,6 @@ from rest_framework.status import (
 logger = logging.getLogger(__name__)
 
 PERMISSION_CLASSES = [
-    IsWCAModelIdApiFeatureFlagOn,
     IsAuthenticated,
     IsAuthenticatedOrTokenHasScope,
     IsOrganisationAdministrator,

--- a/ansible_wisdom/ai/api/wca/tests/test_model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/tests/test_model_id_views.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from unittest import mock
 from unittest.mock import patch
 
 from ai.api.aws.exceptions import WcaSecretManagerError
@@ -8,104 +7,15 @@ from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAModelIdApiFeatureFlagOn,
 )
 from ai.api.tests.test_views import WisdomServiceAPITestCaseBase
 from django.apps import apps
-from django.test import override_settings
 from django.urls import resolve, reverse
 from django.utils import timezone
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
 
 
-@patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
-@patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
-class TestWCAModelIdFeatureFlagView(WisdomServiceAPITestCaseBase):
-    def setUp(self):
-        super().setUp()
-        self.secret_manager_patcher = patch.object(
-            apps.get_app_config('ai'), '_wca_secret_manager', spec=WcaSecretManager
-        )
-        self.mock_secret_manager = self.secret_manager_patcher.start()
-
-    def tearDown(self):
-        self.secret_manager_patcher.stop()
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    def test_featureflag_disabled(self, *args):
-        self.client.force_authenticate(user=self.user)
-        r = self.client.get(reverse('wca_model_id'))
-        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        r = self.client.post(reverse('wca_model_id'))
-        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @mock.patch('ai.api.permissions.feature_flags')
-    def test_featureflag_on_get_model_id(self, feature_flags, *args):
-        def get_feature_flags(name, *args):
-            return "true"
-
-        feature_flags.get = get_feature_flags
-        self.user.organization_id = '123'
-        self.client.force_authenticate(user=self.user)
-        self.mock_secret_manager.get_secret.return_value = {'SecretString': '1', 'CreatedDate': '0'}
-        r = self.client.get(reverse('wca_model_id'))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.mock_secret_manager.get_secret.assert_called_once_with('123', Suffixes.MODEL_ID)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @mock.patch('ai.api.permissions.feature_flags')
-    def test_featureflag_on_set_model_id(self, feature_flags, *args):
-        def get_feature_flags(name, *args):
-            return "true"
-
-        feature_flags.get = get_feature_flags
-        self.user.organization_id = '123'
-        self.client.force_authenticate(user=self.user)
-        r = self.client.post(
-            reverse('wca_model_id'),
-            data='{ "model_id": "secret_model_id" }',
-            content_type='application/json',
-        )
-        self.assertEqual(r.status_code, HTTPStatus.NO_CONTENT)
-        self.mock_secret_manager.save_secret.assert_called_once_with(
-            '123', Suffixes.MODEL_ID, 'secret_model_id'
-        )
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @mock.patch('ai.api.permissions.feature_flags')
-    def test_featureflag_off_get_model_id(self, feature_flags, *args):
-        def get_feature_flags(name, *args):
-            return ""
-
-        feature_flags.get = get_feature_flags
-        self.user.organization_id = '123'
-        self.client.force_authenticate(user=self.user)
-        r = self.client.get(reverse('wca_model_id'))
-        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        self.mock_secret_manager.get_secret.assert_not_called()
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @mock.patch('ai.api.permissions.feature_flags')
-    def test_featureflag_off_set_model_id(self, feature_flags, *args):
-        def get_feature_flags(name, *args):
-            return ""
-
-        feature_flags.get = get_feature_flags
-        self.user.organization_id = '123'
-        self.client.force_authenticate(user=self.user)
-        r = self.client.post(
-            reverse('wca_model_id'),
-            data='{ "model_id": "secret_model_id" }',
-            content_type='application/json',
-        )
-        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        self.mock_secret_manager.save_secret.assert_not_called()
-
-
-@override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-@patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
 class TestWCAModelIdView(WisdomServiceAPITestCaseBase):
@@ -134,7 +44,6 @@ class TestWCAModelIdView(WisdomServiceAPITestCaseBase):
         view = resolve(url).func.view_class
 
         required_permissions = [
-            IsWCAModelIdApiFeatureFlagOn,
             IsAuthenticated,
             IsAuthenticatedOrTokenHasScope,
             IsOrganisationAdministrator,
@@ -234,8 +143,6 @@ class TestWCAModelIdView(WisdomServiceAPITestCaseBase):
         self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
 
-@override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-@patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=False)
 class TestWCAModelIdViewAsNonSubscriber(WisdomServiceAPITestCaseBase):
@@ -246,8 +153,6 @@ class TestWCAModelIdViewAsNonSubscriber(WisdomServiceAPITestCaseBase):
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
 
-@override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-@patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
 class TestWCAModelIdValidatorView(WisdomServiceAPITestCaseBase):
@@ -261,12 +166,7 @@ class TestWCAModelIdValidatorView(WisdomServiceAPITestCaseBase):
         r = self.client.get(reverse('wca_model_id_validator'))
         self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
-    @mock.patch('ai.api.permissions.feature_flags')
-    def test_validate_model_id(self, feature_flags, *args):
-        def get_feature_flags(name, *args):
-            return "true"
-
-        feature_flags.get = get_feature_flags
+    def test_validate_model_id(self, *args):
         self.user.organization_id = '123'
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('wca_model_id_validator'))

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -9,10 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class WisdomFlags(str, Enum):
-    MODEL_NAME = "model_name"  # model name selection
-    WCA_API = "wca-api"  # WCA cloud endpoint
-    WCA_KEY_API = "wca-key-api"  # WCA Key management API
-    WCA_MODEL_ID_API = "wca-model-id-api"  # WCA Model ID management API
+    pass
 
 
 class FeatureFlags:

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -5,11 +5,8 @@ from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAKeyApiFeatureFlagOn,
-    IsWCAModelIdApiFeatureFlagOn,
 )
 from ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from django.test import override_settings
 from django.urls import resolve, reverse
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
@@ -21,9 +18,6 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         r = self.client.get(reverse('console'))
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
-    @patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
     @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
     @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
     def test_get_when_authenticated(self, *args):
@@ -32,9 +26,6 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
 
     # Mock Permissions not being satisfied
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=False)
-    @patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=False)
     @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=False)
     @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=False)
     def test_get_when_authenticated_missing_permission(self, *args):
@@ -47,8 +38,6 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         view = resolve(url).func.view_class
 
         required_permissions = [
-            IsWCAKeyApiFeatureFlagOn,
-            IsWCAModelIdApiFeatureFlagOn,
             IsAuthenticated,
             IsAuthenticatedOrTokenHasScope,
             IsOrganisationAdministrator,
@@ -59,9 +48,6 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         for permission in required_permissions:
             self.assertTrue(permission in view.permission_classes)
 
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(IsWCAKeyApiFeatureFlagOn, 'has_permission', return_value=True)
-    @patch.object(IsWCAModelIdApiFeatureFlagOn, 'has_permission', return_value=True)
     @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
     @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
     def test_extra_data(self, *args):

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -6,8 +6,6 @@ from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
-    IsWCAKeyApiFeatureFlagOn,
-    IsWCAModelIdApiFeatureFlagOn,
 )
 from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
@@ -29,8 +27,6 @@ class ConsoleView(ProtectedTemplateView):
     template_name = 'console/console.html'
 
     permission_classes = [
-        IsWCAKeyApiFeatureFlagOn,
-        IsWCAModelIdApiFeatureFlagOn,
         IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         IsOrganisationAdministrator,


### PR DESCRIPTION
Now the feature is properly tested and gated by checking user's eligibility
