### PR TITLE
Do not use ANSIBLE_AI_MODEL_NAME as default for segment events w/o model names

### DIFF
--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -22,8 +22,8 @@ def send_segment_event(event: Dict[str, Any], event_name: str, user: User) -> No
     timestamp = timezone.now().isoformat()
 
     if 'modelName' not in event:
-        # we should probably fail this, it shouldn't happen, right?
-        event['modelName'] = settings.ANSIBLE_AI_MODEL_NAME
+        # Set an empty string if model name is not found in the event
+        event['modelName'] = ''
 
     if 'imageTags' not in event:
         event['imageTags'] = version_info.image_tags

--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -67,16 +67,13 @@ class SegmentMiddleware:
                     suggestion_id = str(uuid.uuid4())
                 context = request_data.get('context')
                 prompt = request_data.get('prompt')
+                model_name = request_data.get('model', '')
                 metadata = request_data.get('metadata', {})
                 promptType = getattr(request, '_prompt_type', None)
 
                 predictions = None
                 message = None
                 response_data = getattr(response, 'data', {})
-
-                # this modelName default will be correct unless we're using launchdarkly
-                # but needs to be revisited with commercial multimodel.
-                model_name = settings.ANSIBLE_AI_MODEL_NAME
 
                 if isinstance(response_data, dict):
                     predictions = response_data.get('predictions')


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18684>
<!-- This PR does not need a corresponding Jira item. -->

## Description
In the inference (completion) API processing with a WCA client, a model ID cannot be retrieved if a WCA key is not found. However, still the segment events contain model ID, which was set in the ANSIBLE_AI_MODEL_NAME environment variable. If the request/response (including exceptions) do not contain a model ID, we should not include it in segment events.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the provided unit test `ai.api.tests.test_views.TestCompletionWCAView.test_wca_completion_seated_user_missing_api_key()`

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Executed the unit test listed above and run some manual tests with local wisdom-service by modifying `WCAClient.get_api_key()` to raise `WcaKeyNotFound`

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
