### PR TITLE
Upgrade Django to 4.2.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==41.0.4
 datasets==2.10.1
-Django==4.2.3
+Django==4.2.7
 django-extensions==3.2.1
 django-health-check==3.17.0
 django-import-export==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ dill==0.3.6
     # via
     #   datasets
     #   multiprocess
-django==4.2.3
+django==4.2.7
     # via
     #   -r requirements.in
     #   django-allow-cidr


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
django | 4.2.3 | PYSEC-2023-222 | 3.2.23,4.1.13,4.2.7 | An issue was discovered in Django 3.2 before 3.2.23, 4.1 before 4.1.13, and 4.2 before 4.2.7. The NFKC normalization is slow on Windows. As a consequence, django.contrib.auth.forms.UsernameField is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.
django | 4.2.3 | PYSEC-2023-225 | 3.2.21,4.1.11,4.2.5 | In Django 3.2 before 3.2.21, 4.1 before 4.1.11, and 4.2 before 4.2.5, django.utils.encoding.uri_to_iri() is subject to a potential DoS (denial of service) attack via certain inputs with a very large number of Unicode characters.
django | 4.2.3 | PYSEC-2023-226 | 3.2.22,4.1.12,4.2.6 | In Django 3.2 before 3.2.22, 4.1 before 4.1.12, and 4.2 before 4.2.6, the django.utils.text.Truncator chars() and words() methods (when used with html=True) are subject to a potential DoS (denial of service) attack via certain inputs with very long, potentially malformed HTML text. The chars() and words() methods are used to implement the truncatechars_html and truncatewords_html template filters, which are thus also vulnerable. NOTE: this issue exists because of an incomplete fix for CVE-2019-14232.
```