### PR TITLE
How to configure Red Hat login locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ ifeq ($(ENVIRONMENT),development)
 	export PYTHONUNBUFFERED := 1
 	export SECRET_KEY := somesecret
 	export DJANGO_SUPERUSER_PASSWORD := somesecret
+	export SOCIAL_AUTH_OIDC_OIDC_ENDPOINT := https://sso.redhat.com/auth/realms/redhat-external
+	export SOCIAL_AUTH_OIDC_KEY := ansible-wisdom-staging
 
 	ifeq ($(wildcard $(PWD)/.env/.),)
 		ifneq ($(wildcard $(PWD)/.env),)

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ The wisdom service supports both GitHub and Red Hat authentication. GitHub authe
 GitHub users, or limited to a specific team. The following directions are for configuring the service to grant
 access to any GitHub user.
 
+### Authenticate with GitHub
+
 To test GitHub authentication locally, you will need to create a new OAuth App at
 https://github.com/settings/developers. Provide an Authorization callback URL of
 http://localhost:8000/complete/github/. Export Update `SOCIAL_AUTH_GITHUB_KEY` and
@@ -333,6 +335,24 @@ http://localhost:8000/complete/github/. Export Update `SOCIAL_AUTH_GITHUB_KEY` a
 both of which are provided after creating a new OAuth App. If you are running with the
 compose [development environment](#development-environment) described below, put these
 env vars in a .env file in the `tools/docker-compose` directory.
+
+### Authenticate with Red Hat
+
+To test Red Hat authentication locally, you will need to export 3 variables before start the application.
+
+```bash
+export SOCIAL_AUTH_OIDC_OIDC_ENDPOINT="https://sso.redhat.com/auth/realms/redhat-external"
+export SOCIAL_AUTH_OIDC_KEY="ansible-wisdom-staging"
+export SOCIAL_AUTH_OIDC_SECRET=secret_value
+```
+
+If, to run the application, you are using Makefile first two variables will be set automatically.
+Third one should be set manually in either way: you are using Makefile or running
+application directly. To get the secret value go to [AWS Secret Manager](https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws)
+select `it-cloud-aws-ansible-wisdom-staging` to log in. Click on `Secrets Manager` than `wisdom` and at last
+`Retrieve secret value` than copy value of `SOCIAL_AUTH_OIDC_SECRET`.
+
+### After authentication
 
 Once you start the app, navigate to http://localhost:8000/ to log in. Once authenticated, you will be presented with an
 authentication token that will be configured in VS Code (coming soon) to access the task prediction API.


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Make it easier to configure Red Hat log in to wisdom service for local tests/devs.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Check steps how to find SECRET value
2. Set up SECRET value and run the service using Makefile
3. Red Hat login should work as expected.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
  - No production code/configurations are changed.
