### PR TITLE
Fix of "AAP-16553 - ansible-lint not initializing properly in wisdom-service in stage"

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -34,6 +34,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 # Compile Python/Django application
 RUN /usr/bin/python3 -m pip --no-cache-dir install supervisor
 RUN /usr/bin/python3 -m venv /var/www/venv
+ENV PATH="/var/www/venv/bin:${PATH}"
 COPY requirements.txt /var/www/
 COPY model-cache /var/www/model-cache
 # See: https://github.com/advisories/GHSA-r9hx-vwmv-q579


### PR DESCRIPTION
This PR appends venv/bin path in PATH in the wisdom-service container so that we can solve the defined problem in AAP-16553.

For the details see AAP-16553 and this thread: https://redhat-internal.slack.com/archives/C04G3TZBGHJ/p1695882695381729?thread_ts=1695840860.617959&cid=C04G3TZBGHJ

Here is my problem inspection:

```
I guess the problem is:

We call and run everything from the venv we create. we dont activate it but use the python and the dependencies under the venv whcih is the best parctice for container runtimes. see the containerfile here: https://github.com/ansible/ansible-wisdom-service/blob/main/wisdom-service.Containerfile

In our wisdom service instance, which runs in our venv, we call the linter by calling it as  dependency which also runs in the same venv. So far so good. Then it calls ansible-compat, which this time an ansible-lint dependency and again it runs under the venv we create. The problem occurs when we call the ansible-config command as a subprocess because it tries to run the command out of the venv where there is no ansible-config.Calling other CLIs always tricky in Python
```