### PR TITLE
fix additional context with no pre-existing vars

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -68,6 +68,10 @@ class AnsibleDumper(yaml.Dumper):
             return "'"
         return self.preferred_quote_
 
+    # Prevent aliases when enhanced context adds same vars to multiple plays
+    def ignore_aliases(self, data):
+        return True
+
 
 class InvalidPromptException(Exception):
     pass
@@ -149,7 +153,7 @@ def preprocess(context, prompt, ansible_file_type="playbook", additional_context
     """
     Formatting and normalization performed in this function is redundant in WCA case because
     it is already handled on the WCA side. We can safely skip it for multitask scenarios,
-    which we know are WCA. No need to adopt to suppot both single and multitask.
+    which we know are WCA. No need to adopt to support both single and multitask.
 
     We call normalize_yaml regardless of single or multi in order to process the
     additional_context content. We need to hold the original multi-task prompt because


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issues: 
https://issues.redhat.com/browse/AAP-18756
https://issues.redhat.com/browse/AAP-18768

## Description
When you have a playbook containing `vars_files` but no `vars`, with enhanced context enabled, the variables from the vars_files get added to a new `vars` field that is placed at the bottom of the playbook, which causes the prompt to NOT be placed inside the `tasks` field. We need to ensure the `tasks` field is always last in the dict so yaml.dump puts it last.

Second fix added:
When a playbook contains two plays that reference the same vars_files and don't contain any vars, yaml.dump uses an [alias](https://ttl255.com/yaml-anchors-and-aliases-and-how-to-disable-them/) for the second instance of the vars. This PR fixes that.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service with ENABLE_ADDITIONAL_CONTEXT: "True"
3. Create this playbook:
```
---
- name: Ansible Ansible
  hosts: all
  vars_files:
    - external_vars.yml
  tasks:
    - name: print hello
```
4. Create a file external_vars.yml and add a couple variables.
5. Request a completion for the playbook in step 3.
6. The suggestion should succeed.
7. Create this playbook and request a suggestion:
```
---
- name: Ansible Ansible
  hosts: all
  vars_files:
    - external_vars.yml
  tasks:
    - name: print hello

      ansible.builtin.debug:
        msg: Hello   
- name: Ansible Ansible
  hosts: all
  vars_files:
    - external_vars.yml
  tasks:
    - name: print goodbye
```
8. The suggestion should succeed.

### Scenarios tested
Unit test added plus manual steps described above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
This code is good to move forward, but `ENABLE_ADDITIONAL_CONTEXT` is not ready for production. More testing is needed in staging.