### PR TITLE
Upgrade urllib3 to 1.26.17

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -42,6 +42,7 @@ social-auth-core[openidconnect]==4.4.2
 # UPDATED MANUALLY: waiting for parent package to be updated
 transformers==4.30.0
 tqdm==4.64.1
+urllib3==1.26.17
 uwsgi==2.0.22
 uwsgi-readiness-check==0.2.0
 django-allow-cidr==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -497,8 +497,9 @@ tzdata==2023.3
     # via pandas
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.16
+urllib3==1.26.17
     # via
+    #   -r requirements.in
     #   botocore
     #   launchdarkly-server-sdk
     #   opensearch-py


### PR DESCRIPTION
Open in lieu of #594 (as I prefer the branch name to be correct).

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
urllib3 | 1.26.16 | GHSA-v845-jxx5-vc9f | 1.26.17,2.0.6 | urllib3 doesn't treat the `Cookie` HTTP header special...
```