### PR TITLE
repo_url no longer included in codematch response

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -440,7 +440,7 @@ class AttributionResponseSerializer(serializers.Serializer):
 
 class ContentMatchSerializer(serializers.Serializer):
     repo_name = serializers.CharField()
-    repo_url = serializers.URLField()
+    repo_url = serializers.URLField(allow_blank=True)
     path = serializers.CharField(allow_blank=True)
     license = serializers.CharField()
     data_source_description = serializers.CharField()

--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from ai.api.serializers import (
     CompletionRequestSerializer,
     ContentMatchRequestSerializer,
+    ContentMatchSerializer,
     FeedbackRequestSerializer,
     SuggestionQualityFeedback,
 )
@@ -123,6 +124,20 @@ class ContentMatchRequestSerializerTest(TestCase):
         }
         serializer.validate(data)
         self.assertIsNone(data.get("model"))
+
+
+class ContentMatchSerializerTest(TestCase):
+    def test_empty_repo_url_allowed(self):
+        data = {
+            "repo_url": "",
+            "repo_name": "ansible.product_demos",
+            "path": "playbooks/infrastructure/aws_provision_vm.yml",
+            "license": "gpl-3.0",
+            "data_source_description": "Ansible Galaxy collections",
+            "score": 0.96241134,
+        }
+        serializer = ContentMatchSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
 
 
 class SuggestionQualityFeedbackTest(TestCase):


### PR DESCRIPTION
Jira Issue: N/A

## Description
Since 6 AM EST, contentmatch has been broken because WCA codematch response no longer includes a repo_url. TBD if this is by design or a bug, but this code change prevents the service from failing on a missing repo_url. Note it's missing from codematch response, but once it hits our serializer, it's an empty string due to https://github.com/ansible/ansible-wisdom-service/blob/8bca96cbedd6f9df4f534eab776bf6873537fb08/ansible_wisdom/ai/api/data/data_model.py#L44


## Testing
### Steps to test
1. Pull down the PR
2. Run the wisdom-service
3. Test a contentmatch against prod WCA. Confirm it works.

### Scenarios tested
Unit test plus manually validated with VSCode extension. Content match works and URL is displayed as empty.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
