### PR TITLE
check/status: add attribution in the dependencies

### DIFF
--- a/ansible_wisdom/healthcheck/apps.py
+++ b/ansible_wisdom/healthcheck/apps.py
@@ -7,6 +7,7 @@ class HealthCheckAppConfig(AppConfig):
 
     def ready(self):
         from .backends import (
+            AttributionCheck,
             AuthorizationHealthCheck,
             AWSSecretManagerHealthCheck,
             ModelServerHealthCheck,
@@ -17,3 +18,4 @@ class HealthCheckAppConfig(AppConfig):
         plugin_dir.register(AWSSecretManagerHealthCheck)
         plugin_dir.register(WCAHealthCheck)
         plugin_dir.register(AuthorizationHealthCheck)
+        plugin_dir.register(AttributionCheck)

--- a/ansible_wisdom/healthcheck/backends.py
+++ b/ansible_wisdom/healthcheck/backends.py
@@ -1,3 +1,4 @@
+import ai.search
 import requests
 from ai.api.aws.wca_secret_manager import Suffixes
 from ai.api.model_client.wca_client import WcaInferenceFailure, WcaTokenFailure
@@ -114,6 +115,20 @@ class AuthorizationHealthCheck(BaseLightspeedHealthCheck):
     def check_status(self):
         try:
             apps.get_app_config("ai").get_seat_checker().self_test()
+        except Exception as e:
+            self.add_error(ServiceUnavailable(ERROR_MESSAGE), e)
+
+    def identifier(self):
+        return self.__class__.__name__
+
+
+class AttributionCheck(BaseLightspeedHealthCheck):
+    critical_service = False
+
+    def check_status(self):
+        try:
+            attributions = ai.search.search("aaa")["attributions"]
+            assert len(attributions) > 0, "No attribution found"
         except Exception as e:
             self.add_error(ServiceUnavailable(ERROR_MESSAGE), e)
 

--- a/ansible_wisdom/healthcheck/views.py
+++ b/ansible_wisdom/healthcheck/views.py
@@ -35,6 +35,7 @@ class HealthCheckCustomView(MainView):
         'AWSSecretManagerHealthCheck': 'secret-manager',
         'WCAHealthCheck': 'wca',
         'AuthorizationHealthCheck': 'authorization',
+        'AttributionCheck': 'attribution',
     }
 
     _version_info = VersionInfo()


### PR DESCRIPTION
Add a check for the attributions in the /chec/status end-point. This will
speed up the detection of potential problem with the backend.
