### PR TITLE
AAP-18027: WCAClient.get_token: Distinguish between API Key related failures and others

### DIFF
--- a/ansible_wisdom/ai/api/model_client/exceptions.py
+++ b/ansible_wisdom/ai/api/model_client/exceptions.py
@@ -48,6 +48,11 @@ class WcaTokenFailure(WcaException):
 
 
 @dataclass
+class WcaTokenFailureApiKeyError(WcaException):
+    """An attempt to retrieve a WCA Token failed due to a problem with the provided API Key."""
+
+
+@dataclass
 class WcaCloudflareRejection(WcaException):
     """Cloudflare rejected the request."""
 

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -9,6 +9,8 @@ from ai.api.model_client.wca_utils import (
     ContentMatchResponseChecks,
     InferenceContext,
     InferenceResponseChecks,
+    TokenContext,
+    TokenResponseChecks,
 )
 from django.apps import apps
 from django.conf import settings
@@ -204,6 +206,8 @@ class WCAClient(ModelMeshClient):
 
         try:
             response = post_request()
+            context = TokenContext(response)
+            TokenResponseChecks().run_checks(context)
             response.raise_for_status()
 
         except HTTPError as e:

--- a/ansible_wisdom/ai/api/wca/model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/model_id_views.py
@@ -240,11 +240,6 @@ def do_validated_operation(request, api_key_provider, model_id_provider, on_succ
         logger.info(e, exc_info=True)
         raise WcaBadRequestException(cause=e)
 
-    except WcaSecretManagerError as e:
-        exception = e
-        logger.exception(e)
-        return Response(status=HTTP_500_INTERNAL_SERVER_ERROR)
-
     except Exception as e:
         exception = e
         logger.exception(e)

--- a/ansible_wisdom/ai/api/wca/tests/test_model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/tests/test_model_id_views.py
@@ -231,7 +231,7 @@ class TestWCAModelIdView(WisdomServiceAPITestCaseBase, WisdomLogAwareMixin):
                 data='{ "model_id": "secret_model_id" }',
                 content_type='application/json',
             )
-            self.assertEqual(r.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+            self.assertEqual(r.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
             self.assertInLog('ai.api.aws.exceptions.WcaSecretManagerError', log)
             _assert_segment_log(self, log, "modelIdSet", "WcaSecretManagerError")
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-18027

For `inference` and `codematch` we catch all generic `HTTPError`'s and return a genetic `WcaInferenceFailure` or `WcaCodeMatchFailure`. I have changed `WCAClient.get_token(..)` to follow the same approach making our codebase consistent: **IF** the HTTP response is known to be caused by an API Key error I now raise a `WcaTokenFailureApiKeyError`. All other _unhandled_ `HTTPError`'s are raised as a generic `WcaTokenFailure` for the `WCAClient.get_token(..)` function.

We log the underlying `HTTPError`. I am talking about exceptions eventually propagated to Users.
