### PR TITLE
mesh_client: adjust the name of the fake backends

### DIFF
--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import random
+import secrets
 import time
 
 import requests
@@ -11,7 +11,7 @@ from .base import ModelMeshClient
 logger = logging.getLogger(__name__)
 
 
-class MockClient(ModelMeshClient):
+class DummyClient(ModelMeshClient):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
         self.session = requests.Session()
@@ -19,9 +19,12 @@ class MockClient(ModelMeshClient):
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
         model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
-        logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'mock' !!!!")
+        logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
-        jitter = random.random() if settings.MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER else 1
+        if settings.MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER:
+            jitter: float = secrets.randbelow(1000) * 0.001
+        else:
+            jitter: float = 1.0
         time.sleep((settings.MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter) / 1000)
         response_body = json.loads(settings.MOCK_MODEL_RESPONSE_BODY)
         response_body['model_id'] = '_'

--- a/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
@@ -3,41 +3,41 @@ from unittest import mock
 import requests
 from django.test import SimpleTestCase, override_settings
 
-from ..mock_client import MockClient
+from ..dummy_client import DummyClient
 
-latency = 300
+latency = 3000
 body = {"test": "true"}
-random_value = 10
+random_value = 1000
 
 
 @override_settings(MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC=latency)
 @override_settings(MOCK_MODEL_RESPONSE_BODY=body)
-class TestMockClient(SimpleTestCase):
+class TestDummyClient(SimpleTestCase):
     def test_init(self):
         url = "https://redhat.com"
         session = requests.Session()
         with mock.patch("requests.Session", return_value=session):
-            client = MockClient(inference_url=url)
+            client = DummyClient(inference_url=url)
             self.assertEqual(client._inference_url, url)
             self.assertEqual(client.session, session)
             self.assertEqual(client.headers["Content-Type"], "application/json")
 
     @override_settings(MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER=True)
     @mock.patch("time.sleep")
-    @mock.patch("random.random")
+    @mock.patch("secrets.randbelow")
     @mock.patch("json.loads")
-    def test_infer_with_jitter(self, loads, random, sleep):
-        client = MockClient(inference_url="https://example.com")
-        random.return_value = random_value
+    def test_infer_with_jitter(self, loads, randbelow, sleep):
+        client = DummyClient(inference_url="https://example.com")
+        randbelow.return_value = random_value
         client.infer(model_input="input")
-        sleep.assert_called_once_with((latency * random_value) / 1000)
+        sleep.assert_called_once_with(latency / 1000)
         loads.assert_called_once_with(body)
 
     @override_settings(MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER=False)
     @mock.patch("time.sleep")
     @mock.patch("json.loads")
     def test_infer_without_jitter(self, loads, sleep):
-        client = MockClient(inference_url="https://ibm.com")
+        client = DummyClient(inference_url="https://ibm.com")
         client.infer(model_input="input")
         sleep.assert_called_once_with(latency / 1000)
         loads.assert_called_once_with(body)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -52,7 +52,7 @@ from test_utils import (
 DEFAULT_SUGGESTION_ID = uuid.uuid4()
 
 
-class DummyMeshClient(ModelMeshClient):
+class MockedMeshClient(ModelMeshClient):
     def __init__(
         self, test, payload, response_data, test_inference_match=True, rh_user_has_seat=False
     ):
@@ -462,7 +462,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -486,7 +486,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         self.user.rh_user_has_seat = True
         self.client.force_authenticate(user=self.user)
         mock_get_model_client.return_value = (
-            DummyMeshClient(self, payload, response_data, rh_user_has_seat=True),
+            MockedMeshClient(self, payload, response_data, rh_user_has_seat=True),
             None,
         )
 
@@ -528,7 +528,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         self.client.force_authenticate(user=self.user)
         # test_inference_match=False because anonymizer changes the prompt before calling WCA
         mock_get_model_client.return_value = (
-            DummyMeshClient(
+            MockedMeshClient(
                 self, payload, response_data, test_inference_match=False, rh_user_has_seat=True
             ),
             None,
@@ -560,7 +560,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -583,7 +583,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -604,7 +604,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -632,7 +632,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -653,7 +653,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -674,7 +674,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -697,7 +697,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -724,7 +724,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data),
+                MockedMeshClient(self, payload, response_data),
             ):
                 r = self.client.post(reverse('completions'), payload)
                 self.assertEqual(r.status_code, HTTPStatus.OK)
@@ -748,7 +748,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data),
+                MockedMeshClient(self, payload, response_data),
             ):
                 r = self.client.post(reverse('completions'), payload)
                 self.assertEqual(HTTPStatus.NO_CONTENT, r.status_code)
