### PR TITLE
preserve multitask prompts in explicit feedback

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -193,25 +193,25 @@ class SuggestionQualityFeedback(serializers.Serializer):
     class Meta:
         fields = ['prompt', 'providedSuggestion', 'expectedSuggestion', 'additionalComment']
 
-    prompt = AnonymizedCharField(
+    prompt = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='File Content used as context',
         help_text='File Content till end of task name description before cursor position.',
     )
-    providedSuggestion = AnonymizedCharField(
+    providedSuggestion = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='Provided Model suggestion',
         help_text='Inline suggestion from model as shared by user for given prompt.',
     )
-    expectedSuggestion = AnonymizedCharField(
+    expectedSuggestion = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='Expected Model suggestion',
         help_text='Suggestion expected by the user.',
     )
-    additionalComment = AnonymizedCharField(
+    additionalComment = serializers.CharField(
         trim_whitespace=False,
         required=False,
         label='Additional Comment',
@@ -226,7 +226,7 @@ class SentimentFeedback(serializers.Serializer):
 
     value = serializers.IntegerField(required=True, min_value=1, max_value=5)
 
-    feedback = AnonymizedCharField(
+    feedback = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='Free form text feedback',
@@ -241,13 +241,13 @@ class IssueFeedback(serializers.Serializer):
         fields = ['type', 'title', 'description']
 
     type = serializers.ChoiceField(choices=ISSUE_TYPE, required=True)
-    title = AnonymizedCharField(
+    title = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='Issue title',
         help_text='The title of the issue.',
     )
-    description = AnonymizedCharField(
+    description = serializers.CharField(
         trim_whitespace=False,
         required=True,
         label='Issue description',

--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -5,7 +5,7 @@ from unittest.case import TestCase
 from unittest.mock import Mock
 from uuid import UUID
 
-from ai.api.serializers import CompletionRequestSerializer
+from ai.api.serializers import CompletionRequestSerializer, SuggestionQualityFeedback
 from django.test import override_settings
 from rest_framework import serializers
 
@@ -83,3 +83,16 @@ class CompletionRequestSerializerTest(TestCase):
         # model raises exception when no seat
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
+
+
+class SuggestionQualityFeedbackTest(TestCase):
+    def test_multitask_prompt_not_stripped(self):
+        data = {
+            "prompt": "---\n- name: Deploy AWS EC2\n  hosts: localhost\n  tasks:\n    # create vpc & create security group",  # noqa: E501
+            "providedSuggestion": "got this",
+            "expectedSuggestion": "wanted this",
+            "additionalComment": "p.s.",
+        }
+        serializer = SuggestionQualityFeedback(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertIn("# create vpc & create security group", serializer.validated_data['prompt'])


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAP-16975
Don't anonymize explicit feedback. The user acknowledges they're sharing the data with us, switching values in their feedback will make it less useful or possibly even useless if we can't recreate their issue.