### PR TITLE
Log more info for AMS issues

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import json
 import logging
 from abc import abstractmethod
 from datetime import datetime, timedelta
@@ -144,7 +143,7 @@ class AMSCheck(BaseCheck):
         try:
             return data["items"][0]["id"]
         except (IndexError, KeyError, ValueError):
-            logger.exception("Unexpected organization answer from AMS: data=%s" % json.dumps(data))
+            logger.exception("Unexpected organization answer from AMS: data=%s" % data)
             return ""
 
     def self_test(self):

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -151,7 +151,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
 
         with self.assertLogs(logger='root', level='ERROR') as log:
             self.assertEqual(checker.get_ams_org("123"), "")
-            self.assertInLog('Unexpected organization answer from AMS: data={"items": []}', log)
+            self.assertInLog("Unexpected organization answer from AMS: data={'items': []}", log)
             self.assertInLog("IndexError: list index out of range", log)
 
     def test_ams_check(self):


### PR DESCRIPTION
For [AAP-17057](https://issues.redhat.com/browse/AAP-17057).

Added more logging info in `authz_checker.py`:

1. Added status code to the log when non-200 code is received.
2. Added code to dump `data` in  `get_ams_org()` when it is not in the expected form. 

For 2, we could add similar changes to other methods in  `authz_checker.py`, but logging data in those Authz-related codes has a risk of exposing PII unexpectedly.  So I added it only to `get_ams_org()` where we need such information for problem determination.