### PR TITLE
Change Grafana port # in compose env from 3000 to 13000

### DIFF
--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       - GF_LOG_LEVEL=warn
     ports:
-      - "3000:3000"
+      - "13000:3000"
     volumes:
       - $PWD/grafana:/var/lib/grafana
     networks:

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -95,7 +95,7 @@ services:
     environment:
       - GF_LOG_LEVEL=warn
     ports:
-      - "3000:3000"
+      - "13000:3000"
     volumes:
       - $PWD/grafana:/var/lib/grafana
     networks:


### PR DESCRIPTION
Change Grafana port # from 3000, which is the default, to 13000 because 3000 is used as the default port # of our Lightning Bot. For testing Bot on the local machine, we need to change either of two.