### PR TITLE
fix ansible lint postprocess for single task recommendations

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -900,7 +900,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
 
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
-    def test_payload_with_ansible_lint(self):
+    def test_payload_with_ansible_lint_without_commercial(self):
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
             "suggestionId": str(uuid.uuid4()),
@@ -975,15 +975,15 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
-    def test_full_payload_with_ansible_lint_with_commercial_user(self):
+    def test_full_payload_with_ansible_lint_without_ari_postprocess_with_commercial_user(self):
         self.user.rh_user_has_seat = True
         payload = {
-            "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
+            "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Sample shell\n",
             "suggestionId": str(uuid.uuid4()),
         }
         response_data = {
             "model_id": self.DUMMY_MODEL_ID,
-            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+            "predictions": ["      ansible.builtin.shell:\n        cmd: echo hello"],
         }
         self.client.force_authenticate(user=self.user)
         with patch.object(
@@ -995,6 +995,46 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 r = self.client.post(reverse('completions'), payload)
                 self.assertEqual(r.status_code, HTTPStatus.OK)
                 self.assertIsNotNone(r.data['predictions'])
+                self.assertEqual(
+                    r.data['predictions'][0],
+                    '      ansible.builtin.command:\n        cmd: echo hello\n',
+                )
+                self.assertSegmentTimestamp(log)
+
+                segment_events = self.extractSegmentEventsFromLog(log)
+                self.assertTrue(len(segment_events) > 0)
+                for event in segment_events:
+                    properties = event['properties']
+                    self.assertTrue('modelName' in properties)
+                    self.assertEqual(properties['modelName'], self.DUMMY_MODEL_ID)
+
+    @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
+    @override_settings(ENABLE_ARI_POSTPROCESS=True)
+    @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
+    def test_full_payload_with_ansible_lint_with_ari_postprocess_with_commercial_user(self):
+        self.user.rh_user_has_seat = True
+        payload = {
+            "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Sample shell\n",
+            "suggestionId": str(uuid.uuid4()),
+        }
+        response_data = {
+            "model_id": self.DUMMY_MODEL_ID,
+            "predictions": ["      ansible.builtin.shell:\n        cmd: echo hello"],
+        }
+        self.client.force_authenticate(user=self.user)
+        with patch.object(
+            apps.get_app_config('ai'),
+            '_wca_client',
+            MockedMeshClient(self, payload, response_data, rh_user_has_seat=True),
+        ):
+            with self.assertLogs(logger='root', level='DEBUG') as log:
+                r = self.client.post(reverse('completions'), payload)
+                self.assertEqual(r.status_code, HTTPStatus.OK)
+                self.assertIsNotNone(r.data['predictions'])
+                self.assertEqual(
+                    r.data['predictions'][0],
+                    '      ansible.builtin.command:\n        cmd: echo hello\n',
+                )
                 self.assertSegmentTimestamp(log)
 
                 segment_events = self.extractSegmentEventsFromLog(log)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-19333

## Description
Fixes ansible-lint postprocessing for single task. The file being linted for single task recommendations was missing the task name and never worked. Updates the unit test to check the response to ensure a lint rule actually transformed the recommendation. Tests both with and without ARI enabled, as the patching together of the prompt and recommendation to make the lintable file differs for the two scenarios due to indention.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service
3. Test single and multi task prompts as a commercial user and confirm the linter transforms the results as expected, no exceptions in the logs, and recommendation is properly indented.

### Scenarios tested
Followed steps above and tested with the prompt in [Slack](https://redhat-internal.slack.com/archives/C04G3TZBGHJ/p1704482574426109), both single and multi-task.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
