### PR TITLE
all faux commercial users need 9999999999 org

### DIFF
--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -20,10 +20,10 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
 
     @property
     def org_id(self):
-        if self.organization_id:
-            return self.organization_id
         if self.groups.filter(name='Commercial').exists():
             return '9999999999'
+        if self.organization_id:
+            return self.organization_id
         return None
 
     def is_oidc_user(self) -> bool:


### PR DESCRIPTION
RHSSO users who are in the "Commercial" group need the 9999999999 org, even though they have an actual org, because their actual org presumably won't have a key and model set up (otherwise they don't need to be in Commercial group).