### PR TITLE
send segment group event for RHSSO org

### DIFF
--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -15,6 +15,23 @@ logger = logging.getLogger(__name__)
 version_info = VersionInfo()
 
 
+def send_segment_group(group_id: str, group_type: str, group_value: str, user: User) -> None:
+    if not settings.SEGMENT_WRITE_KEY:
+        logger.debug("segment write key not set, skipping group")
+        return
+    try:
+        analytics.group(
+            str(user.uuid), group_id, {'group_type': group_type, 'group_value': group_value}
+        )
+
+        logger.info("sent segment group: %s", group_id)
+    except Exception as ex:
+        logger.exception(
+            f"An exception {ex.__class__} occurred in sending group to segment: %s",
+            group_id,
+        )
+
+
 def send_segment_event(event: Dict[str, Any], event_name: str, user: User) -> None:
     if not settings.SEGMENT_WRITE_KEY:
         logger.info("segment write key not set, skipping event")

--- a/ansible_wisdom/ai/api/utils/tests/test_segment.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment.py
@@ -7,6 +7,7 @@ from ai.api.utils.segment import (
     base_send_segment_event,
     redact_seated_users_data,
     send_segment_event,
+    send_segment_group,
 )
 from ai.api.utils.segment_analytics_telemetry import get_segment_analytics_client
 from django.test import override_settings
@@ -255,6 +256,18 @@ class TestSegment(TestCase):
         self.assertEqual(
             redact_seated_users_data(test_data, ALLOW_LIST['contentmatch']), expected_result
         )
+
+    @mock.patch("ai.api.utils.segment.analytics.group")
+    @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
+    def test_send_segment_group(self, group_method):
+        user = Mock()
+        group_type = 'RH Org'
+        group_value = '1234'
+        send_segment_group('rhsso-1234', group_type, group_value, user)
+        group_method.assert_called_once()
+        traits = group_method.call_args.args[2]
+
+        self.assertEqual(traits, {'group_type': group_type, 'group_value': group_value})
 
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -1,6 +1,7 @@
 import logging
 
 import jwt
+from ai.api.utils.segment import send_segment_group
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -105,6 +106,9 @@ def redhat_organization(backend, user, response, *args, **kwargs):
         id=backend.id_token['organization']['id']
     )[0]
     user.save()
+    send_segment_group(
+        f'rhsso-{user.organization.id}', 'Red Hat Organization', user.organization.id, user
+    )
     return {
         'organization_id': user.organization.id,
         'rh_user_is_org_admin': user.rh_user_is_org_admin,


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-19802

## Description
Amplitude allows us to report not just on users but also accounts. To do this, we need to send "groups" to segment. One option for this is to explicitly map fields from specific events, like `completion`, as group type and value. The other is to explicitly send a group event. I opted for the latter to send the group event whenever a user logs in with RHSSO. This also sets us up for sending other group types in the future. Per my reading re: group id, two things:
    * Segment requires that all Group calls provide a group ID. What you provide as group ID doesn’t matter, but you cannot leave group ID empty.
    * A Group ID is the unique identifier which you recognize a group by in your own database.
Given these two statements, and given that we use the RH org id as the unique identifier for Organizations in our service, rather than a guid, e.g., I though `rhsso-` prefix plus the RH org id was a good unique group id. Open to other suggestions.

I decided to explicitly add traits named Group Type and Group Value to easily map the type and value for Amplitude as described here: https://segment.com/docs/connections/destinations/catalog/amplitude/#group Again, I think this sets us up to add other groups besides RH org in the future. 
 
## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the service with a personal segment api key
3. Log in as a RHSSO user, and request a completion
4. Confirm in segment that your group event flowed. Map it in the Amplitude destination, and confirm it flows correctly to Amplitude (dev).

### Scenarios tested
I tried the steps above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production: Needs to be mapped in segment dev and amplitude dev and confirm behavior is desirable with Marty.
