### PR TITLE
[AAP-18621] minimize use of lightspeed service by deactivated users

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ansible_wisdom/ai/api/aws/wca_secret_manager.py
   pull_request:
     branches:
       - main
-    paths:
-      - ansible_wisdom/ai/api/aws/wca_secret_manager.py
 permissions:
   contents: read
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18621>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Check if the user is still active before granting the seat.
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ... Run the test-suite or disable a user
3. ...

### Scenarios tested

An active user has a token VSCode and can use the service, it then get removed from the RH Org.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] his code is ready for product