### PR TITLE
AAP-15464: Enable Opt-Out Telemetry (the UI/UX to enable). Parameterise timeout

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -190,6 +190,7 @@ if sys.argv[1:2] not in [['migrate'], ['test']]:
 # - remove "Authentication Token" line from ansible_wisdom/users/templates/users/home.html
 
 COMPLETION_USER_RATE_THROTTLE = os.environ.get('COMPLETION_USER_RATE_THROTTLE') or '10/minute'
+ME_USER_CACHE_TIMEOUT_SEC = int(os.environ.get('ME_USER_CACHE_TIMEOUT_SEC', 30))
 ME_USER_RATE_THROTTLE = os.environ.get('ME_USER_RATE_THROTTLE') or '50/minute'
 SPECIAL_THROTTLING_GROUPS = ['test']
 

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -18,7 +18,7 @@ from social_django.utils import load_strategy
 
 from .serializers import UserResponseSerializer
 
-ME_CACHE_TIMEOUT = 30
+ME_USER_CACHE_TIMEOUT_SEC = settings.ME_USER_CACHE_TIMEOUT_SEC
 logger = logging.getLogger(__name__)
 
 
@@ -63,7 +63,7 @@ class CurrentUserView(RetrieveAPIView):
     serializer_class = UserResponseSerializer
     throttle_classes = [MeRateThrottle]
 
-    @method_decorator(cache_per_user(ME_CACHE_TIMEOUT))
+    @method_decorator(cache_per_user(ME_USER_CACHE_TIMEOUT_SEC))
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
 


### PR DESCRIPTION
Further to https://github.com/ansible/ansible-wisdom-service/pull/718

## Description
This PR parameterizes the `/me` endpoint cache timeout to facilitate tests.

## Testing
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Start the `wisdom-service` (varies per developer)

### Scenarios tested
The `/me` endpoint should work.

Changes to the Telemetry `optOut` flag should be reflected according to the configured cache timeout.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
