### PR TITLE
Pin ansible-core to 2.15.8 and upgrade transformers to 4.36.0 to fix various pip-audit issues

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,11 @@
 # remove this once datasets or fsspec is updated
 # to properly pull a version of aiohttp > 3.8.5.
 aiohttp==3.9.0
+# pin ansible-core on 2.15.8 to address GHSA-7j69-qfc3-2fq9
+# remove this once ansible-anonymizer, ansible-risk-insight and
+# ansible-lint are updated to properly pull a version of
+# ansible-core > 2.15.0.
+ansible-core==2.15.8
 ansible-anonymizer==1.4.2
 ansible-risk-insight==0.2.4
 ansible-lint==6.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,9 @@ ansible-anonymizer==1.4.2
     # via -r requirements.in
 ansible-compat==4.1.10
     # via ansible-lint
-ansible-core==2.15.0
+ansible-core==2.15.8
     # via
+    #   -r requirements.in
     #   ansible
     #   ansible-compat
     #   ansible-lint


### PR DESCRIPTION
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
ansible-core | 2.15.0 | GHSA-7j69-qfc3-2fq9 | 2.14.12,2.15.8,2.16.1 | A template injection flaw was found in Ansible where a user's controller internal templating operations may remove the unsafe designation from template data. This issue could allow an attacker to use a specially crafted file to introduce code injection when supplying templating data.
transformers | 4.30.0 | GHSA-3863-2447-669p | 4.36.0 | Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.0.
transformers | 4.30.0 | GHSA-v68g-wm8c-6x7j | 4.36.0 | Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.
```