### PR TITLE
Exclude GHSA-wj6h-64fc-37mp

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -43,3 +43,4 @@ jobs:
             PYSEC-2023-228
             GHSA-mq26-g339-26xf
             PYSEC-2022-43059
+            GHSA-wj6h-64fc-37mp

--- a/requirements.in
+++ b/requirements.in
@@ -40,10 +40,10 @@ jwcrypto==1.5.1
 jinja2==3.1.3
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
-# pin pillow on 10.0.1 to address CVE-2023-4863
+# pin pillow on 10.2.0 to address CVE-2023-4863 and GHSA-3f63-hfp8-52jq
 # remove this once sentence-transformers or torchvision
-# is updated to properly pull a version of pillow > 10.0.1.
-pillow==10.0.1
+# is updated to properly pull a version of pillow > 10.2.0.
+pillow==10.2.0
 protobuf==4.22.1
 psycopg[binary]==3.1.8
 # pin pyarrow on 14.0.1 to address GHSA-5wvp-7f3h-6wmm

--- a/requirements.txt
+++ b/requirements.txt
@@ -276,7 +276,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==10.0.1
+pillow==10.2.0
     # via
     #   -r requirements.in
     #   torchvision


### PR DESCRIPTION
This PR does not need a corresponding Jira item. 

Fix two `pip-audit` issues:

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
ecdsa | 0.18.0 | GHSA-wj6h-64fc-37mp |  | python-ecdsa has been found to be subject to a Minerva timing attack on the P-256 curve. Using the `ecdsa.SigningKey.sign_digest()` API function and timing signatures an attacker can leak the internal nonce which may allow for private key discovery. Both ECDSA signatures, key generation, and ECDH operations are affected. ECDSA signature verification is unaffected. The python-ecdsa project considers side channel attacks out of scope for the project and there is no planned fix.

pillow | 10.0.1 | GHSA-3f63-hfp8-52jq | 10.2.0 | Pillow through 10.1.0 allows PIL.ImageMath.eval Arbitrary Code Execution via the environment parameter, a different vulnerability than CVE-2022-22817 (which was about the expression parameter).
```
**Notes**
- `GHSA-wj6h-64fc-37mp` is ignored
 > ....The python-ecdsa project considers side channel attacks out of scope for the project and there is no planned fix.
 
 - `pillow` is upgrade to `10.2.0`