### PR TITLE
AAP-17433: Console UI: WCA API Key textbox should be 'password' - Exclude value attribute when a password

### DIFF
--- a/ansible_wisdom_console_react/src/SingleInlineEdit.tsx
+++ b/ansible_wisdom_console_react/src/SingleInlineEdit.tsx
@@ -14,39 +14,66 @@ export interface InlineTextInputProps {
 
 export const SingleInlineEdit = (props: InlineTextInputProps) => {
     const {t} = useTranslation();
-    const [passwordHidden, setPasswordHidden] = useState<boolean>(props.isPassword)
+
+    const {value, onChange, placeholder, isDisabled, isPassword} = props;
+    const [passwordHidden, setPasswordHidden] = useState<boolean>(isPassword)
+
     return (
-        <InputGroup>
-            <TextInput
-                value={props.value}
-                type={props.isPassword && passwordHidden ? "password" : "text"}
-                onChange={(value, event) => props.onChange?.(value)}
-                aria-label={props["aria-label"]}
-                placeholder={props.placeholder}
-                isDisabled={props.isDisabled}
-                data-testid={"model-settings-editor__input"}
-            />
-            {props.isPassword && (
-                <Button
-                    variant="control"
-                    onClick={() => setPasswordHidden(!passwordHidden)}
-                    aria-label={passwordHidden ? t('ShowText') : t('HideText')}
-                    data-testid={"model-settings-editor__toggleView"}>
-                    {passwordHidden ? <EyeIcon/> : <EyeSlashIcon/>}
-                </Button>
+        <>
+            {isPassword && (
+                <InputGroup>
+                    <TextInput
+                        type={isPassword && passwordHidden ? "password" : "text"}
+                        onChange={(value, event) => props.onChange?.(value)}
+                        aria-label={props["aria-label"]}
+                        placeholder={placeholder}
+                        isDisabled={isDisabled}
+                        data-testid={"model-settings-editor__input"}
+                    />
+                    <Button
+                        variant="control"
+                        onClick={() => setPasswordHidden(!passwordHidden)}
+                        aria-label={passwordHidden ? t('ShowText') : t('HideText')}
+                        data-testid={"model-settings-editor__toggleView"}>
+                        {passwordHidden ? <EyeIcon/> : <EyeSlashIcon/>}
+                    </Button>
+                    <Button variant="plain"
+                            aria-label={t('ClearText')}
+                            title={t('ClearText')}
+                            onClick={() => {
+                                onChange?.('');
+                            }}
+                            isDisabled={isDisabled || value.trim().length === 0}
+                            data-testid={"model-settings-editor__clear-button"}
+                    >
+                        <TimesIcon/>
+                    </Button>
+                </InputGroup>
             )}
-            <Button variant="plain"
-                    aria-label={t('ClearText')}
-                    title={t('ClearText')}
-                    onClick={() => {
-                        props.onChange?.('');
-                    }}
-                    isDisabled={props.isDisabled || props.value.trim().length === 0}
-                    data-testid={"model-settings-editor__clear-button"}
-            >
-                <TimesIcon/>
-            </Button>
-        </InputGroup>
-    )
-        ;
+            {!isPassword && (
+                <InputGroup>
+                    <TextInput
+                        value={value}
+                        type={"text"}
+                        onChange={(value, event) => props.onChange?.(value)}
+                        aria-label={props["aria-label"]}
+                        placeholder={placeholder}
+                        isDisabled={isDisabled}
+                        data-testid={"model-settings-editor__input"}
+                    />
+                    <Button variant="plain"
+                            aria-label={t('ClearText')}
+                            title={t('ClearText')}
+                            onClick={() => {
+                                onChange?.('');
+                            }}
+                            isDisabled={isDisabled || value.trim().length === 0}
+                            data-testid={"model-settings-editor__clear-button"}
+                    >
+                        <TimesIcon/>
+                    </Button>
+                </InputGroup>
+            )}
+        </>
+    );
 }

--- a/ansible_wisdom_console_react/src/__tests__/SingleInlineEdit.test.tsx
+++ b/ansible_wisdom_console_react/src/__tests__/SingleInlineEdit.test.tsx
@@ -47,7 +47,7 @@ describe('SingleInlineEdit',
                         const textInputElement = screen.getByTestId("model-settings-editor__input");
                         expect(textInputElement).toBeInTheDocument();
                         expect(textInputElement).toHaveAttribute('type', 'password');
-                        expect(textInputElement).toHaveAttribute('value', 'test-value');
+                        expect(textInputElement).not.toHaveAttribute('value', 'test-value');
                         expect(textInputElement).toHaveAttribute('aria-label', 'test-aria-label');
                         expect(textInputElement).toHaveAttribute('placeholder', 'test-placeholder');
                         expect(textInputElement).not.toBeDisabled();
@@ -119,7 +119,7 @@ describe('SingleInlineEdit',
                 const textInputElement = screen.getByTestId("model-settings-editor__input");
                 expect(textInputElement).toBeInTheDocument();
                 expect(textInputElement).toHaveAttribute('type', 'password');
-                expect(textInputElement).toHaveAttribute('value', 'test-value')
+                expect(textInputElement).not.toHaveAttribute('value', 'test-value')
                 const toggleViewElement = screen.getByTestId("model-settings-editor__toggleView");
                 expect(toggleViewElement).toBeInTheDocument();
                 expect(toggleViewElement).toHaveAttribute('aria-label', 'ShowText');


### PR DESCRIPTION
Further to https://github.com/ansible/ansible-wisdom-service/pull/669

See https://issues.redhat.com/browse/AAP-17433

A _controlled_ React component for `passwords` includes the HTML attribute `value` in plain text containing the password value.

This PR ensures we don't include such an attribute when the field type is `password`.

 
