### PR TITLE
Upgrade dependencies to pull in newer version of urllib.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,30 +6,32 @@
 #
 black==22.10.0
     # via -r requirements-dev.in
-build==0.10.0
+build==1.0.3
     # via pip-tools
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
-click==8.1.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
 coverage==7.2.1
     # via -r requirements-dev.in
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 enum-compat==0.0.3
     # via torch-model-archiver
-filelock==3.12.0
+filelock==3.12.4
     # via virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
-grpcio==1.54.2
+grpcio==1.59.0
     # via grpcio-tools
 grpcio-tools==1.54.2
     # via -r requirements-dev.in
-identify==2.5.24
+identify==2.5.30
     # via pre-commit
+importlib-metadata==6.8.0
+    # via build
 isort==5.10.1
     # via -r requirements-dev.in
 mccabe==0.7.0
@@ -38,21 +40,21 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via build
-pathspec==0.11.1
+pathspec==0.11.2
     # via
     #   black
     #   yamllint
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via -r requirements-dev.in
-platformdirs==3.5.1
+platformdirs==3.11.0
     # via
     #   black
     #   virtualenv
-pre-commit==3.3.2
+pre-commit==3.4.0
     # via -r requirements-dev.in
-protobuf==4.23.2
+protobuf==4.24.3
     # via grpcio-tools
 pycodestyle==2.10.0
     # via flake8
@@ -60,7 +62,7 @@ pyflakes==3.0.1
     # via flake8
 pyproject-hooks==1.0.0
     # via build
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   pre-commit
     #   yamllint
@@ -68,17 +70,20 @@ tomli==2.0.1
     # via
     #   black
     #   build
+    #   pip-tools
     #   pyproject-hooks
-torch-model-archiver==0.8.0
+torch-model-archiver==0.8.2
     # via -r requirements-dev.in
-typing-extensions==4.6.3
+typing-extensions==4.8.0
     # via black
-virtualenv==20.23.0
+virtualenv==20.24.5
     # via pre-commit
-wheel==0.40.0
+wheel==0.41.2
     # via pip-tools
 yamllint==1.29.0
     # via -r requirements-dev.in
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -1,15 +1,15 @@
 # pin aiohttp on 3.8.5 to address CVE-2023-30589
 # remove this once datasets or fsspec is updated
 # to properly pull a version of aiohttp > 3.8.4.
-aiohttp==3.8.5
+#aiohttp==3.8.5
 # Pin on 3.8.5 to
 ansible-anonymizer==1.4.2
 ansible-risk-insight==0.1.11
 ansible-lint==6.19.0
-boto3==1.26.84
+boto3==1.28.58
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==41.0.4
-datasets==2.10.1
+datasets==2.14.5
 Django==4.2.3
 django-extensions==3.2.1
 django-health-check==3.17.0
@@ -20,8 +20,8 @@ djangorestframework==3.14.0
 drf-spectacular==0.25.1
 grpcio==1.54.2
 ipython==8.10.0
-launchdarkly-server-sdk==8.1.1
-opensearch-py==2.1.1
+launchdarkly-server-sdk==8.1.6
+opensearch-py==2.3.1
 # pin pillow on 10.0.1 to address CVE-2023-4863
 # remove this once sentence-transformers or torchvision
 # is updated to properly pull a version of pillow > 10.0.1.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,17 @@
 #
 aiohttp==3.8.5
     # via
-    #   -r requirements.in
     #   datasets
     #   fsspec
 aiosignal==1.3.1
     # via aiohttp
-ansible==8.0.0
+ansible==8.4.0
     # via ansible-risk-insight
 ansible-anonymizer==1.4.2
     # via -r requirements.in
 ansible-compat==4.1.10
     # via ansible-lint
-ansible-core==2.15.0
+ansible-core==2.15.4
     # via
     #   ansible
     #   ansible-compat
@@ -30,46 +29,47 @@ argparse==1.4.0
     # via uwsgi-readiness-check
 asgiref==3.7.2
     # via django
-asttokens==2.2.1
+asttokens==2.4.0
     # via stack-data
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
+    #   referencing
 backcall==0.2.0
     # via ipython
 backoff==2.2.1
     # via segment-analytics-python
-black==23.7.0
+black==23.9.1
     # via ansible-lint
-boto3==1.26.84
+boto3==1.28.58
     # via -r requirements.in
-botocore==1.29.143
+botocore==1.31.58
     # via
     #   boto3
     #   s3transfer
-bracex==2.3.post1
+bracex==2.4
     # via wcmatch
 certifi==2023.7.22
     # via
     #   launchdarkly-server-sdk
     #   opensearch-py
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pygit2
-charset-normalizer==2.1.1
+charset-normalizer==3.3.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   black
     #   nltk
