### PR TITLE
AAP-17092: Turn health dependency checks on and off via config

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -421,3 +421,17 @@ CSP_INCLUDE_NONCE_IN = ['script-src-elem']
 
 # Region for where the service is deployed. Used by the Health Check endpoint.
 DEPLOYED_REGION = os.getenv('DEPLOYED_REGION', 'unknown')
+
+# Support to disable health checks. The default is that they are enabled.
+# The naming convention in the existing settings is to ENABLE_XXX and not DISABLE_XXX.
+ENABLE_HEALTHCHECK_MODEL_MESH = os.getenv('ENABLE_HEALTHCHECK_MODEL_MESH', 'True').lower() == 'true'
+ENABLE_HEALTHCHECK_SECRET_MANAGER = (
+    os.getenv('ENABLE_HEALTHCHECK_SECRET_MANAGER', 'True').lower() == 'true'
+)
+ENABLE_HEALTHCHECK_WCA = os.getenv('ENABLE_HEALTHCHECK_WCA', 'True').lower() == 'true'
+ENABLE_HEALTHCHECK_AUTHORIZATION = (
+    os.getenv('ENABLE_HEALTHCHECK_AUTHORIZATION', 'True').lower() == 'true'
+)
+ENABLE_HEALTHCHECK_ATTRIBUTION = (
+    os.getenv('ENABLE_HEALTHCHECK_ATTRIBUTION', 'True').lower() == 'true'
+)


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-17092

Individual health checks can be disabled with a respective environment variable. This means we can disable them in the `ConfigMap` - which is probably the simplest approach should we want to disable a check... we don't have any support for [watching k8s resources](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) and so we still need a restart of the Pod to disable a check. Is this an issue; or would you prefer a fuller solution to support only changing the `ConfigMap` and the Containers to restart themselves? 