### PR TITLE
Additional pip_audit exclusion

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -36,3 +36,4 @@ jobs:
             GHSA-jh3w-4vvf-mjgr
             GHSA-ww3m-ffrm-qvqv
             PYSEC-2023-100
+            GHSA-mq26-g339-26xf


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
pip | 22.0.2 | GHSA-mq26-g339-26xf | 23.3 | When installing a package from a Mercurial VCS URL, e.g. `pip install hg+...`, with pip prior to v23.3, the specified Mercurial revision could be used to inject arbitrary configuration options to the `hg clone` call (e.g. `--config`). Controlling the Mercurial configuration can modify how and which repository is installed. This vulnerability does not affect users who aren't installing from Mercurial
```
We do not install from Mercurial so are unaffected.

That said... we should probably be [upgrading](https://github.com/ansible/ansible-wisdom-service/blob/main/.github/workflows/pre-commit.yml#L33-L34) `pip` anyway?!