-cmake==3.27.2
+cmake==3.27.6
     # via triton
 cryptography==41.0.4
     # via
@@ -78,11 +78,11 @@ cryptography==41.0.4
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
-datasets==2.10.1
+datasets==2.14.5
     # via -r requirements.in
 decorator==5.1.1
     # via ipython
-defusedxml==0.7.1
+defusedxml==0.8.0rc2
     # via
     #   odfpy
     #   python3-openid
@@ -91,7 +91,7 @@ deprecated==1.2.14
     # via jwcrypto
 diff-match-patch==20230430
     # via django-import-export
-dill==0.3.6
+dill==0.3.7
     # via
     #   datasets
     #   multiprocess
@@ -131,11 +131,11 @@ ecdsa==0.18.0
     # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
-executing==1.2.0
+executing==2.0.0
     # via stack-data
 expiringdict==1.2.2
     # via launchdarkly-server-sdk
-filelock==3.12.0
+filelock==3.12.4
     # via
     #   ansible-lint
     #   ansible-risk-insight
@@ -143,11 +143,11 @@ filelock==3.12.0
     #   torch
     #   transformers
     #   triton
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2023.5.0
+fsspec[http]==2023.6.0
     # via
     #   datasets
     #   huggingface-hub
@@ -155,7 +155,7 @@ gitdb==4.0.10
     # via ansible-risk-insight
 grpcio==1.54.2
     # via -r requirements.in
-huggingface-hub==0.14.1
+huggingface-hub==0.17.3
     # via
     #   datasets
     #   sentence-transformers
@@ -170,7 +170,7 @@ inflection==0.5.1
     # via drf-spectacular
 ipython==8.10.0
     # via -r requirements.in
-jedi==0.18.2
+jedi==0.19.1
     # via ipython
 jinja2==3.1.2
     # via
@@ -180,31 +180,33 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.2.0
+joblib==1.3.2
     # via
     #   ansible-risk-insight
     #   nltk
     #   scikit-learn
-jsonpickle==3.0.1
+jsonpickle==3.0.2
     # via ansible-risk-insight
-jsonschema==4.17.3
+jsonschema==4.19.1
     # via
     #   ansible-compat
     #   ansible-lint
     #   drf-spectacular
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 jwcrypto==1.5.0
     # via django-oauth-toolkit
-launchdarkly-server-sdk==8.1.1
+launchdarkly-server-sdk==8.1.6
     # via -r requirements.in
-levenshtein==0.21.1
+levenshtein==0.22.0
     # via ansible-risk-insight
-lit==16.0.6
+lit==17.0.1
     # via triton
 markdown-it-py==3.0.0
     # via rich
 markuppy==1.14
     # via tablib
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
@@ -218,7 +220,7 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-multiprocess==0.70.14
+multiprocess==0.70.15
     # via datasets
 mypy-extensions==1.0.0
     # via black
@@ -226,7 +228,7 @@ networkx==3.1
     # via torch
 nltk==3.8.1
     # via sentence-transformers
-numpy==1.24.3
+numpy==1.26.0
     # via
     #   datasets
     #   pandas
@@ -270,9 +272,9 @@ odfpy==1.4.1
     # via tablib
 openpyxl==3.1.2
     # via tablib
-opensearch-py==2.1.1
+opensearch-py==2.3.1
     # via -r requirements.in
-packaging==23.1
+packaging==23.2
     # via
     #   ansible-compat
     #   ansible-core
@@ -282,7 +284,7 @@ packaging==23.1
     #   django-allow-cidr
     #   huggingface-hub
     #   transformers
-pandas==2.0.2
+pandas==2.1.1
     # via datasets
 parso==0.8.3
     # via jedi
@@ -299,11 +301,11 @@ pillow==10.0.1
     # via
     #   -r requirements.in
     #   torchvision
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via black
-prometheus-client==0.17.0
+prometheus-client==0.17.1
     # via django-prometheus
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.39
     # via ipython
 protobuf==4.22.1
     # via -r requirements.in
@@ -315,7 +317,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==12.0.0
+pyarrow==13.0.0
     # via datasets
 pyasn1==0.5.0
     # via
@@ -325,30 +327,29 @@ pycparser==2.21
     # via cffi
 pydantic==1.10.2
     # via -r requirements.in
-pygit2==1.12.1
+pygit2==1.13.1
     # via ansible-risk-insight
-pygments==2.15.1
+pygments==2.16.1
     # via
     #   ipython
     #   rich
-pyjwt==2.7.0
+pyjwt==2.8.0
     # via social-auth-core
 pyopenssl==23.2.0
     # via -r requirements.in
 pyrfc3339==1.1
     # via launchdarkly-server-sdk
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   opensearch-py
     #   pandas
     #   segment-analytics-python
 python-jose==3.3.0
     # via social-auth-core
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements.in
     #   djangorestframework
