### PR TITLE
AAP-20249: Admin Dashboard: [Feature flag] -M-A-G-I-C- Organizations

### DIFF
--- a/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
@@ -48,7 +48,7 @@ class TelemetrySettingsView(RetrieveAPIView, CreateAPIView):
     def get(self, request, *args, **kwargs):
         logger.debug("Telemetry settings:: GET handler")
 
-        if not settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
+        if not settings.TELEMETRY_SCHEMA_2_ENABLED:
             raise ServiceUnavailable()
 
         exception = None
@@ -94,7 +94,7 @@ class TelemetrySettingsView(RetrieveAPIView, CreateAPIView):
     def post(self, request, *args, **kwargs):
         logger.debug("Telemetry settings:: POST handler")
 
-        if not settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
+        if not settings.TELEMETRY_SCHEMA_2_ENABLED:
             raise ServiceUnavailable()
 
         exception = None

--- a/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
@@ -36,7 +36,7 @@ class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
         for permission in required_permissions:
             self.assertTrue(permission in view.permission_classes)
 
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
+    @override_settings(TELEMETRY_SCHEMA_2_ENABLED=False)
     def test_get_settings_when_feature_disabled(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('telemetry_settings'))
@@ -80,7 +80,7 @@ class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
         r = self.client.post(reverse('telemetry_settings'))
         self.assertEqual(r.status_code, HTTPStatus.UNAUTHORIZED)
 
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
+    @override_settings(TELEMETRY_SCHEMA_2_ENABLED=False)
     def test_set_settings_when_feature_disabled(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('telemetry_settings'))

--- a/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
@@ -3,6 +3,7 @@ import logging
 from ai.api.utils.segment import base_send_segment_event, send_segment_event
 from attr import asdict
 from django.conf import settings
+from organizations.models import Organization
 from segment.analytics import Client
 from users.models import User
 
@@ -29,16 +30,29 @@ def send_segment_analytics_event(event_enum, event_payload_supplier, user: User)
     if not user.rh_user_has_seat:
         logger.info("Skipping analytics telemetry event for users that has no seat.")
         return
-    if not settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
-        logger.info("Analytics telemetry not active.")
-        return
-    organization = user.organization
+
+    organization: Organization = user.organization
     if not organization:
         logger.info("Analytics telemetry not active, because of no organization assigned for user.")
         return
+
     if organization.telemetry_opt_out:
-        logger.info("Analytics telemetry not active for organization.")
-        return
+        if not organization.is_schema_2_telemetry_override_enabled:
+            logger.info("Analytics telemetry not active for organization.")
+            return
+        logger.info(
+            f'Organization {organization.id} telemetry settings overridden. '
+            f'Telemetry will be captured for Organization {organization.id}.'
+        )
+
+    if not settings.TELEMETRY_SCHEMA_2_ENABLED:
+        if not organization.is_schema_2_telemetry_override_enabled:
+            logger.info("Analytics telemetry not active.")
+            return
+        logger.info(
+            f'System telemetry settings overridden. '
+            f'Telemetry will be captured for Organization {organization.id}.'
+        )
 
     event_name = event_enum.value
     try:

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 from enum import Enum
+from typing import Union
 
 from django.conf import settings
 from ldclient import Context
@@ -13,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 class WisdomFlags(str, Enum):
-    MODEL_NAME = "model_name"  # model name selection
+    # model name selection
+    MODEL_NAME = "model_name"
+    # white list of org_id's for which Schema 2 Telemetry is enabled overriding all other settings.
+    SCHEMA_2_TELEMETRY_ORG_ID_WHITE_LIST = "schema_2_telemetry_org_id_white_list"
 
 
 class FeatureFlags:
@@ -42,9 +46,9 @@ class FeatureFlags:
                 )
                 logger.info("feature flag client initialized")
 
-    def get(self, name: str, user: User, default: str):
+    def get(self, name: str, user: Union[User, None], default: str):
         if self.client:
-            if user.is_anonymous:
+            if not user or user.is_anonymous:
                 user_context = Context.builder("AnonymousUser").anonymous(True).build()
             else:
                 groups = list(user.groups.values_list("name", flat=True))

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -23,7 +23,18 @@ class TestFeatureFlags(WisdomServiceAPITestCaseBase):
 
         ff = feature_flags.FeatureFlags()
         value = ff.get('model_name', self.user, 'default_value')
