### PR TITLE
disable tech preview in wisdom-service

### DIFF
--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -1,5 +1,6 @@
 from ai.api.aws.wca_secret_manager import Suffixes
 from django.apps import apps
+from django.conf import settings
 from rest_framework import permissions
 
 
@@ -78,3 +79,20 @@ class BlockUserWithSeatButWCANotReady(permissions.BasePermission):
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         org_has_api_key = secret_manager.secret_exists(user.organization.id, Suffixes.API_KEY)
         return org_has_api_key
+
+
+# See: https://issues.redhat.com/browse/AAP-19427
+class BlockUserWithoutSeat(permissions.BasePermission):
+    """
+    Block access to un-seated users when Tech Preview is finished
+    """
+
+    code = 'permission_denied__user_with_no_seat'
+    message = "User doesn't have access to the IBM watsonx Code Assistant."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW:
+            return True
+
+        return user.rh_user_has_seat

--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -12,7 +12,12 @@ class AcceptedTermsPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         user = request.user
         if user.is_authenticated:
-            if user.community_terms_accepted or user.rh_user_has_seat:
+            if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.community_terms_accepted:
+                return True
+            if user.rh_user_has_seat:
+                return True
+            if not settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW:
+                # The permission is deprecated and should be removed
                 return True
         return False
 

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -50,6 +50,7 @@ from .data.data_model import (
 from .model_client.exceptions import ModelTimeoutError
 from .permissions import (
     AcceptedTermsPermission,
+    BlockUserWithoutSeat,
     BlockUserWithoutSeatAndWCAReadyOrg,
     BlockUserWithSeatButWCANotReady,
 )
@@ -115,6 +116,7 @@ class Completions(APIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
+        BlockUserWithoutSeat,
         BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ]
@@ -308,6 +310,7 @@ class Attributions(GenericAPIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
+        BlockUserWithoutSeat,
     ]
     required_scopes = ['read', 'write']
 

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -403,6 +403,7 @@ class ContentMatches(GenericAPIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
+        BlockUserWithoutSeat,
     ]
     required_scopes = ['read', 'write']
 

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -87,16 +87,24 @@ LOGIN_REDIRECT_URL = 'home'
 LOGOUT_REDIRECT_URL = 'home'
 LOGIN_ERROR_URL = 'login'
 
+
+ANSIBLE_AI_ENABLE_TECH_PREVIEW = (
+    os.getenv('ANSIBLE_AI_ENABLE_TECH_PREVIEW', 'True').lower() == 'true'
+)
+
+
 SIGNUP_URL = os.environ.get('SIGNUP_URL', 'https://www.redhat.com/en/engage/project-wisdom')
-DOCUMENTATION_URL = os.getenv('DOCUMENTATION_URL', 'https://docs.ai.ansible.redhat.com')
 COMMERCIAL_DOCUMENTATION_URL = os.getenv(
     'COMMERCIAL_DOCUMENTATION_URL', 'https://www.redhat.com/en/engage/ansible-lightspeed'
 )
-
+DOCUMENTATION_URL = os.getenv('DOCUMENTATION_URL', 'https://docs.ai.ansible.redhat.com')
 TERMS_NOT_APPLICABLE = os.environ.get("TERMS_NOT_APPLICABLE", False)
 
 SOCIAL_AUTH_JSONFIELD_ENABLED = True
-if os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_KEY'):
+if not ANSIBLE_AI_ENABLE_TECH_PREVIEW:
+    # No Github login after the Tech Preview
+    USE_GITHUB_TEAM = False
+elif os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_KEY'):
     USE_GITHUB_TEAM = True
     SOCIAL_AUTH_GITHUB_TEAM_KEY = os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_KEY')
     SOCIAL_AUTH_GITHUB_TEAM_SECRET = os.environ.get('SOCIAL_AUTH_GITHUB_TEAM_SECRET')

--- a/ansible_wisdom/main/templates/base.html
+++ b/ansible_wisdom/main/templates/base.html
@@ -10,6 +10,7 @@
 
     <body>
         {% block banner %}
+        {% if use_tech_preview %}
         <div class="pf-c-alert pf-m-warning" style="margin-top:3px;">
             <div class="pf-c-alert__icon">
                 <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
@@ -17,6 +18,18 @@
             <p class="pf-c-alert__title" style="font-weight: normal;"><b>NOTE</b>: Due to overwhelming positive demand, we have extended the availability of the Ansible Lightspeed Technical Preview from December 31, 2023 to <b>February 29, 2024</b>.</p>
         </div>
         <br />
+        {% endif %}
+        {% if not use_tech_preview %}
+        <div class="pf-c-alert pf-m-info" aria-label="Information alert">
+          <div class="pf-c-alert__icon">
+            <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+          </div>
+          <p class="pf-c-alert__title">
+             The Tech Preview is no longer available, please <a class="pf-l-level__item" href="https://www.ansible.com/blog/topic/ansible-lightspeed/" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span>read the blog</a> for further details.
+          </p>
+        </div>
+        <br/ >
+        {% endif %}
         {% endblock banner %}
         {% if messages %}
             <ul class="messages">

--- a/ansible_wisdom/main/templates/base.html
+++ b/ansible_wisdom/main/templates/base.html
@@ -28,7 +28,7 @@
              The Tech Preview is no longer available, please <a class="pf-l-level__item" href="https://www.ansible.com/blog/topic/ansible-lightspeed/" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span>read the blog</a> for further details.
           </p>
         </div>
-        <br/ >
+        <br />
         {% endif %}
         {% endblock banner %}
         {% if messages %}

--- a/ansible_wisdom/main/templates/registration/login.html
+++ b/ansible_wisdom/main/templates/registration/login.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+
 <section class="pf-c-page__main-section pf-m-light">
     <div class="pf-l-bullseye">
 
@@ -29,10 +30,12 @@
             <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
             {% endif %}
             {% if not user.is_authenticated %}
+            {% if use_tech_preview %}
             {% if use_github_team %}
             <a class="pf-l-level__item" href="{% url 'social:begin' 'github-team' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
             {% else %}
             <a class="pf-l-level__item" href="{% url 'social:begin' 'github' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
+            {% endif %}
             {% endif %}
             {% endif %}
           </div>

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -49,11 +49,7 @@ urlpatterns = [
     path('o/', include((base_urlpatterns, app_name), namespace='oauth2_provider')),
     path(
         'login/',
-        LoginView.as_view(
-            extra_context={
-                'use_github_team': settings.USE_GITHUB_TEAM,
-            },
-        ),
+        LoginView.as_view(),
         name='login',
     ),
     path('logout/', LogoutView.as_view(), name='logout'),

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 
 
 class LoginView(auth_views.LoginView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['use_github_team'] = settings.USE_GITHUB_TEAM
+        context["use_tech_preview"] = settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW
+        return context
+
     def dispatch(self, request, *args, **kwargs):
         if self.request.user.is_authenticated:
             return HttpResponseRedirect("/")

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -119,6 +119,8 @@ def redhat_organization(backend, user, response, *args, **kwargs):
 def _terms_of_service(strategy, user, backend, **kwargs):
     accepted = 'terms_accepted'
     is_commercial = user.rh_user_has_seat
+    if not settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW:
+        return {accepted: True}
     # Commercial & local users are not presented with T&C page in login flow (new & existing users)
     if settings.TERMS_NOT_APPLICABLE or is_commercial:
         return {accepted: True}

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -5,7 +5,7 @@
 
 {% if not user.is_authenticated %}
 <!-- Not Auth -->
-{% elif user.rh_org_has_subscription  and user.rh_user_is_org_admin and not org_has_api_key %}
+{% elif user.rh_org_has_subscription and user.rh_user_is_org_admin and not org_has_api_key %}
 <div class="pf-c-alert pf-m-warning" aria-label="Warning alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
@@ -15,7 +15,7 @@
     <a href="/console">Click here</a> to access the Lightspeed admin portal to complete configuration.
   </p>
 </div>
-{% elif user.rh_org_has_subscription and not user.rh_user_is_org_admin and org_has_api_key and user.rh_user_has_seat %}
+{% elif user.rh_org_has_subscription and not user.rh_user_is_org_admin and org_has_api_key and not user.rh_user_has_seat %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
@@ -25,7 +25,7 @@
     Contact your Red Hat account organization administrator for more information on how to assign a named seat.
   </p>
 </div>
-{% elif use_tech_preview and not user.rh_user_has_seat %}
+{% elif use_tech_preview and user.rh_org_has_subscription and not user.rh_user_has_seat %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -3,9 +3,9 @@
 
 {% block content %}
 
-{% if user.is_authenticated and user.rh_org_has_subscription %}
-  {% if user.rh_user_is_org_admin %}
-    {% if not org_has_api_key %}
+{% if not user.is_authenticated %}
+<!-- Not Auth -->
+{% elif user.rh_org_has_subscription  and user.rh_user_is_org_admin and not org_has_api_key %}
 <div class="pf-c-alert pf-m-warning" aria-label="Warning alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
@@ -15,14 +15,17 @@
     <a href="/console">Click here</a> to access the Lightspeed admin portal to complete configuration.
   </p>
 </div>
-    {% endif %}
-  {% endif %}
-{% endif %}
-
-
-{% if user.is_authenticated %}
-  {% if use_tech_preview %}
-    {% if not user.rh_user_has_seat %}
+{% elif user.rh_org_has_subscription and not user.rh_user_is_org_admin and org_has_api_key and user.rh_user_has_seat %}
+<div class="pf-c-alert pf-m-info" aria-label="Information alert">
+  <div class="pf-c-alert__icon">
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+  </div>
+  <p class="pf-c-alert__title">
+    You do not have a licensed seat for Ansible Lightspeed and your organization has configured a commercial model.
+    Contact your Red Hat account organization administrator for more information on how to assign a named seat.
+  </p>
+</div>
+{% elif use_tech_preview and not user.rh_user_has_seat %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
@@ -32,8 +35,6 @@
     Contact your Red Hat account organization administrator for more information on how to assign a named seat.
   </p>
 </div>
-    {% endif %}
-  {% endif %}
 {% endif %}
 
 <section class="pf-c-page__main-section pf-m-light">

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -21,9 +21,8 @@
 
 
 {% if user.is_authenticated %}
-  {% if user.rh_org_has_subscription %}
-    {% if use_tech_preview %}
-      {% if not user.rh_user_has_seat and not org_has_api_key %}
+  {% if use_tech_preview %}
+    {% if not user.rh_user_has_seat %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
@@ -33,8 +32,7 @@
     Contact your Red Hat account organization administrator for more information on how to assign a named seat.
   </p>
 </div>
-        {% endif %}
-      {% endif %}
+    {% endif %}
   {% endif %}
 {% endif %}
 
@@ -61,7 +59,7 @@
               <p>Contact your Red Hat Organization's administrator for more information.
             </div>
 
-{% elif user.is_authenticated and user.rh_org_has_subscription and not user.rh_user_has_seat %}
+{% elif user.is_authenticated and not use_tech_preview and user.rh_org_has_subscription and not user.rh_user_has_seat %}
           <span class="pf-c-icon pf-m-xl pf-m-inline">
             <span class="pf-c-icon__content  pf-m-danger">
               <i class="fas fa-exclamation-circle" aria-hidden="true"></i>

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -22,7 +22,8 @@
 
 {% if user.is_authenticated %}
   {% if user.rh_org_has_subscription %}
-    {% if not user.rh_user_has_seat and not org_has_api_key %}
+    {% if use_tech_preview %}
+      {% if not user.rh_user_has_seat and not org_has_api_key %}
 <div class="pf-c-alert pf-m-info" aria-label="Information alert">
   <div class="pf-c-alert__icon">
     <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
@@ -32,7 +33,8 @@
     Contact your Red Hat account organization administrator for more information on how to assign a named seat.
   </p>
 </div>
-    {% endif %}
+        {% endif %}
+      {% endif %}
   {% endif %}
 {% endif %}
 
@@ -44,7 +46,7 @@
         <div class="pf-c-empty-state__content">
 
 {# https://issues.redhat.com/browse/AAP-18386 #}
-{% if user.is_authenticated and user.rh_org_has_subscription and not user.rh_user_is_org_admin and org_has_api_key and not user.rh_user_has_seat %}
+{% if user.is_authenticated and not use_tech_preview and not user.rh_user_is_org_admin and not user.rh_org_has_subscription %}
           <span class="pf-c-icon pf-m-xl pf-m-inline">
             <span class="pf-c-icon__content  pf-m-danger">
               <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
@@ -52,12 +54,26 @@
           </span>
 
           <h1 class="pf-c-title pf-m-lg">
-            You do not have a licensed seat for Ansible Lightspeed and your organization has configured a commercial model.
+              <p>Your organization doesn't have access to Ansible Lightspeed.
+              <p>Contact your Red Hat account organization administrator for more information.
+          </h1>
+             <div style="padding: 15px">
+              <p>Contact your Red Hat Organization's administrator for more information.
+            </div>
+
+{% elif user.is_authenticated and user.rh_org_has_subscription and not user.rh_user_has_seat %}
+          <span class="pf-c-icon pf-m-xl pf-m-inline">
+            <span class="pf-c-icon__content  pf-m-danger">
+              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            </span>
+          </span>
+
+          <h1 class="pf-c-title pf-m-lg">
+            You do not have a licensed seat for Ansible Lightspeed.
           </h1>
              <div style="padding: 15px">
               <p>Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.
             </div>
-
 {% elif user.is_authenticated and user.rh_org_has_subscription and user.rh_user_has_seat and not org_has_api_key and not user.rh_user_is_org_admin %}
           <span class="pf-c-icon pf-m-xl pf-m-inline">
             <span class="pf-c-icon__content  pf-m-danger">
@@ -66,8 +82,8 @@
           </span>
 
           <h1 class="pf-c-title pf-m-lg">
-              You are a licensed Lightspeed user but your administrator has not configured the service for your organization.
-              Contact your organization administrator to have them complete Lightspeed configuration.
+              <p>You are a licensed Lightspeed user but your administrator has not configured the service for your organization.
+              <p>Contact your organization administrator to have them complete Lightspeed configuration.
           </h1>
              <div style="padding: 15px">
               <p>Contact your Red Hat Organization's administrator for more information.

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -72,7 +72,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch.object(users.models.User, "rh_org_has_subscription", False)
     @patch.object(users.models.User, "rh_user_has_seat", False)
-    def test_rh_admin_without_seat_and_with_secret_with_tech_preview(self):
+    def test_rh_admin_without_seat_and_with_no_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
@@ -86,7 +86,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @patch.object(users.models.User, "rh_org_has_subscription", False)
     @patch.object(users.models.User, "rh_user_has_seat", False)
-    def test_rh_admin_without_seat_and_with_secret_without_tech_preview(self):
+    def test_rh_admin_without_seat_and_with_no_secret_no_sub_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -133,6 +133,22 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "pf-c-alert__title")
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
         self.assertContains(response, "You will be limited to features of the Lightspeed")
+        self.assertNotContains(response, "fas fa-exclamation-circle")
+        self.assertNotContains(response, "Admin Portal")
+        self.assertNotContains(response, "The Tech Preview is no longer available")
+
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='valid')
+    @patch.object(users.models.User, "rh_org_has_subscription", True)
+    @patch.object(users.models.User, "rh_user_has_seat", False)
+    def test_rh_user_without_seat_with_secret_with_tech_preview(self):
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Role:")
+        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
+        self.assertContains(response, "You will be limited to features of the Lightspeed")
+        self.assertNotContains(response, "fas fa-exclamation-circle")
         self.assertNotContains(response, "Admin Portal")
         self.assertNotContains(response, "The Tech Preview is no longer available")
 

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -30,9 +30,9 @@ class UserHomeTestAsAnonymous(WisdomAppsBackendMocking, TestCase):
     def test_unauthorized(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Please log in using the button below.")
+        self.assertContains(response, "Please log in using the button below.", count=1)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
@@ -65,9 +65,9 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: administrator, licensed user")
-        self.assertContains(response, "pf-c-alert__title")
-        self.assertContains(response, "model settings have not been configured")
-        self.assertContains(response, "Admin Portal")
+        self.assertContains(response, "pf-c-alert__title", count=2)
+        self.assertContains(response, "model settings have not been configured", count=1)
+        self.assertContains(response, "Admin Portal", count=1)
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch.object(users.models.User, "rh_org_has_subscription", False)
@@ -76,7 +76,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertNotContains(response, "Admin Portal")
         self.assertNotContains(
             response, "Your organization doesn't have access to Ansible Lightspeed."
@@ -104,7 +104,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: administrator, licensed user")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertContains(response, "Admin Portal")
 
 
@@ -130,7 +130,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
         self.assertContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "fas fa-exclamation-circle")
@@ -144,8 +144,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     def test_rh_user_without_seat_with_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
+        print(response.content)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
         self.assertContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "fas fa-exclamation-circle")
@@ -160,7 +161,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
         self.assertNotContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "Admin Portal")
@@ -186,7 +187,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(
             response, "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant</h1>"
         )
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
@@ -196,8 +197,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role: licensed user")
-        self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed.")
-        self.assertContains(response, "pf-c-alert__title")
+        self.assertNotContains(response, "and your organization has configured a commercial model.")
+        self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -76,11 +76,12 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title", count=2)
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
         self.assertNotContains(
             response, "Your organization doesn't have access to Ansible Lightspeed."
         )
+        self.assertNotContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "The Tech Preview is no longer available")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
@@ -144,7 +145,6 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     def test_rh_user_without_seat_with_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
-        print(response.content)
         self.assertNotContains(response, "Role:")
         self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
@@ -187,7 +187,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(
             response, "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant</h1>"
         )
-        self.assertContains(response, "pf-c-alert__title", count=2)
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
@@ -197,7 +197,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role: licensed user")
-        self.assertNotContains(response, "and your organization has configured a commercial model.")
+        self.assertNotContains(response, "more information on how to get a licensed seat.")
         self.assertContains(response, "pf-c-alert__title", count=2)
         self.assertNotContains(response, "Admin Portal")
 
@@ -243,6 +243,7 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         self.client.login(username=self.user.username, password=self.password)
         r = self.client.get(reverse('home'))
         self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, "pf-c-alert__title", count=1)
         self.assertIn("https://community_docs", str(r.content))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
@@ -254,6 +255,8 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         )
         self.client.login(username=self.user.username, password=self.password)
         r = self.client.get(reverse('home'))
+        self.assertContains(r, "pf-c-alert__title", count=1)
+        self.assertContains(r, "Your organization doesn't have access to Ansible Lightspeed.")
         self.assertIn(settings.COMMERCIAL_DOCUMENTATION_URL, str(r.content))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -27,7 +27,7 @@ class HomeView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["documentation_url"] = settings.DOCUMENTATION_URL
+        context["use_tech_preview"] = settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW
 
         try:
             secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
@@ -40,7 +40,11 @@ class HomeView(TemplateView):
             )
             context["org_has_api_key"] = org_has_api_key
 
-        if self.request.user.is_authenticated and self.request.user.rh_user_has_seat:
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and not (
+            self.request.user.is_authenticated and self.request.user.rh_user_has_seat
+        ):
+            context["documentation_url"] = settings.DOCUMENTATION_URL
+        else:
             context["documentation_url"] = settings.COMMERCIAL_DOCUMENTATION_URL
 
         return context


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-19427>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Introduce the new `ANSIBLE_AI_ENABLE_TECH_PREVIEW` configuration key
that can be use to enable or disable the Tech Preview mode.
By default, the key is enable since the Tech Preview is still supported.

The commit also do the following changes when the Tech Preview is disabled:

- Block access to non seated users to the Completion and Attribution end points
- Return specific error to the VSCode extension when a non-seated user get blocked
- Display clear messages regarding the status of the user

## Testing

The PR is fully unit-tested, you can also set `ANSIBLE_AI_ENABLE_TECH_PREVIEW` to `False` to reproduce a situation where the Tech Preview is disabled.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own