### PR TITLE
Additional pip_audit exclusion

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -40,4 +40,5 @@ jobs:
             GHSA-jh3w-4vvf-mjgr
             GHSA-ww3m-ffrm-qvqv
             PYSEC-2023-100
+            PYSEC-2023-228
             GHSA-mq26-g339-26xf


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
pip | 23.0.1 | PYSEC-2023-228 | 23.3 | When installing a package from a Mercurial VCS URL  (ie "pip install  hg+...") with pip prior to v23.3, the specified Mercurial revision could  be used to inject arbitrary configuration options to the "hg clone"  call (ie "--config"). Controlling the Mercurial configuration can modify  how and which repository is installed. This vulnerability does not  affect users who aren't installing from Mercurial. 
```

We do not install from Mercurial so are unaffected.