### PR TITLE
return first three codematch responses in contentmatch

### DIFF
--- a/ansible_wisdom/ai/api/data/data_model.py
+++ b/ansible_wisdom/ai/api/data/data_model.py
@@ -4,7 +4,7 @@ from typing import Any, TypedDict, Union
 from uuid import UUID
 
 from ai.api.serializers import DataSource
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,11 @@ class BaseContentMatchResponseDto(BaseModel):
 
 class ContentMatchResponseDto(BaseContentMatchResponseDto):
     code_matches: list[ContentMatchResponseData]
+
+    @validator('code_matches')
+    @classmethod
+    def trim_to_first_three(cls, v):
+        return v[:3]
 
     def data(self):
         return self.dict()["code_matches"]

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -1351,7 +1351,31 @@ class TestContentMatchesWCAView(WisdomServiceAPITestCaseBase):
                             "license": license,
                             "data_source_description": "Galaxy-R",
                             "score": 0.94550663,
-                        }
+                        },
+                        {
+                            "repo_name": f"{repo_name}2",
+                            "repo_url": f"{repo_url}2",
+                            "path": path,
+                            "license": license,
+                            "data_source_description": "Galaxy-R",
+                            "score": 0.94550662,
+                        },
+                        {
+                            "repo_name": f"{repo_name}3",
+                            "repo_url": f"{repo_url}3",
+                            "path": path,
+                            "license": license,
+                            "data_source_description": "Galaxy-R",
+                            "score": 0.94550661,
+                        },
+                        {
+                            "repo_name": f"{repo_name}4",
+                            "repo_url": f"{repo_url}4",
+                            "path": path,
+                            "license": license,
+                            "data_source_description": "Galaxy-R",
+                            "score": 0.94550660,
+                        },
                     ],
                     "meta": {"encode_duration": 367.3, "search_duration": 151.98},
                 }
@@ -1374,6 +1398,8 @@ class TestContentMatchesWCAView(WisdomServiceAPITestCaseBase):
             self.assertEqual(
                 model_client.session.post.call_args.kwargs['json']['model_id'], 'org-model-id'
             )
+
+            self.assertEqual(len(r.data["contentmatches"][0]["contentmatch"]), 3)
 
             content_match = r.data["contentmatches"][0]["contentmatch"][0]
 


### PR DESCRIPTION
WCA codematch returns 5 matches per task. We only want to show 3. Per Alex they are in order highest to lowest score, so we can just return the first 3.