### PR TITLE
sessions expire after 14h

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -176,8 +176,8 @@ OAUTH2_PROVIDER = {
         'code-oss',
         'checode',
     ],
-    # ACCESS_TOKEN_EXPIRE_SECONDS = 36_000  # = 10 hours, default value
-    'REFRESH_TOKEN_EXPIRE_SECONDS': 864_000,  # = 10 days
+    # 14 hours, to match the duration of the Red Hat SSO sessions
+    'REFRESH_TOKEN_EXPIRE_SECONDS': 50_400,
 }
 
 #


### PR DESCRIPTION
## Description
Match the duration of the session with Red Hat SSO.

See: https://issues.redhat.com/browse/AAP-18621

## Testing

Log-in, wait 14h
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test

Start the service, log-in with VSCode and check the token in the DB:

```
$ podman exec --user=root -it docker-compose_django_1 wisdom-manage shell
In [1]: from oauth2_provider.models import AccessToken

In [2]: for t in AccessToken.objects.all():
   ...:     print(f"user={t.user} expires={t.expires}")
   ...: 
user=gleboude1@redhat.com expires=2024-01-23 03:26:39.381533+00:00
```

The token should not last more than 14h

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own