@@ -367,9 +368,13 @@ pyyaml==6.0
     #   tablib
     #   transformers
     #   yamllint
-rapidfuzz==3.2.0
+rapidfuzz==3.3.1
     # via levenshtein
-regex==2023.5.5
+referencing==0.30.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+regex==2023.8.8
     # via
     #   nltk
     #   transformers
@@ -384,7 +389,6 @@ requests==2.31.0
     #   huggingface-hub
     #   opensearch-py
     #   requests-oauthlib
-    #   responses
     #   segment-analytics-python
     #   social-auth-core
     #   torchvision
@@ -394,31 +398,33 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 resolvelib==1.0.1
     # via ansible-core
-responses==0.18.0
-    # via datasets
-rich==13.5.2
+rich==13.6.0
     # via ansible-lint
+rpds-py==0.10.3
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via python-jose
-ruamel-yaml==0.17.31
+ruamel-yaml==0.17.33
     # via
     #   ansible-lint
     #   ansible-risk-insight
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-s3transfer==0.6.1
+s3transfer==0.7.0
     # via boto3
 safetensors==0.3.3
     # via transformers
-scikit-learn==1.2.2
+scikit-learn==1.3.1
     # via sentence-transformers
-scipy==1.11.1
+scipy==1.11.3
     # via
     #   scikit-learn
     #   sentence-transformers
 segment-analytics-python==2.2.2
     # via -r requirements.in
-semver==2.13.0
+semver==3.0.1
     # via launchdarkly-server-sdk
 sentence-transformers==2.2.2
     # via -r requirements.in
@@ -428,8 +434,9 @@ six==1.16.0
     # via
     #   asttokens
     #   ecdsa
+    #   opensearch-py
     #   python-dateutil
-smmap==5.0.0
+smmap==5.0.1
     # via
     #   ansible-risk-insight
     #   gitdb
@@ -441,7 +448,7 @@ social-auth-core[openidconnect]==4.4.2
     #   social-auth-app-django
 sqlparse==0.4.4
     # via django
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
 subprocess-tee==0.4.1
     # via
@@ -449,11 +456,11 @@ subprocess-tee==0.4.1
     #   ansible-lint
 sympy==1.12
     # via torch
-tablib[html,ods,xls,xlsx,yaml]==3.4.0
+tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
 tabulate==0.9.0
     # via ansible-risk-insight
-threadpoolctl==3.1.0
+threadpoolctl==3.2.0
     # via scikit-learn
 tokenizers==0.13.3
     # via transformers
@@ -474,7 +481,7 @@ tqdm==4.64.1
     #   nltk
     #   sentence-transformers
     #   transformers
-traitlets==5.9.0
+traitlets==5.11.1
     # via
     #   ipython
     #   matplotlib-inline
@@ -484,7 +491,7 @@ transformers==4.30.0
     #   sentence-transformers
 triton==2.0.0
     # via torch
-typing-extensions==4.6.2
+typing-extensions==4.8.0
     # via
     #   ansible-compat
     #   asgiref
@@ -497,20 +504,19 @@ tzdata==2023.3
     # via pandas
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.16
+urllib3==1.26.17
     # via
     #   botocore
     #   launchdarkly-server-sdk
     #   opensearch-py
     #   requests
-    #   responses
 uwsgi==2.0.22
     # via -r requirements.in
 uwsgi-readiness-check==0.2.0
     # via -r requirements.in
 wcmatch==8.5
     # via ansible-lint
-wcwidth==0.2.6
+wcwidth==0.2.8
     # via prompt-toolkit
 wheel==0.41.2
     # via
@@ -526,7 +532,7 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xxhash==3.2.0
+xxhash==3.3.0
     # via datasets
 yamllint==1.32.0
     # via ansible-lint


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
urllib3 | 1.26.16 | GHSA-v845-jxx5-vc9f | 1.26.17,2.0.6 | urllib3 doesn't treat the `Cookie` HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a `Cookie` header and unknowingly leak information via HTTP redirects to a different origin if that user doesn't disable redirects explicitly.  Users **must** handle redirects themselves instead of relying on urllib3's automatic redirects to achieve safe processing of the `Cookie` header, thus we decided to strip the header by default in order to further protect users who aren't using the correct approach.  ## Affected usages  We believe the number of usages affected by this advisory is low. It requires all of the following to be true to be exploited:  * Using an affected version of urllib3 (patched in v1.26.17 and v2.0.6) * Using the `Cookie` header on requests, which is mostly typical for impersonating a browser. * Not disabling HTTP redirects * Either not using HTTPS or for the origin server to redirect to a malicious origin.  ## Remediation  * Upgrading to at least urllib3 v1.26.17 or v2.0.6 * Disabling HTTP redirects using `redirects=False` when sending requests. * Not using the `Cookie` header.
```