### PR TITLE
Upgrade jinja2 to 3.1.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,6 +33,10 @@ ipython==8.10.0
 # remove this once django-oauth-toolkit is updated to properly
 # pull a version of jwcrypto >= 1.5.1.
 jwcrypto==1.5.1
+# pin jinja2 on 3.1.3 to address GHSA-h5c8-rqwp-cp95
+# remove this once ansible-core is updated to properly
+# pull a version of jwcrypto >= 3.1.3.
+jinja2==3.1.3
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
 # pin pillow on 10.0.1 to address CVE-2023-4863

--- a/requirements.txt
+++ b/requirements.txt
@@ -175,8 +175,9 @@ ipython==8.10.0
     # via -r requirements.in
 jedi==0.18.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.3
     # via
+    #   -r requirements.in
     #   ansible-core
     #   torch
 jmespath==1.0.1


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
jinja2 | 3.1.2 | GHSA-h5c8-rqwp-cp95 | 3.1.3 | The `xmlattr` filter in affected versions of Jinja accepts keys containing spaces. XML/HTML attributes cannot contain spaces, as each would then be interpreted as a separate attribute. If an application accepts keys (as opposed to only values) as user input, and renders these in pages that other users see as well, an attacker could use this to inject other attributes and perform XSS. Note that accepting keys as user input is not common or a particularly intended use case of the `xmlattr` filter, and an application doing so should already be verifying what keys are provided regardless of this fix.
```