### PR TITLE
DRAFT: mock a valid seated OIDC user

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ and always use the dummy `WCA_SECRET_BACKEND_TYPE`:
 export WCA_SECRET_BACKEND_TYPE="dummy"
 export WCA_SECRET_DUMMY_SECRETS="11009103:valid"
 ```
-In this example, `11009103`` is your organization id. In this case the model is set to `valid`.
+In this example, `11009103` is your organization id. In this case the model is set to `valid`.
 You can also use the following syntax to set both the model and set key_id:
-`WCA_SECRET_DUMMY_SECRETS='123:my-key<|sepofid|>sec'`
+`WCA_SECRET_DUMMY_SECRETS='11009103:ibm_api_key<sep>model_id<|sepofid|>model_name'`
 
 
 

--- a/ansible_wisdom/ai/api/aws/wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/wca_secret_manager.py
@@ -59,7 +59,7 @@ class DummySecretManager(BaseSecretManager):
 
             org_id = int(values[0])
 
-            fields = values[1].split("<|sepofid|>", 1)
+            fields = values[1].split("<sep>", 1)
             if len(fields) == 1 and fields[0]:
                 output[org_id] = {
                     Suffixes.API_KEY: DummySecretEntry.from_string("some-key"),

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -144,8 +144,9 @@ class WCAClient(ModelMeshClient):
 
         api_key: Optional[int] = None
         try:
-            api_key = self.get_api_key(rh_user_has_seat, organization_id)
-            model_id = self.get_model_id(rh_user_has_seat, organization_id, model_id)
+            if rh_user_has_seat and organization_id:
+                api_key = self.get_api_key(rh_user_has_seat, organization_id)
+            model_id = self.get_model_id(rh_user_has_seat, organization_id, model_id) or ''
             result = self.infer_from_parameters(api_key, model_id, context, prompt, suggestion_id)
 
             response = result.json()

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -49,6 +49,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         return None
 
     def is_oidc_user(self) -> bool:
+        return True
         if not self.social_auth.values():
             return False
         if self.social_auth.values()[0]["provider"] != USER_SOCIAL_AUTH_PROVIDER_OIDC:
@@ -59,6 +60,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
     @cached_property
     def rh_user_has_seat(self) -> bool:
         """True if the user comes from RHSSO and has a Wisdom Seat."""
+        return True
         # For dev/test purposes only:
         if self.groups.filter(name='Commercial').exists():
             return True
@@ -76,6 +78,7 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
     @cached_property
     def rh_org_has_subscription(self) -> bool:
         """True if the user comes from RHSSO and the associated org has access to Wisdom."""
+        return True
         if not self.is_oidc_user():
             return False
 


### PR DESCRIPTION
Create the token with:

```
podman exec -it docker-compose_django_1 wisdom-manage createtoken --token-name=$LIGHTSPEED_TOKEN --duration 600000 --username roger --organization-id 11009103 --create-user
```

And run the service with the following envvars:

```
set -x AUTHZ_BACKEND_TYPE "dummy"
set -x AUTHZ_DUMMY_USERS_WITH_SEAT "roger"
set -x AUTHZ_DUMMY_RH_ORG_ADMINS "roger"
set -x AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION "11009103"

set -x WCA_CLIENT_BACKEND_TYPE "dummy"
set -x WCA_SECRET_BACKEND_TYPE "dummy"
set -x WCA_SECRET_DUMMY_SECRETS "11009103:valid"
set -x ANSIBLE_AI_MODEL_MESH_API_TYPE "dummy"
```
