### PR TITLE
podman-compose: fix the name of the wisdom-service image

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -3,6 +3,7 @@ services:
   django:
     user: "1000"
     platform: linux/amd64
+    image: localhost/docker-compose_django:latest
     build:
       context: $PWD
       dockerfile: wisdom-service.Containerfile


### PR DESCRIPTION
When we only have the `build` key set, the image that is set to the
newly created image doesn't match the expectation.
By fixing the name of the local image, we avoid a problem.

From https://docs.docker.com/compose/compose-file/compose-file-v3/

> If you specify image as well as build, then Compose names the
> built image with the webapp and optional tag specified in image:

