### PR TITLE
createtoken: add new --organization-id parameter

### DIFF
--- a/ansible_wisdom/users/management/commands/createtoken.py
+++ b/ansible_wisdom/users/management/commands/createtoken.py
@@ -8,6 +8,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.timezone import now
 from oauth2_provider.models import AccessToken
 from oauthlib.common import generate_token
+from organizations.models import Organization
 
 
 class Command(BaseCommand):
@@ -15,6 +16,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--username', type=str, help="User associated with the token")
+        parser.add_argument('--organization-id', type=str, help="Org id of the user")
         parser.add_argument(
             '--token-name', type=str, help="Name of the token", default=generate_token()
         )
@@ -28,7 +30,9 @@ class Command(BaseCommand):
             '--duration', type=int, help="How long the token is valid (minute)", default=60
         )
 
-    def handle(self, username, token_name, duration, create_user, groups, *args, **options):
+    def handle(
+        self, username, organization_id, token_name, duration, create_user, groups, *args, **options
+    ):
         u = None
         if not token_name:
             raise CommandError("token_name cannot be empty")
@@ -40,8 +44,15 @@ class Command(BaseCommand):
             if create_user:
                 n = now()
                 u = User.objects.create_user(
-                    username=username, community_terms_accepted=n, commercial_terms_accepted=n
+                    username=username,
+                    external_username=username,
+                    community_terms_accepted=n,
+                    commercial_terms_accepted=n,
                 )
+                if organization_id:
+                    u.organization = Organization.objects.get_or_create(id=organization_id)[0]
+                    u.save()
+
             else:
                 raise CommandError(f"Cannot find user {username}")
         else:

--- a/ansible_wisdom/users/management/commands/test_createtoken.py
+++ b/ansible_wisdom/users/management/commands/test_createtoken.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from oauth2_provider.models import AccessToken
+from organizations.models import Organization
+
+
+class TestCreateToken(TestCase):
+    def tearDown(self):
+        User = get_user_model()
+        AccessToken.objects.filter(token="test-token").delete()
+        User.objects.filter(username="my-test-token-user").delete()
+        Organization.objects.filter(id=12345).delete()
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "createtoken",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_empty_parameter(self):
+        with self.assertRaises(CommandError) as e:
+            self.call_command()
+            self.assertContain(e.msg, "Cannot find user")
+
+    def test_with_extra_parameters(self):
+        self.call_command(
+            "--token-name",
+            "test-token",
+            "--username",
+            "my-test-token-user",
+            "--create-user",
+            "--organization-id=12345",
+        )
+        User = get_user_model()
+        new_user = User.objects.filter(username="my-test-token-user")[0]
+        self.assertTrue(new_user.organization.id, 12345)
+        self.assertTrue(AccessToken.objects.filter(token="test-token").exists())


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-20004>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Add the ability to set an orgranization id to a new user.

## Testing

The use-case is fully tested by a unit-test.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own