+        self.assert_test_feature_flags_with_sdk_key(LDClient, value)
 
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_feature_flags_with_sdk_key_without_user(self, LDClient):
+        LDClient.return_value.variation.return_value = 'server:port:model_name:index'
+
+        ff = feature_flags.FeatureFlags()
+        value = ff.get('model_name', None, 'default_value')
+        self.assert_test_feature_flags_with_sdk_key(LDClient, value)
+
+    def assert_test_feature_flags_with_sdk_key(self, LDClient, value):
         self.assertEqual(value, 'server:port:model_name:index')
         LDClient.assert_called_once()
         _, config_arg, kwargs = LDClient.mock_calls[0]

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -82,4 +82,4 @@ WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
 WCA_CLIENT_BACKEND_TYPE = os.getenv("WCA_CLIENT_BACKEND_TYPE", "dummy")  # or wcaclient
 
 # Enable Telemetry Opt In/Out settings in the Admin Portal
-ADMIN_PORTAL_TELEMETRY_OPT_ENABLED = True
+TELEMETRY_SCHEMA_2_ENABLED = True

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -41,4 +41,4 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
 # Disable Telemetry Opt In/Out settings in the Admin Portal
-ADMIN_PORTAL_TELEMETRY_OPT_ENABLED = os.getenv('ADMIN_PORTAL_TELEMETRY_OPT_ENABLED', False)
+TELEMETRY_SCHEMA_2_ENABLED = os.getenv('TELEMETRY_SCHEMA_2_ENABLED', False)

--- a/ansible_wisdom/main/templates/console/console.html
+++ b/ansible_wisdom/main/templates/console/console.html
@@ -18,5 +18,5 @@
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
     <!-- Flag whether Telemetry settings is supported -->
-    <div id="telemetry_opt_enabled" hidden>{{telemetry_opt_enabled}}</div>
+    <div id="telemetry_schema_2_enabled" hidden>{{telemetry_schema_2_enabled}}</div>
 {% endblock content %}

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -68,7 +68,7 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         context = response.context_data
         self.assertEqual(context['user_name'], self.user.username)
         self.assertEqual(context['rh_org_has_subscription'], self.user.rh_org_has_subscription)
-        self.assertTrue(context['telemetry_opt_enabled'])
+        self.assertTrue(context['telemetry_schema_2_enabled'])
 
     def test_extra_data_telemetry_opt_in(self, *args):
         self.client.force_authenticate(user=self.user)
@@ -76,12 +76,12 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         self.assertIsInstance(response.context_data, dict)
         context = response.context_data
         # The default setting for tests is True
-        self.assertTrue(context['telemetry_opt_enabled'])
+        self.assertTrue(context['telemetry_schema_2_enabled'])
 
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
+    @override_settings(TELEMETRY_SCHEMA_2_ENABLED=False)
     def test_extra_data_telemetry_opt_out(self, *args):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(reverse('console'))
         self.assertIsInstance(response.context_data, dict)
         context = response.context_data
-        self.assertFalse(context['telemetry_opt_enabled'])
+        self.assertFalse(context['telemetry_schema_2_enabled'])

--- a/ansible_wisdom/main/tests/test_urls.py
+++ b/ansible_wisdom/main/tests/test_urls.py
@@ -37,7 +37,7 @@ class TestUrls(TestCase):
         )
         self.assertEqual(1, len(patterns))
 
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
+    @override_settings(TELEMETRY_SCHEMA_2_ENABLED=False)
     def test_telemetry_patterns_when_disabled(self):
         reload(main.urls)
         r = compile("api/v0/telemetry/")

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -62,7 +62,7 @@ urlpatterns = [
     path('console/<slug:slug1>/<slug:slug2>/', ConsoleView.as_view(), name='console'),
 ]
 
