### PR TITLE
rename settings keys associated with dummy backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ export SECRET_KEY=somesecretvalue
 ```
 
 For most development usages, you can skip the call to AWS Secrets Manager
-and always use the `ANSIBLE_WCA_FREE_API_KEY`
-and `ANSIBLE_WCA_FREE_MODEL_ID` values.
+and always use the dummy `WCA_SECRET_BACKEND_TYPE`:
 
 ```bash
-export MOCK_WCA_SECRETS_MANAGER=True
+export WCA_SECRET_BACKEND_TYPE="dummy"
+export WCA_SECRET_DUMMY_SECRETS="11009103:valid"
 ```
+In this example, `11009103`` is your organization id. In this case the model is set to `valid`.
+You can also use the following syntax to set both the model and set key_id:
+`WCA_SECRET_DUMMY_SECRETS='123:my-key<|sepofid|>sec'`
+
+
 
 For deployment and RH SSO integration test/development, set
 environment variables for access to AWS:

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -21,11 +21,11 @@ class DummyClient(ModelMeshClient):
         model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
-        if settings.MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER:
+        if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:
             jitter: float = secrets.randbelow(1000) * 0.001
         else:
-            jitter: float = 1.0
-        time.sleep((settings.MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter) / 1000)
-        response_body = json.loads(settings.MOCK_MODEL_RESPONSE_BODY)
+            jitter: float = 0.001
+        time.sleep(settings.DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter)
+        response_body = json.loads(settings.DUMMY_MODEL_RESPONSE_BODY)
         response_body['model_id'] = '_'
         return response_body

--- a/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
@@ -10,8 +10,8 @@ body = {"test": "true"}
 random_value = 1000
 
 
-@override_settings(MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC=latency)
-@override_settings(MOCK_MODEL_RESPONSE_BODY=body)
+@override_settings(DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC=latency)
+@override_settings(DUMMY_MODEL_RESPONSE_BODY=body)
 class TestDummyClient(SimpleTestCase):
     def test_init(self):
         url = "https://redhat.com"

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -336,7 +336,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             self.assertInLog("WCA Model ID is invalid", log)
 
-    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid<|sepofid|>valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=20)
     def test_wca_completion_timeout_single_task(self):
@@ -357,7 +357,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertEqual(model_client.session.post.call_args[1]['timeout'], 20)
 
-    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid<|sepofid|>valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=20)
     def test_wca_completion_timeout_multi_task(self):
@@ -382,7 +382,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertEqual(model_client.session.post.call_args[1]['timeout'], 40)
 
-    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid')
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='1:valid<|sepofid|>valid')
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_wca_completion_timed_out(self):

--- a/ansible_wisdom/ai/api/wca/model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/model_id_views.py
@@ -120,7 +120,7 @@ class WCAModelIdView(RetrieveAPIView, CreateAPIView):
         logger.debug("WCA Model Id:: POST handler")
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
 
-        def get_api_key(org_id):
+        def get_api_key(org_id: int):
             api_key = secret_manager.get_secret(org_id, Suffixes.API_KEY)
             return get_secret_value(api_key)
 

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -337,19 +337,19 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 APPEND_SLASH = True
 
-MOCK_MODEL_RESPONSE_BODY = os.environ.get(
-    'MOCK_MODEL_RESPONSE_BODY',
+DUMMY_MODEL_RESPONSE_BODY = os.environ.get(
+    'DUMMY_MODEL_RESPONSE_BODY',
     (
         '{"predictions":["ansible.builtin.apt:\\n  name: nginx\\n'
         '  update_cache: true\\n  state: present\\n"]}'
     ),
 )
 
-MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC = int(
-    os.environ.get('MOCK_MODEL_RESPONSE_MAX_LATENCY_MSEC', 3000)
+DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC = int(
+    os.environ.get('DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC', 3000)
 )
-MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER = bool(
-    os.environ.get('MOCK_MODEL_RESPONSE_LATENCY_USE_JITTER', False)
+DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER = bool(
+    os.environ.get('DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER', False)
 )
 
 ENABLE_ARI_POSTPROCESS = os.getenv('ENABLE_ARI_POSTPROCESS', 'False').lower() == 'true'
@@ -439,7 +439,6 @@ WCA_SECRET_MANAGER_PRIMARY_REGION = os.getenv('WCA_SECRET_MANAGER_PRIMARY_REGION
 WCA_SECRET_MANAGER_REPLICA_REGIONS = [
     c.strip() for c in os.getenv('WCA_SECRET_MANAGER_REPLICA_REGIONS', '').split(',') if c
 ]
-MOCK_WCA_SECRETS_MANAGER = os.environ.get("MOCK_WCA_SECRETS_MANAGER", "False") == "True"
 
 CSP_DEFAULT_SRC = ("'self'", "data:")
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")


### PR DESCRIPTION
Remove `MOCK_WCA_SECRETS_MANAGER`, you should now use the following configuration instead:
`WCA_SECRET_BACKEND_TYPE="dummy"`

Extend the `WCA_SECRET_DUMMY_SECRETS` to be able to set both the key and the model_id at the same time using the following syntax:
`WCA_SECRET_DUMMY_SECRETS='123:my-key<|sepofid|>sec'`

Also rename `DUMMY_MODEL_RESPONSE_BODY` to be consistent with the new name of the associated backend.
