### PR TITLE
handle extra spaces in readCookie

### DIFF
--- a/ansible_wisdom_console_react/src/api/api.tsx
+++ b/ansible_wisdom_console_react/src/api/api.tsx
@@ -10,8 +10,9 @@ const readCookie = (name: string) => {
     const nameEQ = name + "=";
     const ca = document.cookie.split(';');
     for (let c of ca) {
-        if (c.trimStart().startsWith(nameEQ)) {
-            return c.substring(nameEQ.length, c.length);
+        const cookie = c.trim();
+        if (cookie.startsWith(nameEQ)) {
+            return cookie.substring(nameEQ.length, cookie.length);
         }
     }
     return null;


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-17067

Testing stage with Chrome, there is a leading space in `c` that was causing the returned cookie value to also include the `=`. 

`return c.trimStart().substring(nameEQ.length, c.length);` fixes the issue but I went with a full `trim()` in case other browsers might end up with trailing spaces as well. 

Full credit to @romartin for the heavy lifting chasing this bug to a csrf token issue.