### PR TITLE
AMS: rh_org_has_subscription uses the QuotaCost API

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -417,5 +417,3 @@ CSP_INCLUDE_NONCE_IN = ['script-src-elem']
 
 # Region for where the service is deployed. Used by the Health Check endpoint.
 DEPLOYED_REGION = os.getenv('DEPLOYED_REGION', 'unknown')
-
-SKU = os.getenv('SKU', 'FakeAnsibleWisdom')

--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -6,7 +6,6 @@ from functools import cache
 from http import HTTPStatus
 
 import requests
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -216,14 +215,14 @@ class AMSCheck(BaseCheck):
 
     def rh_org_has_subscription(self, organization_id: str) -> bool:
         ams_org_id = self.get_ams_org(organization_id)
-        params = {"search": "sku = '" + settings.SKU + "' AND sku_count > 0"}
+        params = {"search": "quota_id LIKE 'seat|ansible.wisdom%'"}
         self.update_bearer_token()
 
         try:
             r = self._session.get(
                 (
                     f"{self._api_server}"
-                    f"/api/accounts_mgmt/v1/organizations/{ams_org_id}/resource_quota"
+                    f"/api/accounts_mgmt/v1/organizations/{ams_org_id}/quota_cost"
                 ),
                 params=params,
                 timeout=0.8,

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -311,7 +311,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
         m_r = Mock()
         m_r.json.side_effect = [
             {"items": [{"id": "rdgdfhbrdb"}]},
-            {"items": [{"subscription": {"status": "Active"}}], "total": 1},
+            {"items": [{"allowed": 10}], "total": 1},
         ]
         m_r.status_code = 200
 
@@ -324,9 +324,9 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
-                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/resource_quota'
+                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/quota_cost'
             ),
-            params={"search": "sku = 'FakeAnsibleWisdom' AND sku_count > 0"},
+            params={"search": "quota_id LIKE 'seat|ansible.wisdom%'"},
             timeout=0.8,
         )
 
@@ -347,9 +347,9 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session.get.assert_called_with(
             (
                 'https://some-api.server.host'
-                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/resource_quota'
+                '/api/accounts_mgmt/v1/organizations/rdgdfhbrdb/quota_cost'
             ),
-            params={"search": "sku = 'FakeAnsibleWisdom' AND sku_count > 0"},
+            params={"search": "quota_id LIKE 'seat|ansible.wisdom%'"},
             timeout=0.8,
         )
 


### PR DESCRIPTION
The number of Seats available for a given Org is now based on its SKUs.
We use the QuotaCost API to get a list of the quotas that dynamically computed.

Depends-On: https://gitlab.cee.redhat.com/service/uhc-account-manager/-/merge_requests/4189
