### PR TITLE
Create a warning banner that tech preview model is coming down soon

### DIFF
--- a/ansible_wisdom/main/templates/base.html
+++ b/ansible_wisdom/main/templates/base.html
@@ -9,6 +9,10 @@
     </head>
 
     <body>
+        <div class="pf-c-alert pf-m-warning" style="margin-top:3px">
+            <div class="pf-c-alert__icon"><svg class="pf-svg" viewBox="0 0 576 512" fill="currentColor" aria-hidden="true" role="img" width="1em" height="1em"><path d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"></path></svg></div>
+            <p class="pf-c-alert__title" style="font-weight: normal;"><b>NOTE</b>: Due to overwhelming positive demand, we have extended the availability of the Ansible Lightspeed Technical Preview from December 31, 2023 to <b>February 29, 2024</b>.</p>
+        </div>
         {% if messages %}
             <ul class="messages">
                 {% for message in messages %}

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -31,7 +31,7 @@ class UserHomeTestAsAnonymous(WisdomAppsBackendMocking, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Please log in using the button below.")
         self.assertNotContains(response, "Role:")
-        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title")
         self.assertNotContains(response, "Admin Portal")
 
 
@@ -64,7 +64,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title")
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
@@ -74,7 +74,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: administrator, licensed user")
-        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title")
         self.assertContains(response, "Admin Portal")
 
 
@@ -123,7 +123,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(
             response, "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant</h1>"
         )
-        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title")
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
@@ -134,7 +134,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role: licensed user")
         self.assertContains(response, "your organization has configured a commercial model.")
-        self.assertNotContains(response, "pf-c-alert__title")
+        self.assertContains(response, "pf-c-alert__title")
         self.assertNotContains(response, "Admin Portal")
 
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-19451>
<!-- This PR does not need a corresponding Jira item. -->
Create a simple warning banner that tech preview model is coming down soon

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Start Login page to the web service and you should see the warning about model is coming down soon.
<img width="1251" alt="image" src="https://github.com/ansible/ansible-wisdom-service/assets/1477262/7f973efc-b379-4d6f-aa27-4dc254fcda31">


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Described above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
