### PR TITLE
AAP-19003 & AAP-19065: Having task names in double/single quote issue 

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
@@ -60,7 +60,8 @@ def completion_pre_process(context: CompletionContext):
         # back from preprocess. We can calculate the proper spacing from the
         # normalized prompt.
         normalized_indent = len(context.payload.prompt) - len(context.payload.prompt.lstrip())
-        original_prompt = " " * normalized_indent + original_prompt.lstrip()
+        normalized_original_prompt = fmtr.normalize_yaml(original_prompt)
+        original_prompt = " " * normalized_indent + normalized_original_prompt
     context.payload.original_prompt = original_prompt
 
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -357,6 +357,24 @@ TASKS_CONTEXT_WITH_VARS = f'''\
 #
 TASKS_CONTEXT_WITHOUT_VARS = "\n".join(TASKS_PAYLOAD["prompt"].split("\n")[1:-2]) + "\n"
 
+TASKS_PAYLOAD_PROMPT_WITH_QUOTED_TASKS = '''\
+---
+- name: "import assert.yml"
+  ansible.builtin.import_tasks: assert.yml
+  run_once: true
+  delegate_to: localhost
+
+- name: "install openvpn packages"
+'''
+
+TASKS_PAYLOAD_PROMPT_WITH_NON_QUOTED_TASK = '''\
+- name: import assert.yml
+  ansible.builtin.import_tasks: assert.yml
+  run_once: true
+  delegate_to: localhost
+
+'''
+
 
 @modify_settings()
 class CompletionPreProcessTest(TestCase):
@@ -379,7 +397,7 @@ class CompletionPreProcessTest(TestCase):
         self.assertEqual(context.payload.context, expected_context)
 
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
-    def test_additional_context_with_commercial_user_and_feauture_enabled(self):
+    def test_additional_context_with_commercial_user_and_feature_enabled(self):
         self.call_completion_pre_process(
             PLAYBOOK_PAYLOAD,
             True,
@@ -387,7 +405,7 @@ class CompletionPreProcessTest(TestCase):
         )
 
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
-    def test_additional_context_with_commercial_user_and_feauture_enabled_with_no_preexisting_vars(
+    def test_additional_context_with_commercial_user_and_feature_enabled_with_no_preexisting_vars(
         self,
     ):
         payload = copy.deepcopy(PLAYBOOK_PAYLOAD)
@@ -400,7 +418,7 @@ class CompletionPreProcessTest(TestCase):
         )
 
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=False)
-    def test_additional_context_with_commercial_user_and_feauture_disabled(self):
+    def test_additional_context_with_commercial_user_and_feature_disabled(self):
         self.call_completion_pre_process(
             PLAYBOOK_PAYLOAD,
             True,
@@ -476,4 +494,16 @@ class CompletionPreProcessTest(TestCase):
             payload,
             True,
             TASKS_CONTEXT_WITHOUT_VARS,
+        )
+
+    def test_quoted_singletask(
+        self,
+    ):
+        payload = copy.deepcopy(TASKS_PAYLOAD)
+        payload["prompt"] = TASKS_PAYLOAD_PROMPT_WITH_QUOTED_TASKS
+
+        self.call_completion_pre_process(
+            payload,
+            True,
+            TASKS_PAYLOAD_PROMPT_WITH_NON_QUOTED_TASK,
         )


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue1: <https://issues.redhat.com/browse/AAP-19003>
Jira Issue2: <https://issues.redhat.com/browse/AAP-19065>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Please see the Jira issues for more details

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the test: `ansible_wisdom.ai.api.pipelines.completion_stages.tests.test_pre_process.CompletionPreProcessTest.test_quoted_singletask`
3. Run the service on your local and configure your VSCode to use your local.
4. On your VSCode, you can use a ansible playbook as follows:

```yaml
---
- hosts: all
  name: Vim
  connection: local
  tasks:
    - name: "install vim"
```

5. The completion suggestions should be received as expected without an error.

### Scenarios tested
Both single and double quotes are tested. This should not affect the multitask but it is tested anyways to see if it is affected or not.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
All the single and multi task `completions` scenarios should be gone thru and validated before going to prod.
