### PR TITLE
upgrade ansible-lint to 6.20.3

### DIFF
--- a/ansible_wisdom/ansible_lint/lintpostprocessing.py
+++ b/ansible_wisdom/ansible_lint/lintpostprocessing.py
@@ -7,7 +7,7 @@ from ansiblelint.config import Options
 from ansiblelint.config import options as default_options
 from ansiblelint.constants import DEFAULT_RULESDIR
 from ansiblelint.rules import RulesCollection
-from ansiblelint.runner import LintResult, _get_matches
+from ansiblelint.runner import LintResult, get_matches
 from ansiblelint.transformer import Transformer
 from django.conf import settings
 
@@ -57,7 +57,7 @@ class AnsibleLintCaller:
                 temp_completion_path = temp_file.name
 
             self.config_options.lintables = [temp_completion_path]
-            result = _get_matches(rules=self.default_rules_collection, options=self.config_options)
+            result = get_matches(rules=self.default_rules_collection, options=self.config_options)
             self.run_transform(result, self.config_options)
 
             # read the transformed file

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ aiohttp==3.8.5
 # Pin on 3.8.5 to
 ansible-anonymizer==1.4.2
 ansible-risk-insight==0.2.2
-ansible-lint==6.19.0
+ansible-lint==6.20.3
 boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==41.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ansible-core==2.15.0
     #   ansible
     #   ansible-compat
     #   ansible-lint
-ansible-lint==6.19.0
+ansible-lint==6.20.3
     # via -r requirements.in
 ansible-risk-insight==0.2.2
     # via -r requirements.in


### PR DESCRIPTION
ansible-lint 6.20.3 contains the remainder of the transform rules we're getting for GA. It also appears to fix https://issues.redhat.com/browse/AAP-16943