### PR TITLE
add rh_user_has_seat and rh_user_org_id to segment

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -916,6 +916,8 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 self.assertTrue('groups' in properties)
                 self.assertTrue('Group 1' in properties['groups'])
                 self.assertTrue('Group 2' in properties['groups'])
+                self.assertTrue('rh_user_has_seat' in properties)
+                self.assertTrue('rh_user_org_id' in properties)
                 self.assertEqual(hostname, properties['hostname'])
                 self.assertIsNotNone(event['timestamp'])
 
@@ -1130,6 +1132,8 @@ class TestAttributionsView(WisdomServiceAPITestCaseBase):
                 self.assertTrue('groups' in properties)
                 self.assertTrue('Group 1' in properties['groups'])
                 self.assertTrue('Group 2' in properties['groups'])
+                self.assertTrue('rh_user_has_seat' in properties)
+                self.assertTrue('rh_user_org_id' in properties)
                 self.assertEqual(hostname, properties['hostname'])
                 self.assertIsNotNone(event['timestamp'])
 

--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -32,6 +32,12 @@ def send_segment_event(event: Dict[str, Any], event_name: str, user: Union[User,
     if 'groups' not in event:
         event['groups'] = list(user.groups.values_list('name', flat=True)) if user else []
 
+    if 'rh_user_has_seat' not in event:
+        event['rh_user_has_seat'] = getattr(user, 'rh_user_has_seat', False)
+
+    if 'rh_user_org_id' not in event:
+        event['rh_user_org_id'] = getattr(user, 'org_id', None)
+
     if 'timestamp' not in event:
         event['timestamp'] = timestamp
 

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -72,6 +72,8 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                     self.assertTrue('groups' in properties)
                     self.assertTrue('Group 1' in properties['groups'])
                     self.assertTrue('Group 2' in properties['groups'])
+                    self.assertTrue('rh_user_has_seat' in properties)
+                    self.assertTrue('rh_user_org_id' in properties)
                     self.assertEqual(hostname, properties['hostname'])
                     if event['event'] == 'completion':
                         self.assertEqual(


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-16533

`rh_user_has_seat` will be true when user is assigned a seat per AMS (future: CIAM) check, OR when user is in the "Commercial" django group (for testing/demo purposes), else false.

`rh_user_org_id` will be the user's redhat organization. If the user logged in with GitHub, his org will be null. The exception to both of these statements is for users in "Commercial" group, this value will always be `9999999999` which gives the user access to our "free" test wca key and model.{}

