### PR TITLE
Var expansion issue with the "other" file type

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -139,7 +139,8 @@ def expand_vars_files(data, ansible_file_type, additional_context):
         "tasks_in_role": expand_vars_tasks_in_role,
         "tasks": expand_vars_tasks,
     }
-    expand_vars_files[ansible_file_type](data, additional_context)
+    if ansible_file_type in expand_vars_files:
+        expand_vars_files[ansible_file_type](data, additional_context)
 
 
 def preprocess(context, prompt, ansible_file_type="playbook", additional_context=None):

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -345,3 +345,13 @@ class CompletionPreProcessTest(TestCase):
             True,
             TASKS_CONTEXT_WITHOUT_VARS,
         )
+
+    @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
+    def test_other_ansible_type(self):
+        payload = copy.deepcopy(TASKS_PAYLOAD)
+        payload["metadata"]["ansibleFileType"] = "other"
+        self.call_completion_pre_process(
+            payload,
+            True,
+            TASKS_CONTEXT_WITHOUT_VARS,
+        )


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18850>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Licensed user cannot get completion suggestions if ansible file type is "other" due to an issue in variable expansion.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
See the Steps to Reproduce section in [AAP-18850](https://issues.redhat.com/browse/AAP-18850).  Also a unit test is included in this PR.

### Steps to test
See the Steps to Reproduce section in [AAP-18850](https://issues.redhat.com/browse/AAP-18850).  

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
A unit test is included in the PR.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
