### PR TITLE
add troubleshooting step for OOM building django container

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,26 @@ write temporary data in it:
 chmod -R 777 ari/
 ```
 
+If your django container build fails with the following error, you've
+probably run out of memory running webpack.
+```bash
+STEP 30/46: RUN npm --prefix /tmp/ansible_wisdom_console_react run build
+
+> admin-portal@0.1.0 build
+> node scripts/build.js
+
+Creating an optimized production build...
+npm ERR! path /tmp/ansible_wisdom_console_react
+npm ERR! command failed
+npm ERR! signal SIGKILL
+npm ERR! command sh -c -- node scripts/build.js
+```
+You can increase the memory of your existing podman machine
+by issuing the following:
+```bash
+podman machine set --memory 8192
+```
+
 Recreating the dev containers might be useful:
 
 ```bash


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
`make build-wisdom-container` was failing on my intel mac. I traced it down to the [webpack compiler](https://github.com/ansible/ansible-wisdom-service/blob/0eded929c0547d95825d51ed0bb1cfc7faeb35ce/ansible_wisdom_console_react/scripts/build.js#L140) using more memory than I'd configured for my podman machine. This PR adds troubleshooting steps for this problem. 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
You can adjust your podman machine with the supplied command if you face the same issue.

### Scenarios tested
As described in PR.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
