### PR TITLE
reduce refresh token expiry to 10 days

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -167,7 +167,7 @@ OAUTH2_PROVIDER = {
         'checode',
     ],
     # ACCESS_TOKEN_EXPIRE_SECONDS = 36_000  # = 10 hours, default value
-    'REFRESH_TOKEN_EXPIRE_SECONDS': 1_209_600,  # = 2 weeks
+    'REFRESH_TOKEN_EXPIRE_SECONDS': 864_000,  # = 10 days
 }
 
 # OAUTH: todo

--- a/ansible_wisdom/main/tests/test_settings.py
+++ b/ansible_wisdom/main/tests/test_settings.py
@@ -6,3 +6,4 @@ class TestSettings(SimpleTestCase):
     def test_oauth2(self):
         REFRESH_TOKEN_EXPIRE_SECONDS = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
         self.assertGreater(REFRESH_TOKEN_EXPIRE_SECONDS, 0)
+        self.assertLessEqual(REFRESH_TOKEN_EXPIRE_SECONDS, 864_000)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-10570

## Description
Reduce the expiration on our refresh token from two weeks to 10 days, which is the max duration recommended as part of our threat model exercise.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
Verifying this beyond the unit test would involve deploying the service, authenticating from the VS Code extension, and waiting 10 days to ensure you are forced to log in again. I have faith in the unit test.

### Scenarios tested
Unit test expanded to ensure the value specified in the settings does not exceed 10 days.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
