### PR TITLE
support incomplete plays

### DIFF
--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -78,7 +78,7 @@ class ARICaller:
             try:
                 context_data = yaml.safe_load(context)
                 if isinstance(context_data, list) and any(
-                    play_keyword in context_data[0]
+                    play_keyword in context_data[-1]
                     for play_keyword in ["tasks", "pre_tasks", "post_tasks", "handlers"]
                 ):
                     is_playbook = True

--- a/ansible_wisdom/ari/tests/test_postprocessing.py
+++ b/ansible_wisdom/ari/tests/test_postprocessing.py
@@ -28,3 +28,45 @@ class ARICallerTestCase(TestCase):
         )
         result = ari_caller.indent_suggestion(multi_task_suggestion, 0)
         self.assertEqual(result, multi_task_suggestion)
+
+    def test_make_input_yaml_is_playbook(self):
+        context = '- hosts: all\n  become: true\n  tasks:\n'
+        prompt = '    - name: Install ssh\n'
+        inference_output = (
+            '      ansible.builtin.package:\n        name: openssh-server\n        state: present'
+        )
+
+        ari_caller = postprocessing.ARICaller(
+            config=None,
+            silent=True,
+        )
+        _, is_playbook = ari_caller.make_input_yaml(context, prompt, inference_output)
+        self.assertTrue(is_playbook)
+
+    def test_make_input_yaml_is_playbook_empty_play(self):
+        context = '---\n- hosts: localhost\n\n- hosts: all\n  become: true\n  tasks:\n'
+        prompt = '    - name: Install ssh\n'
+        inference_output = (
+            '      ansible.builtin.package:\n        name: openssh-server\n        state: present'
+        )
+
+        ari_caller = postprocessing.ARICaller(
+            config=None,
+            silent=True,
+        )
+        _, is_playbook = ari_caller.make_input_yaml(context, prompt, inference_output)
+        self.assertTrue(is_playbook)
+
+    def test_make_input_yaml_is_taskfile(self):
+        context = ''
+        prompt = '- name: Install ssh\n'
+        inference_output = (
+            '  ansible.builtin.package:\n        name: openssh-server\n        state: present'
+        )
+
+        ari_caller = postprocessing.ARICaller(
+            config=None,
+            silent=True,
+        )
+        _, is_playbook = ari_caller.make_input_yaml(context, prompt, inference_output)
+        self.assertFalse(is_playbook)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-19756
<!-- This PR does not need a corresponding Jira item. -->

## Description
When a playbook contains multiple plays, and the first one doesn't contain any of the expected keywords such as `tasks` or `handlers`, we incorrectly identify the file as a tasks file, causing ARI to fail.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service
3. Test completions listed in Jira issue

### Scenarios tested
Tested with simplified scenario in Jira issue plus unit tests.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
