### PR TITLE
dummy backend: accept an envvar with an empty string

### DIFF
--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -66,18 +66,17 @@ AUTHZ_BACKEND_TYPE = os.getenv("AUTHZ_BACKEND_TYPE") or "dummy"
 # AUTHZ_DUMMY_USERS_WITH_SEAT=gleboude1@redhat.com
 # AUTHZ_DUMMY_RH_ORG_ADMINS=gleboude1@redhat.com
 # note: "*" means that all the users from org with a subscription.
-AUTHZ_DUMMY_USERS_WITH_SEAT = os.getenv("AUTHZ_DUMMY_USERS_WITH_SEAT") or "gleboude1@redhat.com"
-AUTHZ_DUMMY_RH_ORG_ADMINS = os.getenv("AUTHZ_DUMMY_RH_ORG_ADMINS") or "gleboude1@redhat.com"
+AUTHZ_DUMMY_USERS_WITH_SEAT = os.getenv("AUTHZ_DUMMY_USERS_WITH_SEAT", "")
+AUTHZ_DUMMY_RH_ORG_ADMINS = os.getenv("AUTHZ_DUMMY_RH_ORG_ADMINS", "")
 # You can get your account number on this page
 # https://www.redhat.com/wapps/ugc/protected/account.html
 # note: "*" means that all the orgs have a subscription.
-AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION = os.getenv("AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION") or "11009103"
+AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION = os.getenv("AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION", "")
 
-
-WCA_SECRET_BACKEND_TYPE = os.getenv("WCA_SECRET_BACKEND_TYPE") or "dummy"  # or aws_sm
+WCA_SECRET_BACKEND_TYPE = os.getenv("WCA_SECRET_BACKEND_TYPE", "dummy")  # or aws_sm
 # a list of key:value with a , separator. key is the orgid, value is the secret.
 # when a secret with the string "valid", it means the backend will accept it has
 # a valid string. e.g:
 # WCA_SECRET_DUMMY_SECRETS=1009103:valid,11009104:not-valid
-WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS") or ""
-WCA_CLIENT_BACKEND_TYPE = os.getenv("WCA_CLIENT_BACKEND_TYPE") or "dummy"  # or wcaclient
+WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
+WCA_CLIENT_BACKEND_TYPE = os.getenv("WCA_CLIENT_BACKEND_TYPE", "dummy")  # or wcaclient


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-17822>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Right now, if I set `AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION`, I will
end-up with `11009103`. There is no way to get an empty string instead.

This is what the PR address.

## Testing

Use an empty `AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION` environment variable.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
