### PR TITLE
flake8: ignore two tests Superfluous because of Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -40,7 +40,9 @@ extend-ignore =
   # Safeguard neutering of flake8-quotes : https://github.com/zheller/flake8-quotes/issues/105
   Q,
   # annoy black by allowing white space before : https://github.com/psf/black/issues/315
-  E203
+  E203,
+  E221,
+  E231
 
 # Accessibility/large fonts and PEP8 unfriendly:
 max-line-length = 100


### PR DESCRIPTION
The two errors are already avoid thanks tothe Black formatter.

- E231 missing whitespace after ':'
- E221 multiple spaces before operator

The remaining errors are only false positives.