### PR TITLE
typing: extend coverage to permissions.py and apps.py

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -21,5 +21,5 @@ jobs:
         python-version: '3.11'
     - name: install
       run: |
-        pip install pyright django boto3 requests prometheus_client backoff django_prometheus
+        pip install pyright django boto3 requests prometheus_client backoff django_prometheus djangorestframework-stubs[compatible-mypy]
         pyright

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -1,12 +1,12 @@
 import logging
 
 from ansible_lint import lintpostprocessing
-from ansible_risk_insight.scanner import Config
+from ansible_risk_insight.scanner import Config  # type: ignore
 from django.apps import AppConfig
 from django.conf import settings
 from users.authz_checker import AMSCheck, CIAMCheck, DummyCheck
 
-from ari import postprocessing
+from ari import postprocessing  # type: ignore
 
 from .api.aws.wca_secret_manager import AWSSecretManager, DummySecretManager
 from .api.model_client.dummy_client import DummyClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,13 @@ skip-string-normalization = true
 profile = "black"
 
 [tool.pyright]
-include = ["ansible_wisdom/ai/api/aws/wca_secret_manager.py", "ansible_wisdom/users/authz_checker.py", "ansible_wisdom/ai/api/model_client/wca_client.py"]
+include = [
+    "ansible_wisdom/ai/api/aws/wca_secret_manager.py",
+    "ansible_wisdom/users/authz_checker.py",
+    "ansible_wisdom/ai/api/model_client/wca_client.py",
+    "ansible_wisdom/ai/api/permissions.py",
+    "ansible_wisdom/ai/apps.py",
+]
 exclude = ["**/test_*.py", "ansible_wisdom/*/migrations/*.py"]
 
 reportMissingImports = true


### PR DESCRIPTION
Also properly log an error if the `secret_manager` is not initialized.
