### PR TITLE
AAP-17820: Consume new ARI version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 # to properly pull a version of aiohttp > 3.8.5.
 aiohttp==3.8.6
 ansible-anonymizer==1.4.2
-ansible-risk-insight==0.2.2
+ansible-risk-insight==0.2.4
 ansible-lint==6.20.3
 boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ ansible-core==2.15.0
     #   ansible-lint
 ansible-lint==6.20.3
     # via -r requirements.in
-ansible-risk-insight==0.2.2
+ansible-risk-insight==0.2.4
     # via -r requirements.in
 argparse==1.4.0
     # via uwsgi-readiness-check


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-17820

## Description
Upgrade to ARI 0.2.4

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
