### PR TITLE
sonar: ignore the ansible_wisdom/users/migrations/* files

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -107,8 +107,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      with:
-        -Dsonar.test.exclusions=ansible_wisdom/users/migrations/*
     ####################
     # OpenAPI file check
     ####################

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,6 @@ sonar.tests = ansible_wisdom/,ansible_wisdom_console_react/
 sonar.test.inclusions = ansible_wisdom/**/test_*.py,ansible_wisdom_console_react/**/__tests__/
 
 # Exclude test subdirectories from source scope
-sonar.exclusions = ansible_wisdom/**/test_*.py,ansible_wisdom_console_react/**/__tests__/*.*,ansible_wisdom_console_react/config/**,ansible_wisdom_console_react/__mocks__/**,ansible_wisdom_console_react/scripts/**,ansible_wisdom_console_react/**/*.json
+sonar.exclusions = ansible_wisdom/**/test_*.py,ansible_wisdom_console_react/**/__tests__/*.*,ansible_wisdom_console_react/config/**,ansible_wisdom_console_react/__mocks__/**,ansible_wisdom_console_react/scripts/**,ansible_wisdom_console_react/**/*.json,ansible_wisdom/users/migrations/*
 
 sonar.qualitygate.wait=true


### PR DESCRIPTION
The files are only used to upgrade the DB and don't need any test coverage.
