### PR TITLE
Manually fix selftest issue (CVE-2023-4863)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,10 @@ grpcio==1.54.2
 ipython==8.10.0
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
+# pin pillow on 10.0.1 to address CVE-2023-4863
+# remove this once sentence-transformers or torchvision
+# is updated to properly pull a version of pillow > 10.0.1.
+pillow==10.0.1
 protobuf==4.22.1
 psycopg[binary]==3.1.8
 pydantic==1.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -295,8 +295,10 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.5.0
-    # via torchvision
+pillow==10.0.1
+    # via
+    #   -r requirements.in
+    #   torchvision
 platformdirs==3.10.0
     # via black
 prometheus-client==0.17.0


### PR DESCRIPTION
Fix PR build break  [(example)](https://github.com/ansible/ansible-wisdom-service/actions/runs/6304677887/job/17116525741) caused by the version of pillow library that contains CVE-2023-4863.

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
pillow | 9.5.0 | PYSEC-2023-175 | 10.0.1 | Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-4863. Pillow v10.0.1 upgrades the bundled libwebp binary to v1.3.2.
```