### PR TITLE
Add model_id to PostprocessException

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -786,6 +786,12 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             infer.side_effect = self.get_side_effect(error)
             self.run_wca_client_error_case(status_code_expected)
 
+    @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
+    @patch('ai.api.model_client.wca_client.WCAClient.infer')
+    def test_wca_client_postprocess_error(self, infer):
+        infer.return_value = {"predictions": [""], "model_id": self.DUMMY_MODEL_ID}
+        self.run_wca_client_error_case(HTTPStatus.NO_CONTENT)
+
     def run_wca_client_error_case(self, status_code_expected):
         """Execute a single WCA client error scenario."""
         self.user.rh_user_has_seat = True


### PR DESCRIPTION
For [AAP-16584](https://issues.redhat.com/browse/AAP-16584).

It is a case, which should have been covered by [AAP-16372](https://issues.redhat.com/browse/AAP-16372).
When WCA Client returns a 200 response, but it caused an exception in postprocessing, the exception thrown from postprocessing does not contain model ID. This PR addresses that case.

Note: This issue was found while I was verifying [a fix for WCA](https://github.com/rh-ibm-synergy/wca-feedback/issues/6).