### PR TITLE
upgrade grpcio to 1.60.1 to address GHSA-p25m-jpj4-qcrr

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ django_prometheus==2.2.0
 django-test-migrations==1.3.0
 djangorestframework==3.14.0
 drf-spectacular==0.25.1
-grpcio==1.54.2
+grpcio==1.60.1
 ipython==8.10.0
 # pin jwcrypto on 1.5.1 to address GHSA-cw2r-4p82-qv79
 # remove this once django-oauth-toolkit is updated to properly

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,7 +157,7 @@ fsspec[http]==2023.5.0
     #   huggingface-hub
 gitdb==4.0.10
     # via ansible-risk-insight
-grpcio==1.54.2
+grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.20.1
     # via


### PR DESCRIPTION
Upgrade grpcio to address the following problem reported by `pip-audit`:

> grpcio | 1.54.2 | GHSA-p25m-jpj4-qcrr | 1.53.2,1.54.3,1.55.3 |
> Lack of error handling in the TCP server in Google's gRPC starting version
> 1.23 on posix-compatible platforms (ex. Linux) allows an attacker to cause
> a denial of service by initiating a significant number of connections with
> the server. Note that gRPC C++ Python, and Ruby are affected, but gRPC Java,
> and Go are NOT affected.
