### PR TITLE
empty model params should be ignored

### DIFF
--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -143,6 +143,15 @@ class TestWCAClient(WisdomServiceLogAwareTestCase):
         model_id = wca_client.get_model_id(False, None, None)
         self.assertEqual(model_id, 'free')
 
+    def test_seated_with_empty_model(self):
+        wca_client = WCAClient(inference_url='http://example.com/')
+        self.mock_secret_manager.get_secret.return_value = {"SecretString": "sec"}
+        model_id = wca_client.get_model_id(
+            rh_user_has_seat=True, organization_id=123, requested_model_id=''
+        )
+        self.mock_secret_manager.get_secret.assert_called_once_with(123, Suffixes.MODEL_ID)
+        self.assertEqual(model_id, 'sec')
+
     def test_seatless_cannot_pick_model(self):
         wca_client = WCAClient(inference_url='http://example.com/')
         with self.assertRaises(WcaBadRequest):

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -63,7 +63,7 @@ class CompletionRequestSerializer(serializers.Serializer):
         default=uuid.uuid4,
     )
     metadata = Metadata(required=False)
-    model = serializers.CharField(required=False)
+    model = serializers.CharField(required=False, allow_blank=True)
 
     @staticmethod
     def validate_extracted_prompt(prompt, user):
@@ -107,6 +107,9 @@ class CompletionRequestSerializer(serializers.Serializer):
         # If suggestion ID was not included in the request, set a random UUID to it.
         if data.get('suggestionId') is None:
             data['suggestionId'] = uuid.uuid4()
+
+        if "model" in data and not data["model"].strip():
+            del data["model"]
         return data
 
 
@@ -352,7 +355,13 @@ class ContentMatchRequestSerializer(serializers.Serializer):
             " attribution data is being requested for."
         ),
     )
-    model = serializers.CharField(required=False)
+    model = serializers.CharField(required=False, allow_blank=True)
+
+    def validate(self, data):
+        data = super().validate(data)
+        if "model" in data and not data["model"].strip():
+            del data["model"]
+        return data
 
 
 class DataSource(models.IntegerChoices):


### PR DESCRIPTION
- completion: ignore the `model` key if the value is an empty string
- WCA :ensure empty `requested_model_id` str returns  org's model_id (test)

See: https://issues.redhat.com/browse/AAP-17440