### PR TITLE
workaround for multiple seat assignment

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -176,7 +176,7 @@ class AMSCheck(BaseCheck):
             return False
         data = r.json()
         try:
-            return len(data["items"]) == 1
+            return len(data["items"]) > 0
         except (KeyError, ValueError):
             logger.error("Unexpected subscription answer from AMS")
             return False

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -173,6 +173,28 @@ class TestToken(WisdomServiceLogAwareTestCase):
             timeout=0.8,
         )
 
+    def test_ams_check_multiple_seats(self):
+        m_r = Mock()
+        m_r.json.side_effect = [
+            {"items": [{"id": "qwe"}, {"id": "rty"}]},
+            {"items": [{"id": "asd"}, {"id": "fgh"}]},
+        ]
+        m_r.status_code = 200
+
+        checker = self.get_default_ams_checker()
+        checker._token = Mock()
+        checker._session = Mock()
+        checker._session.get.return_value = m_r
+        self.assertTrue(checker.check("my_id", "my_name", "123"))
+        checker._session.get.assert_called_with(
+            'https://some-api.server.host/api/accounts_mgmt/v1/subscriptions',
+            params={
+                'search': "plan.id = 'AnsibleWisdom' AND status = 'Active' "
+                "AND creator.username = 'my_name' AND organization_id='qwe'"
+            },
+            timeout=0.8,
+        )
+
     def test_ams_check_with_500_status_code(self):
         m_r = Mock()
         m_r.status_code = 500

--- a/tools/authz/validate_ams.py
+++ b/tools/authz/validate_ams.py
@@ -74,7 +74,7 @@ def check(username: str, organization_id: str) -> bool:
     )
 
     items = r.json().get("items")
-    return len(items) == 1
+    return len(items) > 0
 
 
 def rh_user_is_org_admin(username: str, organization_id: str) -> bool:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-18370
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
If multiple seats are assigned to the same user, our seat check will fail and the user won't be able to take advantage of licensed features (like the commercial model and multitask generation).

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Scenario test
1. As org admin, invite a user to your organization
1. Navigate to https://console.redhat.com/ansible/seats-administration
1. Assign multiple seats to the same user
1. Have the user login and attempt a multitask request
### Steps to test PR
```bash
set -o allexport
source .env
source .venv/bin/activate

pip install -r requirements-dev.txt
pip install -r requirements.txt

# $ANSIBLE_AI_ env vars come from .env
podman run -d --name testdb -e POSTGRES_PASSWORD=$ANSIBLE_AI_DATABASE_PASSWORD -e POSTGRES_USER=$ANSIBLE_AI_DATABASE_USER -e POSTGRES_DB=$ANSIBLE_AI_DATABASE_NAME -p 5432:5432 docker.io/postgres:14-alpine

cd ansible_wisdom

# run related tests
coverage run --rcfile=../setup.cfg manage.py test users.tests.test_authz_checker
```
### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
