### PR TITLE
Fix Telemetry setting usage

### DIFF
--- a/ansible_wisdom_console_react/src/index.tsx
+++ b/ansible_wisdom_console_react/src/index.tsx
@@ -10,7 +10,8 @@ import './i18n'
 import './index.css'
 
 const userName = document.getElementById('user_name')?.innerText ?? "undefined";
-const telemetryOptEnabled = Boolean(document.getElementById('telemetry_opt_enabled')?.innerText);
+const telemetryOptEnabledInnerText = document.getElementById('telemetry_opt_enabled')?.innerText;
+const telemetryOptEnabled = telemetryOptEnabledInnerText?.toLowerCase()==="true";
 
 createRoot(document.getElementById('root') as HTMLElement).render(
     <StrictMode>


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Parsing of a `String` into a `Boolean` was flawed. Fixed.

## Testing
1. Pull down the PR
2. `make admin-portable-bundle`
3. `make start-backends`
4. `make create-applicationa`
5. Run `wisdom-service` Django code as you would normally (if differs person to person).

### Scenarios tested
When `ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True` the Admin Portal will show the "Telemetry" navigation option.
When `ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False` the Admin Portal will not show the "Telemetry" navigation option.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
