### PR TITLE
make platform explicit for multi OS support

### DIFF
--- a/tools/docker-compose/compose-backends.yaml
+++ b/tools/docker-compose/compose-backends.yaml
@@ -1,6 +1,7 @@
 version: "3.8"
 services:
   db:
+    platform: linux/amd64
     image: docker.io/library/postgres:alpine
     environment:
       - POSTGRES_PASSWORD=wisdom
@@ -16,6 +17,7 @@ services:
     ports:
       - "5432:5432"
   prometheus:
+    platform: linux/amd64
     image: docker.io/prom/prometheus
     command:
       - --config.file=/opt/prometheus/prometheus.yaml
@@ -27,6 +29,7 @@ services:
     networks:
       - dbnet
   grafana:
+    platform: linux/amd64
     image: docker.io/grafana/grafana:7.5.17
     environment:
       - GF_LOG_LEVEL=warn

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -1,7 +1,8 @@
 version: "3.8"
 services:
-  django: &django
+  django:
     user: "1000"
+    platform: linux/amd64
     build:
       context: $PWD
       dockerfile: wisdom-service.Containerfile
@@ -65,6 +66,7 @@ services:
     networks:
       - dbnet
   db:
+    platform: linux/amd64
     image: docker.io/library/postgres:alpine
     environment:
       - POSTGRES_PASSWORD=wisdom
@@ -80,6 +82,7 @@ services:
     ports:
       - "5432:5432"
   prometheus:
+    platform: linux/amd64
     image: docker.io/prom/prometheus
     command:
       - --config.file=/opt/prometheus/prometheus.yaml
@@ -91,6 +94,7 @@ services:
     networks:
       - dbnet
   grafana:
+    platform: linux/amd64
     image: docker.io/grafana/grafana:7.5.17
     environment:
       - GF_LOG_LEVEL=warn

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi:latest
 
 ARG IMAGE_TAGS=image-tags-not-defined
 ARG GIT_COMMIT=git-commit-not-defined


### PR DESCRIPTION
## Description
Specify the target platform so we can run containers on platforms that aren't supported by some of our dependencies (specifically Mac M1+ `aarch64` and torch CPU support).

Hardcoding should be safe because:

- We only run on linux/amd64 today in all our hosted environments
- We don't have a plan for moving to other architectures for our cluster nodes in the near term
- We can't move to other architectures for the same reasons that make running a local dev environment on these other architectures difficult and slow.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. `podman-compose -f tools/docker-compose/compose.yaml up`
3. Ensure all containers are started and the app runs as expected

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
