### PR TITLE
attribution: use the local CPU to run the model

### DIFF
--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -1,6 +1,5 @@
 import logging
 
-import torch
 from ansible_lint import lintpostprocessing
 from ansible_risk_insight.scanner import Config
 from django.apps import AppConfig
@@ -34,10 +33,6 @@ class AiConfig(AppConfig):
     _ansible_lint_caller = UNINITIALIZED
 
     def ready(self) -> None:
-        if torch.cuda.is_available():
-            logger.info('GPU is available')
-        else:
-            logger.error('GPU is not available')
         self.wca_client = WCAClient(
             inference_url=settings.ANSIBLE_WCA_INFERENCE_URL,
         )

--- a/ansible_wisdom/ai/search.py
+++ b/ansible_wisdom/ai/search.py
@@ -36,7 +36,9 @@ def initialize_OpenSearch():
             pool_maxsize=20,
         )
 
-        model = SentenceTransformer(f"sentence-transformers/{settings.ANSIBLE_AI_SEARCH['MODEL']}")
+        model = SentenceTransformer(
+            f"sentence-transformers/{settings.ANSIBLE_AI_SEARCH['MODEL']}", device="cpu"
+        )
     else:
         client = None
         model = None

--- a/ansible_wisdom/ai/tests/test_apps.py
+++ b/ansible_wisdom/ai/tests/test_apps.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from ai.api.model_client.grpc_client import GrpcClient
 from ai.api.model_client.http_client import HttpClient
 from ai.api.model_client.mock_client import MockClient
@@ -57,21 +55,3 @@ class TestAiApp(APITestCase):
         app_config = AppConfig.create('ai')
         app_config.ready()
         self.assertIsNone(app_config.get_ansible_lint_caller())
-
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='mock')
-    @patch("torch.cuda.is_available")
-    @patch("ai.apps.logger.info")
-    def test_gpu_available(self, logger, is_available):
-        is_available.return_value = True
-        app_config = AppConfig.create('ai')
-        app_config.ready()
-        logger.assert_called_once_with("GPU is available")
-
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='mock')
-    @patch("torch.cuda.is_available")
-    @patch("ai.apps.logger.error")
-    def test_gpu_unavailable(self, logger, is_available):
-        is_available.return_value = False
-        app_config = AppConfig.create('ai')
-        app_config.ready()
-        logger.assert_called_once_with("GPU is not available")


### PR DESCRIPTION
From my observation, the use of the CPU instead of CUDA doesn't have an
impact on the performance and this would help us to avoid the memory
(and size) issues that we are currently facing.

Node: g4dn.xlarge with CUDA enabled
Input string:

```
"https://galaxy.ansible.com/community/general/ipa_otptoken"], "path": [""], "license": ["gpl-3.0"], "repo_name": ["community.general.ipa_otptoken"], "type": [1], "data_source": [7]}}, {"_index": "attribution-
```


With the CPU ( `model.encode(string, batch_size=16, device='cpu')` ):
- 263.6ms
- memory: 1329MB

With CUDA ( `model.encode(string, batch_size=16, device='cuda')` ):
- 2597.22ms
- memory: 3197MB


If I ignore the first call, CUDA is lightly fast:

```python
    encoded = model.encode(args.output, batch_size=16, device='cuda')

    start_time = time.time()
    encoded = model.encode(args.output*2, batch_size=16, device='cuda')
    encoded = model.encode(args.output*3, batch_size=16, device='cuda')
    encode_duration = round((time.time() - start_time) * 1000, 2)
```
CPU: 48.55ms
CUDA: 13.07ms