### PR TITLE
Use pre-defined query for attribution status check

### DIFF
--- a/ansible_wisdom/ai/search.py
+++ b/ansible_wisdom/ai/search.py
@@ -57,12 +57,16 @@ def generate_query(encoded):
     }
 
 
-def search(suggestion, index=None):
+def search(suggestion, index=None, pre_encoded=None):
     if client is None:
         raise Exception('AI Search is not initialized.')
 
     start_time = time.time()
-    encoded = model.encode(sentences=suggestion, batch_size=16)
+    encoded = (
+        pre_encoded
+        if (pre_encoded is not None)
+        else model.encode(sentences=suggestion, batch_size=16)
+    )
     encode_duration = round((time.time() - start_time) * 1000, 2)
 
     query = generate_query(encoded)

--- a/ansible_wisdom/healthcheck/tests/test_backends.py
+++ b/ansible_wisdom/healthcheck/tests/test_backends.py
@@ -1,0 +1,34 @@
+import base64
+import io
+
+import numpy as np
+from django.conf import settings
+from rest_framework.test import APITestCase
+from sentence_transformers import SentenceTransformer
+
+from ..backends import PRE_DEFINED_SEARCH_STRING, PRE_ENCODED_QUERY
+
+
+class TestSearchWithPreEncoded(APITestCase):
+    def test_pre_encoded_search_string(self):
+        model = SentenceTransformer(f"sentence-transformers/{settings.ANSIBLE_AI_SEARCH['MODEL']}")
+        encoded = model.encode(sentences=PRE_DEFINED_SEARCH_STRING, batch_size=16)
+
+        #
+        # Uncomment following lines to generate PRE_ENCODED_QUERY:
+        #
+        # def chunkstring(string, length):
+        #     return (string[0 + i:length + i] for i in range(0, len(string), length))
+        #
+        # f = io.BytesIO()
+        # np.save(f, encoded)
+        # serialized = f.getvalue()
+        # b64encoded = base64.b64encode(serialized).decode('latin-1')
+        # for chunk in chunkstring(b64encoded, 100):
+        #     print(chunk)
+
+        decoded = base64.b64decode(PRE_ENCODED_QUERY)
+        f = io.BytesIO(decoded)
+        loaded = np.load(f)
+
+        self.assertTrue(np.array_equal(encoded, loaded))


### PR DESCRIPTION
For [AAP-17452](https://issues.redhat.com/browse/AAP-17452).

In this approach, I am usising a predefined query for attribution status check so that it will not use Sentence Transformer's encode function, which seems to trigger drastic memory increase at the first call. It means that this only suppresses the drastic memory increase for health check API calls and the issue still occurs with regular attribution calls.