### PR TITLE
retain spaces before multi-task prompt

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -60,6 +60,7 @@ class WCAClient(ModelMeshClient):
         rh_user_has_seat = model_input.get("instances", [{}])[0].get("rh_user_has_seat", False)
         organization_id = model_input.get("instances", [{}])[0].get("organization_id", None)
 
+        # WCA codegen endpoint requires prompt to end with \n
         if prompt.endswith('\n') is False:
             prompt = f"{prompt}\n"
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
@@ -23,11 +23,6 @@ def completion_pre_process(context: CompletionContext):
     if fmtr.is_multi_task_prompt(cp):
         # Hold the original indent so that we can restore indentation in postprocess
         original_indent = cp.find('#')
-        # WCA codegen endpoint requires prompt to end with \n
-        if cp.endswith('\n') is False:
-            cp = f"{cp}\n"
-        # Workaround for https://github.com/rh-ibm-synergy/wca-feedback/issues/3
-        cp = cp.lstrip()
     else:
         # once we switch completely to WCA, we should be able to remove this entirely
         # since they're doing the same preprocessing on their side


### PR DESCRIPTION
Removes workaround for https://github.com/rh-ibm-synergy/wca-feedback/issues/3, which has been fixed. Also removes a redundant check for trailing newline on prompt.

Tested multi-task prompt with one and multiple prompts and confirmed no regressions.