### PR TITLE
Add support for arrays in segment allow_list

### DIFF
--- a/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
@@ -37,10 +37,12 @@ ALLOW_LIST = {
         },
         'modelName': None,
         'imageTags': None,
-        'tasks': {
-            'collection': None,
-            'module': None,
-        },
+        'tasks': [
+            {
+                'collection': None,
+                'module': None,
+            },
+        ],
         'taskCount': None,
         'promptType': None,
         'hostname': None,

--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -98,13 +98,19 @@ def redact_seated_users_data(event: Dict[str, Any], allow_list: Dict[str, Any]) 
     - dict: A new dictionary containing only the allowed nested keys from the source dictionary.
     """
     redacted_event = {}
-    for key, sub_whitelist in allow_list.items():
+    for key, sub_whitelist in (
+        allow_list.items() if isinstance(allow_list, dict) else allow_list[0].items()
+    ):
         if key in event:
             if isinstance(sub_whitelist, dict):
                 if isinstance(event[key], dict):
                     redacted_event[key] = redact_seated_users_data(event[key], sub_whitelist)
                 else:
                     redacted_event[key] = event[key]
+            elif isinstance(sub_whitelist, list):
+                redacted_event[key] = [
+                    redact_seated_users_data(item, sub_whitelist) for item in event[key]
+                ]
             else:
                 redacted_event[key] = event[key]
     return redacted_event

--- a/ansible_wisdom/ai/api/utils/tests/test_segment.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment.py
@@ -30,6 +30,74 @@ class TestSegment(TestCase):
             redact_seated_users_data(test_data, ALLOW_LIST['postprocess']), expected_result
         )
 
+    def test_redact_seated_users_data_with_array_parameter(self, *args):
+        test_data = {
+            # first level parameter should be redacted
+            'taskCount': 1,
+            'tasks': [
+                {
+                    'collection': 'ansible.builtin',
+                    'module': 'ansible.builtin.shell',
+                    'name': 'i*** r*** o*** r***',
+                    'prediction': '    ansible.builtin.shell: yum install -y cargo\n ',
+                }
+            ],
+        }
+
+        expected_result = {
+            'taskCount': 1,
+            'tasks': [
+                {
+                    'collection': 'ansible.builtin',
+                    'module': 'ansible.builtin.shell',
+                }
+            ],
+        }
+
+        self.assertEqual(
+            redact_seated_users_data(test_data, ALLOW_LIST['completion']), expected_result
+        )
+
+    def test_redact_seated_users_data_with_array_and_several_items_in_it_parameter(self, *args):
+        test_data = {
+            # first level parameter should be redacted
+            'taskCount': 1,
+            'tasks': [
+                {
+                    'collection': 'ansible.builtin',
+                    'module': 'ansible.builtin.shell',
+                    'name': 'i*** r*** o*** r***',
+                    'prediction': '    ansible.builtin.shell: yum install -y cargo',
+                },
+                {
+                    "collection": "ansible.builtin",
+                    "module": "ansible.builtin.shell",
+                    "name": "run an incremental deploy for ibm qradar",
+                    "prediction": "ansible.builtin.shell: \"cd {{ unarchive_dest }}",
+                },
+            ],
+            "suggestionId": "5e917739-3ba1-4253-9a06-00470e0d9977",
+        }
+
+        expected_result = {
+            'taskCount': 1,
+            'tasks': [
+                {
+                    'collection': 'ansible.builtin',
+                    'module': 'ansible.builtin.shell',
+                },
+                {
+                    'collection': 'ansible.builtin',
+                    'module': 'ansible.builtin.shell',
+                },
+            ],
+            "suggestionId": "5e917739-3ba1-4253-9a06-00470e0d9977",
+        }
+
+        self.assertEqual(
+            redact_seated_users_data(test_data, ALLOW_LIST['completion']), expected_result
+        )
+
     def test_redact_seated_users_data_nested_parameter(self, *args):
         test_data = {
             # nested parameter should be redacted


### PR DESCRIPTION
Some segment event's parameters can have an array of parameters, we should support it.