### PR TITLE
fail requests for implicit feedback from seated users

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -309,6 +309,18 @@ class FeedbackRequestSerializer(serializers.Serializer):
     sentimentFeedback = SentimentFeedback(required=False)
     issueFeedback = IssueFeedback(required=False)
 
+    def validate_commercial_user_feedback(self, value):
+        user = self.context.get('request').user
+        if user.rh_user_has_seat is True:
+            raise serializers.ValidationError("invalid feedback type for user")
+        return value
+
+    def validate_inlineSuggestion(self, value):
+        return self.validate_commercial_user_feedback(value)
+
+    def validate_ansibleContent(self, value):
+        return self.validate_commercial_user_feedback(value)
+
 
 class AttributionRequestSerializer(serializers.Serializer):
     class Meta:

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -154,7 +154,9 @@ class Feedback(APIView):
         exception = None
         validated_data = {}
         try:
-            request_serializer = FeedbackRequestSerializer(data=request.data)
+            request_serializer = FeedbackRequestSerializer(
+                data=request.data, context={'request': request}
+            )
             request_serializer.is_valid(raise_exception=True)
             validated_data = request_serializer.validated_data
             logger.info(f"feedback request payload from client: {validated_data}")


### PR DESCRIPTION
While the extension should not be sending implicit feedback requests (accept/reject and ansible content upload), and we already are not creating segment events for these feedback types, we should very clearly fail these requests to indicate they are not being processed. Currently the respond with 200.

https://issues.redhat.com/browse/AAP-13897