### PR TITLE
restore user audit logging

### DIFF
--- a/ansible_wisdom/users/apps.py
+++ b/ansible_wisdom/users/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
     name = 'users'
 
     def ready(self) -> None:
-        ...
+        import users.signals  # noqa: F401

--- a/ansible_wisdom/users/signals.py
+++ b/ansible_wisdom/users/signals.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 @receiver(user_logged_in)
 def user_login_log(sender, user, **kwargs):
     """Successful user login log to user log"""
-    logger.info(f"User: {user} LOGIN successful!")
+    logger.info(f"User: {user} LOGIN successful")
 
 
 @receiver(user_login_failed)
 def user_login_failed_log(sender, user=None, **kwargs):
     """User failed login attempt log to user log"""
     if user:
-        logger.info(f"User: {user} LOGIN failed!")
+        logger.info(f"User: {user} LOGIN failed")
     else:
         logger.info("LOGIN failed; unknown user")
 
@@ -28,4 +28,4 @@ def user_login_failed_log(sender, user=None, **kwargs):
 @receiver(user_logged_out)
 def user_logout_log(sender, user, **kwargs):
     """User logout log to user log"""
-    logger.info(f"User: {user} LOGOUT successful!")
+    logger.info(f"User: {user} LOGOUT successful")

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -48,7 +48,7 @@ def create_user(
     return user
 
 
-class TestUsers(APITransactionTestCase):
+class TestUsers(APITransactionTestCase, WisdomServiceLogAwareTestCase):
     def setUp(self) -> None:
         self.password = "somepassword"
         self.user = create_user(
@@ -77,6 +77,11 @@ class TestUsers(APITransactionTestCase):
     def test_auth_keyword(self):
         bearer = BearerTokenAuthentication()
         self.assertEqual(bearer.keyword, "Bearer")
+
+    def test_users_audit_logging(self):
+        with self.assertLogs(logger='users.signals', level='INFO') as log:
+            self.client.login(username=self.user.username, password=self.password)
+            self.assertInLog('LOGIN successful', log)
 
 
 class TestTermsAndConditions(WisdomServiceLogAwareTestCase):


### PR DESCRIPTION
User audit logging was inadvertently removed (nice find, @jameswnl !). This PR restores it and adds a unit test.