### PR TITLE
AAP-17358: 403 from CloudFlare mistaken as Invalid Model ID

### DIFF
--- a/ansible_wisdom/ai/api/model_client/exceptions.py
+++ b/ansible_wisdom/ai/api/model_client/exceptions.py
@@ -48,6 +48,11 @@ class WcaTokenFailure(WcaException):
 
 
 @dataclass
+class WcaCloudflareRejection(WcaException):
+    """Cloudflare rejected the request."""
+
+
+@dataclass
 class WcaInferenceFailure(WcaException):
     """An attempt to run a WCA inference failed."""
 

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -37,13 +37,17 @@ DEFAULT_SUGGESTION_ID = uuid.uuid4()
 
 
 class MockResponse:
-    def __init__(self, json, status_code, headers=None):
+    def __init__(self, json, status_code, headers=None, text=None):
         self._json = json
         self.status_code = status_code
         self.headers = {} if headers is None else headers
+        self.text = text
 
     def json(self):
         return self._json
+
+    def text(self):
+        return self.text
 
     def raise_for_status(self):
         return

--- a/ansible_wisdom/ai/api/pipelines/common.py
+++ b/ansible_wisdom/ai/api/pipelines/common.py
@@ -111,6 +111,13 @@ class WcaEmptyResponseException(BaseWisdomAPIException):
     default_detail = {"message": "WCA returned an empty response."}
 
 
+class WcaCloudflareRejectionException(BaseWisdomAPIException):
+    status_code = 400
+    default_detail = {
+        "message": "Cloudflare rejected the request. Please contact your administrator."
+    }
+
+
 class ServiceUnavailable(BaseWisdomAPIException):
     status_code = 503
     default_detail = {"message": "An error occurred attempting to complete the request"}

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -6,6 +6,7 @@ from ai.api.data.data_model import ModelMeshPayload
 from ai.api.model_client.exceptions import (
     ModelTimeoutError,
     WcaBadRequest,
+    WcaCloudflareRejection,
     WcaEmptyResponse,
     WcaInvalidModelId,
     WcaKeyNotFound,
@@ -18,6 +19,7 @@ from ai.api.pipelines.common import (
     PipelineElement,
     ServiceUnavailable,
     WcaBadRequestException,
+    WcaCloudflareRejectionException,
     WcaEmptyResponseException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
@@ -144,6 +146,11 @@ class InferenceStage(PipelineElement):
                 f"WCA returned an empty response for suggestion {payload.suggestionId}"
             )
             raise WcaEmptyResponseException(cause=e)
+
+        except WcaCloudflareRejection as e:
+            exception = e
+            logger.exception(f"Cloudflare rejected the request for {payload.suggestionId}")
+            raise WcaCloudflareRejectionException(cause=e)
 
         except Exception as e:
             exception = e

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 
 from ai.api.model_client.exceptions import (
     WcaBadRequest,
+    WcaCloudflareRejection,
     WcaEmptyResponse,
     WcaInvalidModelId,
     WcaKeyNotFound,
@@ -15,6 +16,7 @@ from ai.api.pipelines.common import (
     ModelTimeoutException,
     ServiceUnavailable,
     WcaBadRequestException,
+    WcaCloudflareRejectionException,
     WcaEmptyResponseException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
@@ -450,6 +452,7 @@ class ContentMatches(GenericAPIView):
                 ).inc()
                 logger.exception(f"error serializing final response for suggestion {suggestion_id}")
                 raise InternalServerError
+
         except ModelTimeoutError as e:
             exception = e
             logger.warn(
@@ -500,6 +503,12 @@ class ContentMatches(GenericAPIView):
                 f"WCA returned an empty response for content matching suggestion {suggestion_id}"
             )
             raise WcaEmptyResponseException(cause=e)
+
+        except WcaCloudflareRejection as e:
+            exception = e
+            logger.exception(f"Cloudflare rejected the request for {suggestion_id}")
+            raise WcaCloudflareRejectionException(cause=e)
+
         except Exception as e:
             exception = e
             logger.exception(f"Error requesting content matches for suggestion {suggestion_id}")


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-17358

I have separated error handling of Cloudflare rejections to a new Lightspeed error.

The logic to isolate this type of response is very basic and you might be able to think of improvements?

The JIRA contains more details.