### PR TITLE
AAP-18228: At trial expiry, display CTA to the end-user in VS Code

### DIFF
--- a/ansible_wisdom/ai/api/model_client/exceptions.py
+++ b/ansible_wisdom/ai/api/model_client/exceptions.py
@@ -64,6 +64,11 @@ class WcaCloudflareRejection(WcaException):
 
 
 @dataclass
+class WcaUserTrialExpired(WcaException):
+    """WCA notifies that user's trial has expired."""
+
+
+@dataclass
 class WcaInferenceFailure(WcaException):
     """An attempt to run a WCA inference failed."""
 

--- a/ansible_wisdom/ai/api/pipelines/common.py
+++ b/ansible_wisdom/ai/api/pipelines/common.py
@@ -123,6 +123,16 @@ class WcaCloudflareRejectionException(BaseWisdomAPIException):
     }
 
 
+class WcaUserTrialExpiredException(BaseWisdomAPIException):
+    status_code = 403
+    default_code = "permission_denied__user_trial_expired"
+    default_detail = {
+        # VSCode relies on the code in the data payload.
+        "code": "permission_denied__user_trial_expired",
+        "message": "User trial expired. Please contact your administrator.",
+    }
+
+
 class ServiceUnavailable(BaseWisdomAPIException):
     status_code = 503
     default_detail = {"message": "An error occurred attempting to complete the request"}

--- a/ansible_wisdom/test_utils.py
+++ b/ansible_wisdom/test_utils.py
@@ -45,8 +45,11 @@ class WisdomServiceLogAwareTestCase(TestCase, WisdomLogAwareMixin):
         segment_events = self.extractSegmentEventsFromLog(log)
         self.assertTrue(len(segment_events) == 1)
         self.assertEqual(segment_events[0]["event"], event)
-        self.assertEqual(segment_events[0]["properties"]["problem"], problem)
-        self.assertEqual(segment_events[0]["properties"]["exception"], True if problem else False)
+        if problem:
+            self.assertEqual(segment_events[0]["properties"]["problem"], problem)
+            self.assertEqual(
+                segment_events[0]["properties"]["exception"], True if problem else False
+            )
         for key, value in kwargs.items():
             self.assertEqual(segment_events[0]["properties"][key], value)
 

--- a/ansible_wisdom_console_react/src/ModelSettingsOverview.tsx
+++ b/ansible_wisdom_console_react/src/ModelSettingsOverview.tsx
@@ -72,6 +72,7 @@ export const ModelSettingsOverview = (props: ModelSettingsOverviewProps) => {
                 if (error.response?.status === 400) {
                     setIsModelIdInvalid(true);
                 } else {
+                    // TODO: Need to customize here the trial expired error?
                     setModelIdError({
                         inError: true,
                         message: error.message,


### PR DESCRIPTION
Hey  @manstis @robinbobbitt 

See https://issues.redhat.com/browse/AAP-18228

This is how the error message looks in the VSCode user's perspective once reaching the capacity limits:

![Screenshot from 2023-12-18 23-42-24](https://github.com/ansible/ansible-wisdom-service/assets/4602417/0acad8eb-ad13-4079-b6ab-3ca30ea8ddf1)

NOTE: This PR is **related to** https://github.com/ansible/vscode-ansible/pull/1034
NOTE: This PR is not refactoring actual code duplications or error code propagation across existign exceptions, as we talked before, will just create some follow-up tickets.

Thanks in advance!
Roger