-if settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
+if settings.TELEMETRY_SCHEMA_2_ENABLED:
     urlpatterns += [
         path(
             f'api/{WISDOM_API_VERSION}/telemetry/',

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -66,5 +66,5 @@ class ConsoleView(ProtectedTemplateView):
         if self.request.user:
             context["user_name"] = self.request.user.username
             context["rh_org_has_subscription"] = self.request.user.rh_org_has_subscription
-            context["telemetry_opt_enabled"] = settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED
+            context["telemetry_schema_2_enabled"] = settings.TELEMETRY_SCHEMA_2_ENABLED
         return context

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -1,6 +1,8 @@
 import logging
 
+from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 
 logger = logging.getLogger(__name__)
 
@@ -8,3 +10,20 @@ logger = logging.getLogger(__name__)
 class Organization(models.Model):
     id = models.IntegerField(primary_key=True)
     telemetry_opt_out = models.BooleanField(default=False)
+
+    @cached_property
+    def is_schema_2_telemetry_override_enabled(self):
+        if not settings.LAUNCHDARKLY_SDK_KEY:
+            return False
+
+        # Avoid circular dependency issue with lazy import
+        from ai.feature_flags import FeatureFlags, WisdomFlags
+
+        feature_flags = FeatureFlags()
+        org_ids: str = feature_flags.get(WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ID_WHITE_LIST, None, '')
+        if len(org_ids) == 0:
+            return False
+
+        # Favor cast to str vs cast to int as we cannot
+        # guarantee Users defined numbers in LaunchDarkly
+        return any(org_id == str(self.id) for org_id in org_ids.split(','))

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import ai.feature_flags as feature_flags
+from django.test import TestCase, override_settings
+from organizations.models import Organization
+
+
+class TestIsOrgLightspeedSubscriber(TestCase):
+    def test_org_with_telemetry_schema_2_enabled(self):
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    def test_org_with_telemetry_schema_2_disabled(self):
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags(self, LDClient):
+        LDClient.return_value.variation.return_value = ''
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = '999'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_override(self, LDClient):
+        LDClient.return_value.variation.return_value = '123'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_overrides(self, LDClient):
+        LDClient.return_value.variation.return_value = '000,999,123'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)

--- a/ansible_wisdom_console_react/public/index.html
+++ b/ansible_wisdom_console_react/public/index.html
@@ -11,6 +11,6 @@
 <div id="root" class="Root"></div>
 <script type="module" src="/src/index.tsx"></script>
 <div id="user_name" hidden>development-user</div>
-<div id="telemetry_opt_enabled" hidden>true</div>
+<div id="telemetry_schema_2_enabled" hidden>true</div>
 </body>
 </html>

--- a/ansible_wisdom_console_react/src/index.tsx
+++ b/ansible_wisdom_console_react/src/index.tsx
@@ -10,14 +10,14 @@ import "./i18n";
 import "./index.css";
 
 const userName = document.getElementById("user_name")?.innerText ?? "undefined";
-const telemetryOptEnabledInnerText = document.getElementById(
-  "telemetry_opt_enabled",
+const telemetrySchema2EnabledInnerText = document.getElementById(
+  "telemetry_schema_2_enabled",
 )?.innerText;
-const telemetryOptEnabled =
-  telemetryOptEnabledInnerText?.toLowerCase() === "true";
+const telemetrySchem2Enabled =
+  telemetrySchema2EnabledInnerText?.toLowerCase() === "true";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App userName={userName} telemetryOptEnabled={telemetryOptEnabled} />
+    <App userName={userName} telemetryOptEnabled={telemetrySchem2Enabled} />
   </StrictMode>,
 );


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20249

## Description
This introduces a _magic_ flag in LaunchDarkly for a (comma-separated) white-list of `org_id`'s that circumvent all known checks for "Schema 2 Telemetry". i.e. if an `org_id` is present in LaunchDarkly then the "Schema 2 Telemetry" opt-in/out flag will be present in `/me` irrespective of other settings. Furthermore "Schema 2 Telemetry" events will be sent to Segment. 

See https://github.com/ansible/ansible-wisdom-service/pull/776 for details of local LaunchDarkly test support :tada: 

## Testing
1) `settings.development.TELEMETRY_SCHEMA_2_ENABLED = True`

Using the LaunchDarkly override settings detailed in #776 try with local settings for:
- `"schema_2_telemetry_org_id_white_list": "1234567[*]"` - Expect `org_telemetry_opt_out: false` to be present.
- `"schema_2_telemetry_org_id_white_list": ""` - Expect `org_telemetry_opt_out` to be missing.

For each, execute the `api/v0/me` endpoint and compare results with the expectations above.

1) `settings.development.TELEMETRY_SCHEMA_2_ENABLED = False`

Using the LaunchDarkly override settings detailed in #776 try with local settings for:
- `"schema_2_telemetry_org_id_white_list": "1234567[*]"` - Expect `org_telemetry_opt_out: false` to be present.
- `"schema_2_telemetry_org_id_white_list": ""` - Expect `org_telemetry_opt_out` to be missing.

For each, execute the `api/v0/me` endpoint and compare results with the expectations above.

[*] `1234567` is whatever `org_id` your local login belongs to.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. `make run-server` (or whatever you normally do)

### Scenarios tested
See "Testing" above.

## Production deployment
- [] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

I renamed the system-wide environment variable to `TELEMETRY_SCHEMA_2_ENABLED`.

This needs to be reflected in Staging Secret Manager.