### PR TITLE
requirements: upgrade aiohttp

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # pin aiohttp on 3.8.6 to address GHSA-gfw2-4jvh-wgfg
 # remove this once datasets or fsspec is updated
 # to properly pull a version of aiohttp > 3.8.5.
-aiohttp==3.9.0
+aiohttp==3.9.3
 # pin ansible on 8.5.0 to address GHSA-jpvw-p8pr-9g2x
 # remove this once ansible-risk-insight is updated to properly
 # pull a version of ansible >= 8.5.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-aiohttp==3.9.0
+aiohttp==3.9.3
     # via
     #   -r requirements.in
     #   datasets


### PR DESCRIPTION
Bump the aiohttp version to 3.9.3 to address:

- GHSA-5h86-8mv2-jq9f
- GHSA-8qpw-xqxj-h4r2
