### PR TITLE
only correlate request id header if it is set

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -129,10 +129,10 @@ class WCAClient(ModelMeshClient):
         try:
             response = post_request()
 
-            if suggestion_id:
+            x_request_id = response.headers.get(WCA_REQUEST_ID_HEADER)
+            if suggestion_id and x_request_id:
                 # request/payload suggestion_id is a UUID not a string whereas
                 # HTTP headers are strings.
-                x_request_id = response.headers.get(WCA_REQUEST_ID_HEADER)
                 if x_request_id != str(suggestion_id):
                     raise WcaSuggestionIdCorrelationFailure(
                         model_id=model_id, x_request_id=x_request_id


### PR DESCRIPTION
Today we had 34 instances where a completions request failed because X-Request-Id header was None. This would occur e.g. if there is a gateway timeout making a request to WCA. We should only try to do the comparison if X-Request-Id is set.