### PR TITLE
AAP-15436: Create audit trail for WCA key/model updates

### DIFF
--- a/ansible_wisdom/users/signals.py
+++ b/ansible_wisdom/users/signals.py
@@ -5,9 +5,12 @@ from django.contrib.auth.signals import (
     user_logged_out,
     user_login_failed,
 )
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 logger = logging.getLogger(__name__)
+
+user_set_wca_api_key = Signal()
+user_set_wca_model_id = Signal()
 
 
 @receiver(user_logged_in)
@@ -29,3 +32,32 @@ def user_login_failed_log(sender, user=None, **kwargs):
 def user_logout_log(sender, user, **kwargs):
     """User logout log to user log"""
     logger.info(f"User: {user} LOGOUT successful")
+
+
+@receiver(user_set_wca_api_key)
+def user_set_wca_key_log(sender, user, org_id, api_key, **kwargs):
+    """User set WCA API Key"""
+    logger.info(
+        f"User: '{user}' set WCA Key for Organisation '{org_id}' to '{_obfuscate(api_key)}'."
+    )
+
+
+@receiver(user_set_wca_model_id)
+def user_set_wca_model_id_log(sender, user, org_id, model_id, **kwargs):
+    """User set WCA Model Id"""
+    logger.info(
+        f"User: '{user}' set WCA Model Id for Organisation '{org_id}' to '{_obfuscate(model_id)}'."
+    )
+
+
+def _obfuscate(value: str) -> str:
+    if len(value) < 4:
+        return "*" * len(value)
+
+    retention = 1
+    if len(value) > 8:
+        retention = 2
+    if len(value) > 16:
+        retention = 4
+    repeat = len(value) - 2 * retention
+    return value[:retention] + ("*" * repeat) + value[retention + repeat :]

--- a/ansible_wisdom/users/tests/test_signals.py
+++ b/ansible_wisdom/users/tests/test_signals.py
@@ -1,0 +1,13 @@
+from test_utils import WisdomServiceLogAwareTestCase
+from users.signals import _obfuscate
+
+
+class TestSignals(WisdomServiceLogAwareTestCase):
+    def test_obfuscate(self):
+        self.assertEqual("*", _obfuscate("x"))
+        self.assertEqual("**", _obfuscate("sh"))
+        self.assertEqual("***", _obfuscate("spy"))
+        self.assertEqual("h**e", _obfuscate("hide"))
+        self.assertEqual("h****n", _obfuscate("hidden"))
+        self.assertEqual("to******et", _obfuscate("top-secret"))
+        self.assertEqual("a-lo***************alue", _obfuscate("a-long-top-secret-value"))


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-15436

@robinbobbitt I used `signals` for the WCA audit events; just because:-

- It's consistent with other _User_ audit logging
- Using a _different_ approach for audit log entries helps identify their different nature.

I'm tempted to use structured logging for the audit trail; but structured logging is a bigger topic than this PR.

For now, the new audit entries are formatted consistently with the existing. 

BTW I obfuscate both the WCA API Key and Model Id in the log.. having a "hint" to the value is more useful for the use-case than no value at all (i.e. User X notices Model Id `12345` is not working and wants to know how set it.. they'll be able to see `1***5` in the logs).