### PR TITLE
pr build images has another tag pr-<pr-number>

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -25,7 +25,7 @@ jobs:
       id: tag_name
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "IMAGE_TAGS=pr-${{ github.event.pull_request.number }}.$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAGS=pr-${{ github.event.pull_request.number }}.$(date +'%Y%m%d%H%M') pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "LABEL quay.expires-after=3d" >> ./wisdom-service.Containerfile # tag expires in 3 days
         elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
           echo "IMAGE_TAGS=${{ github.ref_name }}-$( git rev-parse --short HEAD ).$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-8491
<!-- This PR does not need a corresponding Jira item. -->

## Description
Adding a stable tag to PR based images: `pr-<pr-number`

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. [quay.io](https://quay.io/repository/ansible/wisdom-service?tab=tags) will now have an additional tag `pr-<pr-number`

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