@@ -777,7 +777,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data),
+                MockedMeshClient(self, payload, response_data),
             ):
                 r = self.client.post(reverse('completions'), payload)
                 self.assertEqual(HTTPStatus.NO_CONTENT, r.status_code)
@@ -810,7 +810,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data),
+                MockedMeshClient(self, payload, response_data),
             ):
                 r = self.client.post(reverse('completions'), payload)
                 self.assertEqual(r.status_code, HTTPStatus.OK)
@@ -831,7 +831,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -860,7 +860,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             '_wca_client',
-            DummyMeshClient(self, payload, response_data, rh_user_has_seat=True),
+            MockedMeshClient(self, payload, response_data, rh_user_has_seat=True),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -885,7 +885,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             '_wca_client',
-            DummyMeshClient(self, payload, response_data, rh_user_has_seat=True),
+            MockedMeshClient(self, payload, response_data, rh_user_has_seat=True),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)
@@ -980,7 +980,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data, False),
+                MockedMeshClient(self, payload, response_data, False),
             ):
                 self.client.post(reverse('completions'), payload)
                 self.assertInLog('Create an account for james8@example.com', log)
@@ -999,7 +999,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload)

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -9,6 +9,7 @@ from users.authz_checker import AMSCheck, CIAMCheck, DummyCheck
 from ari import postprocessing
 
 from .api.aws.wca_secret_manager import AWSSecretManager, DummySecretManager
+from .api.model_client.dummy_client import DummyClient
 from .api.model_client.wca_client import DummyWCAClient, WCAClient
 
 logger = logging.getLogger(__name__)
@@ -42,10 +43,12 @@ class AiConfig(AppConfig):
             self.model_mesh_client = HttpClient(
                 inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
             )
-        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock":
-            from .api.model_client.mock_client import MockClient
-
-            self.model_mesh_client = MockClient(
+        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE in ["dummy", "mock"]:
+            if settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock":
+                logger.error(
+                    'ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock" is deprecated, use "dummy" instead'
+                )
+            self.model_mesh_client = DummyClient(
                 inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
             )
         else:

--- a/ansible_wisdom/ai/tests/test_apps.py
+++ b/ansible_wisdom/ai/tests/test_apps.py
@@ -1,6 +1,6 @@
+from ai.api.model_client.dummy_client import DummyClient
 from ai.api.model_client.grpc_client import GrpcClient
 from ai.api.model_client.http_client import HttpClient
-from ai.api.model_client.mock_client import MockClient
 from ai.api.model_client.wca_client import WCAClient
 from django.apps.config import AppConfig
 from django.test import override_settings
@@ -27,11 +27,11 @@ class TestAiApp(APITestCase):
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, HttpClient)
 
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='mock')
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='dummy')
     def test_mock_client(self):
         app_config = AppConfig.create('ai')
         app_config.ready()
-        self.assertIsInstance(app_config.model_mesh_client, MockClient)
+        self.assertIsInstance(app_config.model_mesh_client, DummyClient)
 
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     def test_enable_ari(self):

--- a/ansible_wisdom/healthcheck/tests/test_healthcheck.py
+++ b/ansible_wisdom/healthcheck/tests/test_healthcheck.py
@@ -135,7 +135,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
         return timestamp, dependencies
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_all_healthy(self):
         cache.clear()
         r = self.client.get(reverse('health_check'))
@@ -224,7 +224,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
                 'unavailable: An error occurred',
             )
 
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
     def test_health_check_model_mesh_mock(self):
         cache.clear()
@@ -234,7 +234,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
         for dependency in dependencies:
             self.assertTrue(is_status_ok(dependency['status']))
 
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @mock.patch('healthcheck.views.get_feature_flags')
     @mock.patch('ldclient.get')
