### PR TITLE
bump ARI to 0.2.2 and use ARI KB 0.0.12-all-slim

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.11
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.12-all-slim
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Retrieve ari knowledge base from s3
       run: |
-        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.11
+        KB_ARI_PATH=s3://rhaw-knowledgebase-868937679750-us-east-1/ari/v0.0.12-all-slim
         aws s3 cp --recursive ${KB_ARI_PATH}/data ari/kb/data
         aws s3 cp --recursive ${KB_ARI_PATH}/rules ari/kb/rules
       env:

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 aiohttp==3.8.5
 # Pin on 3.8.5 to
 ansible-anonymizer==1.4.2
-ansible-risk-insight==0.1.11
+ansible-risk-insight==0.2.2
 ansible-lint==6.19.0
 boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ ansible-core==2.15.0
     #   ansible-lint
 ansible-lint==6.19.0
     # via -r requirements.in
-ansible-risk-insight==0.1.11
+ansible-risk-insight==0.2.2
     # via -r requirements.in
 argparse==1.4.0
     # via uwsgi-readiness-check


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- bump ARI to 0.2.2
  - including a fix for the handler issue [AAP-16649](https://issues.redhat.com/browse/AAP-16649)
- use ARI KB 0.0.12-all-slim
  - This version of ARI KB contains all modules in ansible-galaxy (older versions contain modules only in the most popular 100 collections)
  - however its data size is almost same as the previous ones