### PR TITLE
Ensure organizations_organization is populated for existing Users.

### DIFF
--- a/ansible_wisdom/organizations/migrations/0002_user_organization_fix_id.py
+++ b/ansible_wisdom/organizations/migrations/0002_user_organization_fix_id.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [('organizations', '0001_initial'), ('users', '0009_user_organization')]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            insert into
+            organizations_organization
+            select
+            organization_id, false
+            from
+            users_user
+            where
+            organization_id is not null
+            on conflict (id) do nothing;
+            update
+            users_user
+            set
+            fk_organization_id = organization_id
+            where
+            organization_id is not null;
+            """
+        )
+    ]

--- a/ansible_wisdom/organizations/migrations/tests/test_0002_user_organization_fix_id.py
+++ b/ansible_wisdom/organizations/migrations/tests/test_0002_user_organization_fix_id.py
@@ -1,0 +1,27 @@
+from django_test_migrations.contrib.unittest_case import MigratorTestCase
+
+
+class TestDirectMigration(MigratorTestCase):
+    migrate_from = ('organizations', '0001_initial')
+    migrate_to = ('organizations', '0002_user_organization_fix_id')
+
+    def prepare(self):
+        user = self.old_state.apps.get_model('users', 'User')
+        user.objects.create(organization_id=123)
+
+    def test_migration_0002_user_organization_fix_id(self):
+        user_old = self.old_state.apps.get_model('users', 'User')
+        self.assertFalse(hasattr(user_old, 'organization'))
+
+        user_new = self.new_state.apps.get_model('users', 'User')
+        users = user_new.objects.all()
+        self.assertEqual(1, len(users))
+        self.assertTrue(hasattr(users[0], 'organization'))
+        self.assertIsNotNone(users[0].organization)
+        self.assertEqual(123, users[0].organization.id)
+
+        organization_new = self.new_state.apps.get_model('organizations', 'Organization')
+        organizations = organization_new.objects.all()
+        self.assertEqual(1, len(organizations))
+        self.assertTrue(hasattr(users[0], 'organization'))
+        self.assertEqual(organizations[0].id, users[0].organization.id)

--- a/ansible_wisdom/organizations/migrations/tests/test_0002_user_organization_fix_id.py
+++ b/ansible_wisdom/organizations/migrations/tests/test_0002_user_organization_fix_id.py
@@ -1,18 +1,12 @@
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
-class TestDirectMigration(MigratorTestCase):
-    migrate_from = ('organizations', '0001_initial')
-    migrate_to = ('organizations', '0002_user_organization_fix_id')
-
+class BaseOrganizationMigrationTest(MigratorTestCase):
     def prepare(self):
         user = self.old_state.apps.get_model('users', 'User')
         user.objects.create(organization_id=123)
 
-    def test_migration_0002_user_organization_fix_id(self):
-        user_old = self.old_state.apps.get_model('users', 'User')
-        self.assertFalse(hasattr(user_old, 'organization'))
-
+    def assert_organization_relationship(self):
         user_new = self.new_state.apps.get_model('users', 'User')
         users = user_new.objects.all()
         self.assertEqual(1, len(users))
@@ -25,3 +19,23 @@ class TestDirectMigration(MigratorTestCase):
         self.assertEqual(1, len(organizations))
         self.assertTrue(hasattr(users[0], 'organization'))
         self.assertEqual(organizations[0].id, users[0].organization.id)
+
+
+class TestOrganizationMigration(BaseOrganizationMigrationTest):
+    migrate_from = ('organizations', '0001_initial')
+    migrate_to = ('organizations', '0002_user_organization_fix_id')
+
+    def test_migration_0002_user_organization_fix_id(self):
+        user_old = self.old_state.apps.get_model('users', 'User')
+        self.assertFalse(hasattr(user_old, 'organization'))
+        self.assert_organization_relationship()
+
+
+class TestUserOrganizationMigration(BaseOrganizationMigrationTest):
+    migrate_from = ('users', '0009_user_organization')
+    migrate_to = ('organizations', '0002_user_organization_fix_id')
+
+    def test_migration_0002_user_organization_fix_id(self):
+        user_old = self.old_state.apps.get_model('users', 'User')
+        self.assertTrue(hasattr(user_old, 'organization'))
+        self.assert_organization_relationship()

--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,7 @@ django-health-check==3.17.0
 django-import-export==3.2.0
 django-oauth-toolkit==2.2.0
 django_prometheus==2.2.0
+django-test-migrations==1.3.0
 djangorestframework==3.14.0
 drf-spectacular==0.25.1
 grpcio==1.54.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,6 +123,8 @@ django-oauth-toolkit==2.2.0
     # via -r requirements.in
 django-prometheus==2.2.0
     # via -r requirements.in
+django-test-migrations==1.3.0
+    # via -r requirements.in
 djangorestframework==3.14.0
     # via
     #   -r requirements.in
@@ -475,6 +477,7 @@ typing-extensions==4.6.2
     #   ansible-compat
     #   asgiref
     #   black
+    #   django-test-migrations
     #   huggingface-hub
     #   psycopg
     #   pydantic

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.sources = ansible_wisdom/,ansible_wisdom_console_react/
 sonar.tests = ansible_wisdom/,ansible_wisdom_console_react/
 
 # Include test subdirectories in test scope
-sonar.test.inclusions = ansible_wisdom/**/test_*.py,ansible_wisdom/users/migrations/*,ansible_wisdom_console_react/**/__tests__/
+sonar.test.inclusions = ansible_wisdom/**/test_*.py,ansible_wisdom/users/migrations/*,ansible_wisdom/organizations/migrations/*,ansible_wisdom_console_react/**/__tests__/
 
 # Exclude test subdirectories from source scope
 sonar.exclusions = ansible_wisdom/**/test_*.py,ansible_wisdom_console_react/**/__tests__/*.*,ansible_wisdom_console_react/config/**,ansible_wisdom_console_react/__mocks__/**,ansible_wisdom_console_react/scripts/**,ansible_wisdom_console_react/**/*.json


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Following https://issues.redhat.com/browse/AAP-15464

The `organizations_organization` record is only created when the User logs in.

However, with newer container images, the table is used to determine the Users' `organization_id`.

Therefore, for Users who remain logged in after https://github.com/ansible/ansible-wisdom-service/pull/718 is rolled out, the `organizations_organization` table does not contain a record for their Organization and `wisdom-service` returns `None`. This leads to erroneous behaviour of the system for logged in Users.

This migration ensures the database is updated for existing Users.

## Testing
1. Before pulling down this PR.
2. `make stop-backends`
3. `make start-backends`
4. `make create-application`
5. `docker exec -it <postgress-docker-container-id> bash`
6. In the docker container: `psql -U wisdom`
7. `select * from users_user where fk_organization_id is null;`. There _may be_ records.
8. Pull down this PR
9. `make create-application`
10. `select * from users_user where fk_organization_id is null;`. There should be none.
11. `select * from users_user where fk_organization_id not in (select id from organizations_organization)`. There should be none.

### Scenarios tested
The above!

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
