### PR TITLE
put back feature flag MODEL_NAME = "model_name"

### DIFF
--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class WisdomFlags(str, Enum):
-    pass
+    MODEL_NAME = "model_name"  # model name selection
 
 
 class FeatureFlags:


### PR DESCRIPTION
this is still being used, removed accidentally