### PR TITLE
disable seat assignment check from wisdom service

### DIFF
--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -53,7 +53,7 @@ class BlockUserWithoutSeatAndWCAReadyOrg(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        if user.organization is None:
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.organization is None:
             # We accept the Community users, the won't have access to WCA
             return True
         if user.rh_user_has_seat is True:
@@ -75,6 +75,8 @@ class BlockUserWithSeatButWCANotReady(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.organization is None:
+            return True
         if user.organization is None:
             # We accept the Community users, the won't have access to WCA
             return True
@@ -101,3 +103,18 @@ class BlockUserWithoutSeat(permissions.BasePermission):
             return True
 
         return user.rh_user_has_seat
+
+
+class BlockUserWhenOrgHasNoSubscription(permissions.BasePermission):
+    """
+    Ensure the user's Org has a subscription
+    """
+
+    code = 'permission_denied__no_licence'
+    message = "User doesn't have access to the IBM watsonx Code Assistant."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW:
+            return True
+        return user.rh_org_has_subscription

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -50,6 +50,7 @@ from .data.data_model import (
 from .model_client.exceptions import ModelTimeoutError
 from .permissions import (
     AcceptedTermsPermission,
+    BlockUserWhenOrgHasNoSubscription,
     BlockUserWithoutSeat,
     BlockUserWithoutSeatAndWCAReadyOrg,
     BlockUserWithSeatButWCANotReady,
@@ -119,6 +120,7 @@ class Completions(APIView):
         BlockUserWithoutSeat,
         BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
+        BlockUserWhenOrgHasNoSubscription,
     ]
     required_scopes = ['read', 'write']
 
@@ -311,6 +313,7 @@ class Attributions(GenericAPIView):
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
         BlockUserWithoutSeat,
+        BlockUserWhenOrgHasNoSubscription,
     ]
     required_scopes = ['read', 'write']
 
@@ -404,6 +407,7 @@ class ContentMatches(GenericAPIView):
         IsAuthenticatedOrTokenHasScope,
         AcceptedTermsPermission,
         BlockUserWithoutSeat,
+        BlockUserWhenOrgHasNoSubscription,
     ]
     required_scopes = ['read', 'write']
 

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -474,3 +474,8 @@ ENABLE_HEALTHCHECK_AUTHORIZATION = (
 ENABLE_HEALTHCHECK_ATTRIBUTION = (
     os.getenv('ENABLE_HEALTHCHECK_ATTRIBUTION', 'True').lower() == 'true'
 )
+
+# NOTE: This key will be removed after the seat support removal
+ENABLE_SEAT_SUPPORT_DEFAULT_VALUE = (
+    os.getenv('ENABLE_SEAT_SUPPORT_DEFAULT_VALUE', 'True').lower() == 'true'
+)

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 
+from ai.feature_flags import FeatureFlags
 from django.apps import apps
 from django.contrib.auth.models import AbstractUser
 from django.db import models
@@ -12,6 +13,7 @@ from organizations.models import Organization
 from .constants import FAUX_COMMERCIAL_USER_ORG_ID, USER_SOCIAL_AUTH_PROVIDER_OIDC
 
 logger = logging.getLogger(__name__)
+feature_flags = FeatureFlags()
 
 
 class NonClashingForeignKey(models.ForeignKey):
@@ -59,6 +61,8 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
     @cached_property
     def rh_user_has_seat(self) -> bool:
         """True if the user comes from RHSSO and has a Wisdom Seat."""
+        if not feature_flags.has_seat_support(self):
+            return True
         # For dev/test purposes only:
         if self.groups.filter(name='Commercial').exists():
             return True

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -2,6 +2,7 @@ import logging
 
 from ai.api.aws.exceptions import WcaSecretManagerMissingCredentialsError
 from ai.api.aws.wca_secret_manager import Suffixes
+from ai.feature_flags import FeatureFlags
 from django.apps import apps
 from django.conf import settings
 from django.forms import Form
@@ -20,6 +21,7 @@ from .serializers import UserResponseSerializer
 
 ME_USER_CACHE_TIMEOUT_SEC = settings.ME_USER_CACHE_TIMEOUT_SEC
 logger = logging.getLogger(__name__)
+feature_flags = FeatureFlags()
 
 
 class HomeView(TemplateView):
@@ -41,7 +43,9 @@ class HomeView(TemplateView):
             context["org_has_api_key"] = org_has_api_key
 
         if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and not (
-            self.request.user.is_authenticated and self.request.user.rh_user_has_seat
+            self.request.user.is_authenticated
+            and feature_flags.has_seat_support(self.request.user)
+            and self.request.user.rh_user_has_seat
         ):
             context["documentation_url"] = settings.DOCUMENTATION_URL
         else:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-19864>
<!-- This PR does not need a corresponding Jira item. -->

## Description

This change introduce a Feature flag `has_seat_support` that can be used to
disable the seat check and always return `True`.
It also declares a new configuration key called `ENABLE_SEAT_SUPPORT_DEFAULT_VALUE`
that define what should be the default value for the new feature flag above.

The goal is to do the transition following these steps:

1. Define the `has_seat_support` Feature flag has `True`
2. Set it to `False` for a specific user
3. Validate the behaviour for the user
4. Switch it to `False` by default
5. Change the `ENABLE_SEAT_SUPPORT_DEFAULT_VALUE` envar to `False` to lock the behaviour

Once this is done, another commit will follow to remove the code associated with the Seat management.
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

## Testing

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

Switch `ENABLE_SEAT_SUPPORT_DEFAULT_VALUE` to `False` or create the `has_seat_support` FF.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: