### PR TITLE
additional fixes for enhanced context with no existing vars

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -116,10 +116,12 @@ def expand_vars_playbook(data, additional_context):
     merged_vars = load_and_merge_vars_in_context(var_infiles + include_vars)
     if len(merged_vars) > 0:
         for d in data:
-            tasks = d.pop("tasks", None)  # tasks needs to be last for proper placement with prompt
+            # last key ("tasks", "handlers", ...) needs to stay last
+            # for proper placement of the prompt
+            last_key = list(d.keys())[-1]
+            last_key_value = d.pop(last_key)
             d["vars"] = merged_vars if "vars" not in d else (merged_vars | d["vars"])
-            if tasks:
-                d["tasks"] = tasks
+            d[last_key] = last_key_value
 
 
 def expand_vars_tasks_in_role(data, additional_context):

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -137,6 +137,69 @@ PLAYBOOK_CONTEXT_WITH_ONLY_ADDITIONAL_CONTEXT_VARS = f'''\
         file: ./vars/external_vars_3.yml
 '''
 
+PLAYBOOK_PAYLOAD_PROMPT_WITH_NO_PREEXISTING_VARS_AND_ONE_MULTITASK_PROMPT = '''\
+---
+- hosts: all
+  remote_user: root
+  vars_files:
+    - ./vars/external_vars_1.yml
+    - ./vars/external_vars_2.yml
+  tasks:
+    # Include variable
+'''
+
+#
+# If the prompt is processed with the formatter with inserting variables,
+# with no other pre-existing vars, following context
+# will be generated:
+#
+PLAYBOOK_CONTEXT_WITH_ONLY_ADDITIONAL_CONTEXT_VARS_AND_EMPTY_TASKS = f'''\
+- hosts: all
+  remote_user: root
+  vars_files:
+    - ./vars/external_vars_1.yml
+    - ./vars/external_vars_2.yml
+  vars:
+{add_indents(VARS_1, 4)}
+{add_indents(VARS_2, 4)}
+{add_indents(VARS_3, 4)}
+  tasks:
+'''
+
+PLAYBOOK_PAYLOAD_PROMPT_WITH_HANDLERS_NO_PREEXISTING_VARS = '''\
+---
+- hosts: all
+  remote_user: root
+  vars_files:
+    - ./vars/external_vars_1.yml
+    - ./vars/external_vars_2.yml
+  handlers:
+    - name: Include variable
+      ansible.builtin.include_vars:
+        file: ./vars/external_vars_3.yml
+    - name: Run container with podman using mattermost_app var
+'''
+
+#
+# If the prompt is processed with the formatter with inserting variables,
+# with no other pre-existing vars, following context
+# will be generated:
+#
+PLAYBOOK_CONTEXT_WITH_HANDLERS_ONLY_ADDITIONAL_CONTEXT_VARS = f'''\
+- hosts: all
+  remote_user: root
+  vars_files:
+    - ./vars/external_vars_1.yml
+    - ./vars/external_vars_2.yml
+  vars:
+{add_indents(VARS_1, 4)}
+{add_indents(VARS_2, 4)}
+{add_indents(VARS_3, 4)}
+  handlers:
+    - name: Include variable
+      ansible.builtin.include_vars:
+        file: ./vars/external_vars_3.yml
+'''
 #
 # If the prompt is processed with the formatter without inserting variables, following
 # changes will be made to generate the context:
@@ -415,6 +478,34 @@ class CompletionPreProcessTest(TestCase):
             payload,
             True,
             PLAYBOOK_CONTEXT_WITH_ONLY_ADDITIONAL_CONTEXT_VARS,
+        )
+
+    @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
+    def test_additional_context_with_commercial_user_and_feature_enabled_with_no_preexisting_vars_and_one_multitask_prompt(  # noqa: E501
+        self,
+    ):
+        payload = copy.deepcopy(PLAYBOOK_PAYLOAD)
+        payload[
+            "prompt"
+        ] = PLAYBOOK_PAYLOAD_PROMPT_WITH_NO_PREEXISTING_VARS_AND_ONE_MULTITASK_PROMPT
+
+        self.call_completion_pre_process(
+            payload,
+            True,
+            PLAYBOOK_CONTEXT_WITH_ONLY_ADDITIONAL_CONTEXT_VARS_AND_EMPTY_TASKS,
+        )
+
+    @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
+    def test_additional_context_with_commercial_user_and_feature_enabled_with_no_preexisting_vars_and_handlers(  # noqa: E501
+        self,
+    ):
+        payload = copy.deepcopy(PLAYBOOK_PAYLOAD)
+        payload["prompt"] = PLAYBOOK_PAYLOAD_PROMPT_WITH_HANDLERS_NO_PREEXISTING_VARS
+
+        self.call_completion_pre_process(
+            payload,
+            True,
+            PLAYBOOK_CONTEXT_WITH_HANDLERS_ONLY_ADDITIONAL_CONTEXT_VARS,
         )
 
     @override_settings(ENABLE_ADDITIONAL_CONTEXT=False)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-18756


## Description
The original fix for https://issues.redhat.com/browse/AAP-18756 was incomplete. Two scenarios missed were:
1) Multi-task prompt that is the first line under `tasks`
2) Prompt might be under `handlers` rather than `tasks`

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service
3. From your vscode, test with multi-task prompt that is first in tasks or handlers section.

### Scenarios tested
Steps listed above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
