### PR TITLE
verify signature of rhsso access token

### DIFF
--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -83,7 +83,7 @@ def redhat_organization(backend, user, response, *args, **kwargs):
     payload = jwt.decode(
         response['access_token'],
         rsakey.to_pem().decode("utf-8"),
-        algorithms=['RS256'],
+        algorithms=[key['alg']],
         audience="account",
     )
 

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 
-
 from uuid import uuid4
 
 import jwt
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from django.contrib.auth import get_user_model
 from django.test import override_settings
+from jose import constants, jwk
 from social_django.models import UserSocialAuth
 from test_utils import WisdomServiceLogAwareTestCase
 from users.pipeline import load_extra_data, redhat_organization
 
 
-def build_access_token(payload):
-    return jwt.encode(payload, key='secret', algorithm='HS256')
+def build_access_token(private_key, payload):
+    payload["aud"] = ["account"]
+    return jwt.encode(payload, key=private_key, algorithm='RS256')
 
 
 class DummyGithubBackend:
@@ -31,6 +35,12 @@ class DummyGithubBackend:
 class DummyRHBackend:
     id_token = {"organization": {"id": 345}}
     name = "oidc"
+
+    def __init__(self, public_key):
+        self.public_key = public_key
+
+    def find_valid_key(self, id_token):
+        return self.public_key
 
     def extra_data(*args, **kwargs):
         return {
@@ -61,6 +71,18 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
         self.github_usa = UserSocialAuth.objects.create(
             user=self.rh_user, provider="github", uid=str(uuid4())
         )
+        self.rsa_private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+
+        public_bytes = self.rsa_private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+        self.jwks_public_key = jwk.RSAKey(
+            algorithm=constants.Algorithms.RS256, key=public_bytes.decode('utf-8')
+        ).to_dict()
 
     def tearDown(self):
         self.rh_user.delete()
@@ -68,7 +90,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
 
     def test_load_extra_data(self):
         load_extra_data(
-            backend=DummyRHBackend(),
+            backend=DummyRHBackend(public_key=self.jwks_public_key),
             details=None,
             response=None,
             uid=None,
@@ -80,11 +102,16 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_rh_admin_user(self):
         response = {
             "access_token": build_access_token(
-                {"realm_access": {"roles": ["admin:org:all"]}, "preferred_username": "jean-michel"}
+                self.rsa_private_key,
+                {"realm_access": {"roles": ["admin:org:all"]}, "preferred_username": "jean-michel"},
             )
         }
 
-        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
+        answer = redhat_organization(
+            backend=DummyRHBackend(public_key=self.jwks_public_key),
+            user=self.rh_user,
+            response=response,
+        )
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -97,11 +124,16 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_rh_user(self):
         response = {
             "access_token": build_access_token(
-                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"}
+                self.rsa_private_key,
+                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"},
             )
         }
 
-        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
+        answer = redhat_organization(
+            backend=DummyRHBackend(public_key=self.jwks_public_key),
+            user=self.rh_user,
+            response=response,
+        )
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': False,
@@ -112,7 +144,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
         assert self.rh_user.external_username == "yves"
 
     def test_redhat_organization_with_github_user(self):
-        response = {"access_token": build_access_token({})}
+        response = {"access_token": build_access_token(self.rsa_private_key, {})}
 
         answer = redhat_organization(
             backend=DummyGithubBackend(), user=self.github_user, response=response
@@ -125,11 +157,16 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_AUTHZ_DUMMY_parameter(self):
         response = {
             "access_token": build_access_token(
-                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"}
+                self.rsa_private_key,
+                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"},
             )
         }
 
-        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
+        answer = redhat_organization(
+            backend=DummyRHBackend(public_key=self.jwks_public_key),
+            user=self.rh_user,
+            response=response,
+        )
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -143,11 +180,16 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_AUTHZ_DUMMY_wildcard(self):
         response = {
             "access_token": build_access_token(
-                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"}
+                self.rsa_private_key,
+                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"},
             )
         }
 
-        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
+        answer = redhat_organization(
+            backend=DummyRHBackend(public_key=self.jwks_public_key),
+            user=self.rh_user,
+            response=response,
+        )
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -161,12 +203,15 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_invalid_AUTHZ_DUMMY_parameter(self):
         response = {
             "access_token": build_access_token(
-                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"}
+                self.rsa_private_key,
+                {"realm_access": {"roles": ["another_other_role"]}, "preferred_username": "yves"},
             )
         }
         with self.assertLogs(logger='users.pipeline', level='ERROR') as log:
             answer = redhat_organization(
-                backend=DummyRHBackend(), user=self.rh_user, response=response
+                backend=DummyRHBackend(public_key=self.jwks_public_key),
+                user=self.rh_user,
+                response=response,
             )
             self.assertInLog("AUTHZ_DUMMY_RH_ORG_ADMINS has an invalid format.", log)
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-19248

## Description
SonarCloud is complaining that we're using `"verify_signature": False` when we decode our RHSSO access token. In the original PR that added this code, the explanation was that the python social auth pipeline is already doing the verification. Looking closer, the python social auth pipeline appears to verify the signature of the identity token, and checks the access token hash, but doesn't verify the signature of the access token. Therefore, it seems we should go ahead and verify the signature of the access token. This implementation borrows from the OpenIdConnectAuth backend to get the already-cached public key and uses it to decode the token.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Log in to the wisdom service using RHSSO. Should succeed without error.

### Scenarios tested
Confirmed RHSSO still works and I'm still detected as a RHSSO org admin.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
