### PR TITLE
Upgrade cryptography to 41.0.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ ansible-risk-insight==0.2.4
 ansible-lint==6.20.3
 boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated
-cryptography==41.0.4
+cryptography==41.0.6
 datasets==2.10.1
 Django==4.2.7
 django-extensions==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ click==8.1.3
     # via
     #   black
     #   nltk
-cryptography==41.0.4
+cryptography==41.0.6
     # via
     #   -r requirements.in
     #   ansible-core


### PR DESCRIPTION
This PR does not need a corresponding Jira item.
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
cryptography | 41.0.4 | GHSA-jfhm-5ghh-2f97 | 41.0.6 | ### Summary  Calling `load_pem_pkcs7_certificates` or `load_der_pkcs7_certificates` could lead to a NULL-pointer dereference and segfault.  ### PoC Here is a Python code that triggers the issue: ```python from cryptography.hazmat.primitives.serialization.pkcs7 import load_der_pkcs7_certificates, load_pem_pkcs7_certificates  pem_p7 = b""" -----BEGIN PKCS7----- MAsGCSqGSIb3DQEHAg== -----END PKCS7----- """  der_p7 = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"  load_pem_pkcs7_certificates(pem_p7) load_der_pkcs7_certificates(der_p7) ```  ### Impact Exploitation of this vulnerability poses a serious risk of Denial of Service (DoS) for any application attempting to deserialize a PKCS7 blob/certificate. The consequences extend to potential disruptions in system availability and stability.
```