### PR TITLE
Analytics telemetry opting-out support

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -174,8 +174,8 @@ class FeedbackRequestSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_commercial_user_not_opted_out_passes_on_inlineSuggestion(self):
-        org = Mock(telemetry_opt_out=False)
+    def test_commercial_user_not_telemetry_enabled_raises_exception_on_inlineSuggestion(self):
+        org = Mock(telemetry_opt_out=False, is_schema_2_telemetry_enabled=False)
         user = Mock(rh_user_has_seat=True, organization=org)
         request = Mock(user=user)
         serializer = FeedbackRequestSerializer(
@@ -190,7 +190,27 @@ class FeedbackRequestSerializerTest(TestCase):
             },
         )
 
-        # inlineSuggestion feedback allowed is user seated but not opted Out
+        # inlineSuggestion feedback raises exception when seat and not telemetry enabled
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_commercial_user_not_opted_out_passes_on_inlineSuggestion(self):
+        org = Mock(telemetry_opt_out=False, is_schema_2_telemetry_enabled=True)
+        user = Mock(rh_user_has_seat=True, organization=org)
+        request = Mock(user=user)
+        serializer = FeedbackRequestSerializer(
+            context={'request': request},
+            data={
+                "inlineSuggestion": {
+                    "latency": 1000,
+                    "userActionTime": 5155,
+                    "action": "0",
+                    "suggestionId": "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
+                }
+            },
+        )
+
+        # inlineSuggestion feedback allowed if user seated but not opted Out
         try:
             serializer.is_valid(raise_exception=True)
         except Exception:

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -56,18 +56,6 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
 
         return True
 
-    # It should be static since we in tests we have AnonymUser and for this case
-    # we just use static User.is_opt_out method.
-    @staticmethod
-    def is_opt_out(user):
-        return (
-            True
-            if hasattr(user, 'organization')
-            and user.organization is not None
-            and user.organization.telemetry_opt_out
-            else False
-        )
-
     @cached_property
     def rh_user_has_seat(self) -> bool:
         """True if the user comes from RHSSO and has a Wisdom Seat."""


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18663>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Since the addition of the opt-out flag for the analytics telemetry, the VSCode extension should send data to the wisdom service if user is not Opt Out from sending telemetry [VS Code extension](https://github.com/ansible/vscode-ansible/pull/1078)). Also Wisdom service (this PR) should send an event to the segment if user is not opt out from the telemetry.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR and [vscode-ansible](https://github.com/ansible/vscode-ansible/pull/1078) PR
2. Create a user without org and/or user with opt out from telemetry org
3. Do a completion in VS Code plugin. Now one events will be send to the wisdom service (and to the segment).
4. Add user with org with not opt out from telemetry
5. Do a completion in VS Code plugin. Now two events will be send to the wisdom service (and to the segment after) Recommendation Action event is sent to the wisdom service and further to the segment.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Described above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own