### PR TITLE
support enhanced context  with multi-task prompts

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -6,6 +6,18 @@ from ruamel.yaml import YAML, scalarstring
 
 logger = logging.getLogger(__name__)
 
+"""
+The code below causes any yaml.dump calls to dump None
+as blank rather than "null"
+"""
+
+
+def represent_none(self, _):
+    return self.represent_scalar('tag:yaml.org,2002:null', '')
+
+
+yaml.add_representer(type(None), represent_none)
+
 
 class AnsibleDumper(yaml.Dumper):
     """
@@ -132,41 +144,60 @@ def expand_vars_files(data, ansible_file_type, additional_context):
 
 def preprocess(context, prompt, ansible_file_type="playbook", additional_context=None):
     """
+    Formatting and normalization performed in this function is redundant in WCA case because
+    it is already handled on the WCA side. We can safely skip it for multitask scenarios,
+    which we know are WCA. No need to adopt to suppot both single and multitask.
+
+    We call normalize_yaml regardless of single or multi in order to process the
+    additional_context content. We need to hold the original multi-task prompt because
+    pyyaml does not preserve comments.
+    """
+    multi_task = is_multi_task_prompt(prompt)
+    original_multi_task_prompt = prompt
+
+    """
     Add a newline between the input context and prompt in case context doesn't end with one
-    Format and split off the last line as the prompt
-    Append a newline to both context and prompt (as the model expects)
     """
     formatted = normalize_yaml(f'{context}\n{prompt}', ansible_file_type, additional_context)
 
     if formatted is not None:
         logger.debug(f'initial user input {context}\n{prompt}')
 
-        segs = formatted.rsplit('\n', 2)  # Last will be the final newline
-        if len(segs) == 3:
-            context = segs[0] + '\n'
-            prompt = segs[1]
-        elif len(segs) == 2:  # Context is empty
-            context = ""
-            prompt = segs[0]
+        if multi_task:
+            context = formatted
+            prompt = original_multi_task_prompt
         else:
-            logger.warning(f"preprocess failed - too few new-lines in: {formatted}")
+            """
+            Format and split off the last line as the prompt
+            Append a newline to both context and prompt (as the model expects)
+            """
+            segs = formatted.rsplit('\n', 2)  # Last will be the final newline
+            if len(segs) == 3:
+                context = segs[0] + '\n'
+                prompt = segs[1]
+            elif len(segs) == 2:  # Context is empty
+                context = ""
+                prompt = segs[0]
+            else:
+                logger.warning(f"preprocess failed - too few new-lines in: {formatted}")
 
-            logger.debug(f'preprocessed user input {context}\n{prompt}')
+            prompt = handle_spaces_and_casing(prompt)
 
-        prompt = handle_spaces_and_casing(prompt)
+            # TODO - We can probably ditch this since it's covered by
+            # CompletionRequestSerializer.validate_extracted_prompt
+            # Make sure the prompt is in the form "  - name: a string description."
+            prompt_list = yaml.load(prompt, Loader=yaml.SafeLoader)
+            if (
+                not isinstance(prompt_list, list)
+                or len(prompt_list) != 1
+                or not isinstance(prompt_list[0], dict)
+                or len(prompt_list[0]) != 1
+                or 'name' not in prompt_list[0]
+                or not isinstance(prompt_list[0]['name'], str)
+            ):
+                raise InvalidPromptException()
 
-        # Make sure the prompt is in the form "  - name: a string description."
-        prompt_list = yaml.load(prompt, Loader=yaml.SafeLoader)
-        if (
-            not isinstance(prompt_list, list)
-            or len(prompt_list) != 1
-            or not isinstance(prompt_list[0], dict)
-            or len(prompt_list[0]) != 1
-            or 'name' not in prompt_list[0]
-            or not isinstance(prompt_list[0]['name'], str)
-        ):
-            raise InvalidPromptException()
-
+        logger.debug(f'preprocessed user input {context}\n{prompt}')
     return context, prompt
 
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
@@ -40,18 +40,17 @@ def completion_pre_process(context: CompletionContext):
     # fmtr.preprocess() performs:
     #
     #   1. Insert additional context (variables), and
-    #   2. Formatting prompt/context YAML data,
+    #   2. Formatting/normalizing prompt/context YAML data,
     #
-    # When non-empty additional context is given, fmtr.preprocess() needs to
-    # be called. Otherwise, it is called when a non-multi task prompt is
-    # specified because multi-task prompts are supported by WCA only and WCA
-    # contains its own formatter for 2.
+    # Calling fmtr.preprocess for of (2) is redundant in WCA case
+    # because WCA is already doing this. However, enhanced context
+    # support also relies on this preprocess step, so we will
+    # always call fmtr.preprocess, regardless of model server.
     #
-    if additionalContext or not multi_task:
-        ansibleFileType = context.metadata.get("ansibleFileType", "playbook")
-        context.payload.context, context.payload.prompt = fmtr.preprocess(
-            cc, cp, ansibleFileType, additionalContext
-        )
+    ansibleFileType = context.metadata.get("ansibleFileType", "playbook")
+    context.payload.context, context.payload.prompt = fmtr.preprocess(
+        cc, cp, ansibleFileType, additionalContext
+    )
 
 
 class PreProcessStage(PipelineElement):

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -304,7 +304,6 @@ class CompletionPreProcessTest(TestCase):
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
     def test_additional_context_with_commercial_user_and_multi_task_prompt(self):
         payload = copy.deepcopy(PLAYBOOK_PAYLOAD)
-        payload["metadata"]["additionalContext"] = {}
         # Replace the last line of the prompt with a multi-task prompt that includes '&'
         payload["prompt"] = (
             "\n".join(payload["prompt"].split("\n")[:-2]) + "\n    # do this & do that\n"
@@ -312,7 +311,7 @@ class CompletionPreProcessTest(TestCase):
         self.call_completion_pre_process(
             payload,
             True,
-            PLAYBOOK_CONTEXT_WITHOUT_FORMATTING,
+            PLAYBOOK_CONTEXT_WITH_VARS,
         )
 
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-18749

## Description
Currently with enhanced context support enabled (ENABLE_ADDITIONAL_CONTEXT="True"), multi-task completion requests fail due to a bug in pre-processing. These requests were being sent through fmtr.preprocess, which had not been updated to support multi-task. This PR updates fmtr.preprocess to support multitask.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service with `ENABLE_ADDITIONAL_CONTEXT: "True"`
3. Make a multi-task completion request

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Tested single and mutli task requests in playbook files. Tested multitask in a tasks file. Tested with and without adding `vars_files` field which would cause some additional context to be populated. Note that adding some additional context when you dont' have an existing `vars` field in your playbook will fail. This is tracked as a different bug (https://issues.redhat.com/browse/AAP-18756) and will be fixed separately.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
This code is good to move forward, but `ENABLE_ADDITIONAL_CONTEXT` is not ready for production. More testing is needed in staging. 
