### PR TITLE
Force use of Python 3.9

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
       - name: install
         run: |
           python -m venv env/


### PR DESCRIPTION
This (hopefully!) ensures `pip_audit` runs with Python 3.9 for `torch-2.0.1+cpu-cp39-cp39-linux_x86_64.whl`