### PR TITLE
Fix WCAClient Unit Test failures

### DIFF
--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -171,21 +171,21 @@ class TestWCAClient(WisdomServiceLogAwareTestCase):
 
     def test_infer_garbage_model_id(self):
         stub = self.stub_wca_client(400, "zavala")
-        model_name, model_client, model_input = stub
+        model_id, model_client, model_input = stub
         with self.assertRaises(WcaInvalidModelId):
-            model_client.infer(model_input=model_input, model_name=model_name)
+            model_client.infer(model_input=model_input, model_id=model_id)
 
     def test_infer_invalid_model_id_for_api_key(self):
         stub = self.stub_wca_client(403, "zavala")
-        model_name, model_client, model_input = stub
+        model_id, model_client, model_input = stub
         with self.assertRaises(WcaInvalidModelId):
-            model_client.infer(model_input=model_input, model_name=model_name)
+            model_client.infer(model_input=model_input, model_id=model_id)
 
     def test_infer_empty_response(self):
         stub = self.stub_wca_client(204, "zavala")
-        model_name, model_client, model_input = stub
+        model_id, model_client, model_input = stub
         with self.assertRaises(WcaEmptyResponse):
-            model_client.infer(model_input=model_input, model_name=model_name)
+            model_client.infer(model_input=model_input, model_id=model_id)
 
     @override_settings(ANSIBLE_WCA_FREE_API_KEY='abcdef')
     def test_get_api_key_without_seat(self):


### PR DESCRIPTION
This PR fix unit test failures occurred after merging #567 ([link to failed GitHub Action](https://github.com/ansible/ansible-wisdom-service/actions/runs/6315204123))