@@ -253,7 +253,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
         for dependency in dependencies:
             self.assertTrue(is_status_ok(dependency['status']))
 
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
     @override_settings(ENABLE_HEALTHCHECK_MODEL_MESH=False)
     def test_health_check_model_mesh_mock_disabled(self):
@@ -272,7 +272,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
         self.assertEqual(healthcheck_views.get_feature_flags(), "return this")
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_aws_secret_manager_error(self):
         cache.clear()
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
@@ -297,7 +297,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
             )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(ENABLE_HEALTHCHECK_SECRET_MANAGER=False)
     def test_health_check_aws_secret_manager_disabled(self):
         cache.clear()
@@ -311,7 +311,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
                 self.assertTrue(is_status_ok(dependency['status']))
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_wca_token_error(self, *args):
         cache.clear()
         mock_wca_client = apps.get_app_config("ai").get_wca_client()
@@ -341,7 +341,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
             )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_wca_inference_error(self, *args):
         cache.clear()
         mock_wca_client = apps.get_app_config("ai").get_wca_client()
@@ -368,7 +368,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
             )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_wca_inference_generic_error(self, *args):
         cache.clear()
         mock_wca_client = apps.get_app_config("ai").get_wca_client()
@@ -398,7 +398,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
             )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(ENABLE_HEALTHCHECK_WCA=False)
     def test_health_check_wca_disabled(self):
         cache.clear()
@@ -413,7 +413,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
                 self.assertTrue(is_status_ok(dependency['status']))
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     def test_health_check_authorization_error(self, *args):
         cache.clear()
         apps.get_app_config('ai')._seat_checker.self_test = Mock(side_effect=HTTPError)
@@ -437,7 +437,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomLogAwareMixin
             )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
-    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="mock")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
     @override_settings(ENABLE_HEALTHCHECK_AUTHORIZATION=False)
     def test_health_check_authorization_disabled(self):
         cache.clear()

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -18,7 +18,7 @@ ANSIBLE_AI_MODEL_MESH_INFERENCE_URL = (
     f"{ANSIBLE_AI_MODEL_MESH_HOST}:{ANSIBLE_AI_MODEL_MESH_INFERENCE_PORT}"
 )
 
-ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http", "mock", "wca"] = (
+ANSIBLE_AI_MODEL_MESH_API_TYPE: Literal["grpc", "http", "dummy", "wca"] = (
     os.getenv("ANSIBLE_AI_MODEL_MESH_API_TYPE") or "http"
 )
 

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-from ai.api.tests.test_views import DummyMeshClient, WisdomServiceAPITestCaseBase
+from ai.api.tests.test_views import MockedMeshClient, WisdomServiceAPITestCaseBase
 from django.apps import apps
 from django.conf import settings
 from django.test import override_settings
@@ -46,7 +46,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, expected, response_data),
+            MockedMeshClient(self, expected, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(reverse('completions'), payload, format='json')
@@ -163,7 +163,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
             with patch.object(
                 apps.get_app_config('ai'),
                 'model_mesh_client',
-                DummyMeshClient(self, payload, response_data),
+                MockedMeshClient(self, payload, response_data),
             ):
                 with self.assertLogs(logger='root', level='DEBUG') as log:
                     r = self.client.post(reverse('completions'), payload, format='json')
@@ -226,7 +226,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
         with patch.object(
             apps.get_app_config('ai'),
             'model_mesh_client',
-            DummyMeshClient(self, payload, response_data),
+            MockedMeshClient(self, payload, response_data),
         ):
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 self.client.post(reverse('completions'), payload, format='json')


### PR DESCRIPTION
https://github.com/ansible/ansible-wisdom-service/pull/720 harmonized the way we name our fake backends.

- Dummy is for the fake backend that can be instanced during the run time. We enable them
  setting the value `dummy` for the associated `*BACKEND_TYPE` in the configuration.
- Anything called Mock or Mocked should only be used in the unit-tests

Also, to address a SonarCloud error, the PR adjusts the code of the
DummyClient to avoid the use of random.random().
Note: The original unit-test was wrong, the value returned by `random.random()`
is a float between `0` and `1`, not `10`.