### PR TITLE
non-seated user of WCA-ready org should not default to TP model

### DIFF
--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -47,13 +47,14 @@ class BlockUserWithoutSeatAndWCAReadyOrg(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        if user.organization_id is None:
+        if user.organization is None:
             # We accept the Community users, the won't have access to WCA
             return True
         if user.rh_user_has_seat is True:
             return True
+
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
-        org_has_api_key = secret_manager.secret_exists(user.organization_id, Suffixes.API_KEY)
+        org_has_api_key = secret_manager.secret_exists(user.organization.id, Suffixes.API_KEY)
         return not org_has_api_key
 
 
@@ -68,10 +69,12 @@ class BlockUserWithSeatButWCANotReady(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        if user.organization_id is None:
+        if user.organization is None:
             # We accept the Community users, the won't have access to WCA
             return True
-        secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
+        if user.rh_user_has_seat is not True:
+            return True
 
-        org_has_api_key = secret_manager.secret_exists(user.organization_id, Suffixes.API_KEY)
-        return user.rh_user_has_seat and org_has_api_key
+        secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
+        org_has_api_key = secret_manager.secret_exists(user.organization.id, Suffixes.API_KEY)
+        return org_has_api_key

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -129,7 +129,6 @@ class WisdomServiceAPITestCaseBase(APITransactionTestCase, WisdomServiceLogAware
 
 
 @override_settings(WCA_CLIENT_BACKEND_TYPE="wcaclient")
-@modify_settings()
 class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def stub_wca_client(
         self,
@@ -168,6 +167,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         self.assertFalse(isinstance(model_client, WCAClient))
         self.assertIsNone(model_name)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion(self):
         self.user.rh_user_has_seat = True
@@ -190,6 +190,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             model_client.session.post.call_args.kwargs['json']['model_id'], 'org-model-id'
         )
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_wca_completion_seated_user_missing_api_key(self):
@@ -217,6 +218,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
                 elif event['event'] == 'prediction':
                     self.assertEqual(properties['problem'], 'WcaKeyNotFound')
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_missing_model_id(self):
         self.user.rh_user_has_seat = True
@@ -234,6 +236,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             self.assertInLog("A WCA Model ID was expected but not found", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_garbage_model_id(self):
         self.user.rh_user_has_seat = True
@@ -251,6 +254,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             self.assertInLog("WCA Model ID is invalid", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_invalid_model_id_for_api_key(self):
         self.user.rh_user_has_seat = True
@@ -267,6 +271,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             self.assertInLog("WCA Model ID is invalid", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_empty_response(self):
         self.user.rh_user_has_seat = True
@@ -283,6 +288,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.NO_CONTENT)
             self.assertInLog("WCA returned an empty response", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_cloudflare_rejection(self):
         self.user.rh_user_has_seat = True
@@ -302,6 +308,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
             self.assertInLog("Cloudflare rejected the request", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_wca_completion_seated_user_model_id_error(self):
         self.user.rh_user_has_seat = True
@@ -320,6 +327,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             self.assertInLog("WCA Model ID is invalid", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=20)
     def test_wca_completion_timeout_single_task(self):
@@ -340,6 +348,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertEqual(model_client.session.post.call_args[1]['timeout'], 20)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=20)
     def test_wca_completion_timeout_multi_task(self):
@@ -361,6 +370,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertEqual(model_client.session.post.call_args[1]['timeout'], 40)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_wca_completion_timed_out(self):
@@ -390,6 +400,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
                     self.assertTrue(properties['exception'])
                     self.assertEqual(properties['problem'], 'ModelTimeoutError')
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_wca_completion_request_id_correlation_failure(self):
@@ -428,6 +439,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertInLog(f"suggestion_id: '{DEFAULT_SUGGESTION_ID}'", log)
             self.assertInLog(f"x_request_id: '{x_request_id}'", log)
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @patch('main.middleware.send_segment_event')
     def test_wca_compeletion_segment_event_with_invalid_modelid_error(

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -46,7 +46,7 @@ from .data.data_model import (
     ContentMatchResponseDto,
 )
 from .model_client.exceptions import ModelTimeoutError
-from .permissions import AcceptedTermsPermission
+from .permissions import AcceptedTermsPermission, BlockUserWithoutSeatAndWCAReadyOrg
 from .pipelines.common import BaseWisdomAPIException
 from .serializers import (
     AnsibleContentFeedback,
@@ -103,6 +103,7 @@ class Completions(APIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
+        BlockUserWithoutSeatAndWCAReadyOrg,
     ]
     required_scopes = ['read', 'write']
 

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -46,7 +46,11 @@ from .data.data_model import (
     ContentMatchResponseDto,
 )
 from .model_client.exceptions import ModelTimeoutError
-from .permissions import AcceptedTermsPermission, BlockUserWithoutSeatAndWCAReadyOrg
+from .permissions import (
+    AcceptedTermsPermission,
+    BlockUserWithoutSeatAndWCAReadyOrg,
+    BlockUserWithSeatButWCANotReady,
+)
 from .pipelines.common import BaseWisdomAPIException
 from .serializers import (
     AnsibleContentFeedback,
@@ -104,6 +108,7 @@ class Completions(APIView):
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
         BlockUserWithoutSeatAndWCAReadyOrg,
+        BlockUserWithSeatButWCANotReady,
     ]
     required_scopes = ['read', 'write']
 

--- a/ansible_wisdom/main/exception_handler.py
+++ b/ansible_wisdom/main/exception_handler.py
@@ -1,3 +1,4 @@
+import rest_framework.exceptions
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
@@ -19,5 +20,10 @@ def exception_handler_with_error_type(exc, context):
         # Add error type if specified
         if hasattr(exc, 'error_type'):
             response.error_type = exc.error_type
+
+        # We want to return the 'message' and the 'code' to the client to be
+        # able to properly present the error to the user.
+        if isinstance(exc, rest_framework.exceptions.PermissionDenied):
+            response.data = exc.get_full_details()
 
     return response

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -19,9 +19,10 @@
   {% endif %}
 {% endif %}
 
+
 {% if user.is_authenticated %}
   {% if user.rh_org_has_subscription %}
-    {% if not user.rh_user_has_seat %}
+    {% if not user.rh_user_has_seat and not org_has_api_key %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
@@ -42,7 +43,22 @@
       <div class="pf-c-empty-state">
         <div class="pf-c-empty-state__content">
 
-{% if user.is_authenticated and user.rh_org_has_subscription and user.rh_user_has_seat and not org_has_api_key and not user.rh_user_is_org_admin %}
+{# https://issues.redhat.com/browse/AAP-18386 #}
+{% if user.is_authenticated and user.rh_org_has_subscription and not user.rh_user_is_org_admin and org_has_api_key and not user.rh_user_has_seat %}
+          <span class="pf-c-icon pf-m-xl pf-m-inline">
+            <span class="pf-c-icon__content  pf-m-danger">
+              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            </span>
+          </span>
+
+          <h1 class="pf-c-title pf-m-lg">
+            You do not have a licensed seat for Ansible Lightspeed and your organization has configured a commercial model.
+          </h1>
+             <div style="padding: 15px">
+              <p>Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.
+            </div>
+
+{% elif user.is_authenticated and user.rh_org_has_subscription and user.rh_user_has_seat and not org_has_api_key and not user.rh_user_is_org_admin %}
           <span class="pf-c-icon pf-m-xl pf-m-inline">
             <span class="pf-c-icon__content  pf-m-danger">
               <i class="fas fa-exclamation-circle" aria-hidden="true"></i>

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -79,7 +79,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
 
 
 @override_settings(WCA_SECRET_BACKEND_TYPE='dummy')
-@override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
+@override_settings(WCA_SECRET_DUMMY_SECRETS='')
 @patch.object(boto3, "client", Mock())
 class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     def setUp(self):
@@ -92,7 +92,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.user.delete()
         super().tearDown()
 
-    @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:none')
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='')
     @patch.object(users.models.User, "rh_org_has_subscription", True)
     @patch.object(users.models.User, "rh_user_has_seat", False)
     def test_rh_user_without_seat_and_no_secret(self):
@@ -113,6 +113,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "but your administrator has not configured the service")
         self.assertNotContains(response, "Admin Portal")
 
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
     @patch.object(users.models.User, "rh_org_has_subscription", True)
     @patch.object(users.models.User, "rh_user_has_seat", True)
     def test_rh_user_with_a_seat_and_with_secret(self):
@@ -122,6 +123,17 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(
             response, "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant</h1>"
         )
+        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertNotContains(response, "Admin Portal")
+
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
+    @patch.object(users.models.User, "rh_org_has_subscription", True)
+    @patch.object(users.models.User, "rh_user_has_seat", False)
+    def test_rh_user_with_no_seat_and_with_secret(self):
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Role: licensed user")
+        self.assertContains(response, "your organization has configured a commercial model.")
         self.assertNotContains(response, "pf-c-alert__title")
         self.assertNotContains(response, "Admin Portal")
 

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -34,13 +34,9 @@ class HomeView(TemplateView):
         except WcaSecretManagerMissingCredentialsError:
             return context
 
-        if (
-            self.request.user.is_authenticated
-            and self.request.user.rh_org_has_subscription
-            and self.request.user.organization
-        ):
-            org_has_api_key = bool(
-                secret_manager.get_secret(self.request.user.organization.id, Suffixes.API_KEY)
+        if self.request.user.is_authenticated and self.request.user.rh_org_has_subscription:
+            org_has_api_key = secret_manager.secret_exists(
+                self.request.user.organization.id, Suffixes.API_KEY
             )
             context["org_has_api_key"] = org_has_api_key
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18386>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->


Do not default to TP model when end-user is in an org with model settings configured,
but no seat assignment.

## Testing

Set-up your environment like this, here `11009103` is your organization id.

```
set -x AUTHZ_BACKEND_TYPE "dummy"
set -x AUTHZ_DUMMY_USERS_WITH_SEAT ""
set -x AUTHZ_DUMMY_RH_ORG_ADMINS ""
# You can get your account number on this page
# https://www.redhat.com/wapps/ugc/protected/account.html
set -x AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION "11009103"

set -x WCA_CLIENT_BACKEND_TYPE "dummy"
set -x WCA_SECRET_BACKEND_TYPE "dummy"
set -x WCA_SECRET_DUMMY_SECRETS "11009103:valid"
```
The VSCode integration can be tested by rebuilding the extension with https://github.com/ansible/vscode-ansible/pull/1024.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
