### PR TITLE
Add inline suggestion action value for ignore scenario

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -149,7 +149,7 @@ class CompletionResponseSerializer(serializers.Serializer):
 
 
 class InlineSuggestionFeedback(serializers.Serializer):
-    USER_ACTION_CHOICES = (('0', 'ACCEPT'), ('1', 'IGNORE'))
+    USER_ACTION_CHOICES = (('0', 'ACCEPTED'), ('1', 'REJECTED'), ('2', 'IGNORED'))
 
     class Meta:
         fields = [

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -1114,7 +1114,7 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 "latency": 1000,
                 "userActionTime": 3500,
                 "documentUri": "file:///home/rbobbitt/ansible.yaml",
-                "action": "2",  # invalid choice for action
+                "action": "3",  # invalid choice for action
                 "suggestionId": str(uuid.uuid4()),
             }
         }

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -451,6 +451,7 @@ components:
       enum:
       - '0'
       - '1'
+      - '2'
       type: string
     AnsibleContentFeedback:
       type: object


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAP-15520

If the user ignores the suggestion the value of action sent from the client is `2`

*  `0` - Accepted
*  `1` - Rejected
*  `2` - Ignored

Client changes: https://github.com/ansible/vscode-ansible/blob/main/src/definitions/lightspeed.ts#L16

Note:
Prior to this change both `Ignored` and `Rejected` scenario where considered as ignored.