### PR TITLE
Upgrade pyarrow to 14.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,6 +28,10 @@ opensearch-py==2.1.1
 pillow==10.0.1
 protobuf==4.22.1
 psycopg[binary]==3.1.8
+# pin pyarrow on 14.0.1 to address GHSA-5wvp-7f3h-6wmm
+# remove this once datasets is updated to properly pull
+# a version of pyarrow > 14.0.1.
+pyarrow==14.0.1
 pydantic==1.10.2
 pytz
 pyOpenSSL==23.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -288,8 +288,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==12.0.0
-    # via datasets
+pyarrow==14.0.1
+    # via
+    #   -r requirements.in
+    #   datasets
 pyasn1==0.5.0
     # via
     #   python-jose


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
pyarrow | 12.0.0 | GHSA-5wvp-7f3h-6wmm | 14.0.1 | Deserialization of untrusted data in IPC and Parquet readers in PyArrow versions 0.14.0 to 14.0.0 allows arbitrary code execution. An application is vulnerable if it reads Arrow IPC, Feather or Parquet data from untrusted sources (for example user-supplied input files).  This vulnerability only affects PyArrow, not other Apache Arrow implementations or bindings.  It is recommended that users of PyArrow upgrade to 14.0.1. Similarly, it is recommended that downstream libraries upgrade their dependency requirements to PyArrow 14.0.1 or later. PyPI packages are already available, and we hope that conda-forge packages will be available soon.  If it is not possible to upgrade, maintainers provide a separate package `pyarrow-hotfix` that disables the vulnerability on older PyArrow versions. See https://pypi.org/project/pyarrow-hotfix/  for instructions.
```