### PR TITLE
pip-audit: ignore GHSA-ww3m-ffrm-qvqv

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -34,4 +34,5 @@ jobs:
           ignore-vulns: |
             GHSA-282v-666c-3fvg
             GHSA-jh3w-4vvf-mjgr
+            GHSA-ww3m-ffrm-qvqv
             PYSEC-2023-100


### PR DESCRIPTION
The service doesn't use Ansible's `ec2_key` module. We can safely ignore this warning.
