### PR TITLE
Exclude PYSEC-2022-43059.

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -42,3 +42,4 @@ jobs:
             PYSEC-2023-100
             PYSEC-2023-228
             GHSA-mq26-g339-26xf
+            PYSEC-2022-43059


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
aiohttp | 3.8.5 | PYSEC-2022-43059 |  | AIOHTTP 3.8.1 can report a "ValueError: Invalid IPv6 URL" outcome, which can lead to a Denial of Service (DoS). NOTE: multiple third parties dispute this issue because there is no example of a context in which denial of service would occur, and many common contexts have exception handing in the calling application
```
There is no fix version.