### PR TITLE
AAP-20249: Admin Dashboard: [Feature flag] -M-A-G-I-C- Organizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ ari/kb/rules/
 
 # Generated Grafana files
 grafana/*
+
+# Local LaunchDarkly data
+./flagdata.json

--- a/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import ai.feature_flags as feature_flags
 from ai.api.tests.test_views import WisdomServiceAPITestCaseBase
 from ai.api.utils import segment_analytics_telemetry
 from ai.api.utils.analytics_telemetry_model import (
@@ -74,11 +75,13 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
             error_event_payload, "analyticsTelemetryError", self.user
         )
 
-    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
-    def test_send_segment_analytics_event(self, base_send_segment_event):
-        analytics_event_object = AnalyticsProductFeedback("3", 123)
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    def test_send_segment_analytics_event(self, base_send_segment_event, LDClient):
+        LDClient.return_value.variation.return_value = True
+        analytics_event_object = AnalyticsProductFeedback(3, 123)
         payload = Mock(return_value=analytics_event_object)
         send_segment_analytics_event(AnalyticsTelemetryEvents.PRODUCT_FEEDBACK, payload, self.user)
         payload.assert_called()
@@ -89,10 +92,12 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
             get_segment_analytics_client(),
         )
 
-    @patch("ai.api.utils.segment_analytics_telemetry.send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
-    def test_send_segment_analytics_event_error_validation(self, send_segment_event):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.send_segment_event")
+    def test_send_segment_analytics_event_error_validation(self, send_segment_event, LDClient):
+        LDClient.return_value.variation.return_value = True
         payload = Mock(side_effect=ValueError)
         send_segment_analytics_event(AnalyticsTelemetryEvents.PRODUCT_FEEDBACK, payload, self.user)
         payload.assert_called()
@@ -107,42 +112,58 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
             error_event_payload, "analyticsTelemetryError", self.user
         )
 
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
     @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
-    def test_send_segment_analytics_event_error_not_write_key(self, base_send_segment_event):
+    def test_send_segment_analytics_event_error_not_write_key(
+        self, base_send_segment_event, LDClient
+    ):
+        LDClient.return_value.variation.return_value = True
         self._assert_event_not_sent(base_send_segment_event)
 
-    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
-    def test_send_segment_analytics_event_error_user_no_seat(self, base_send_segment_event):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    def test_send_segment_analytics_event_error_user_no_seat(
+        self, base_send_segment_event, LDClient
+    ):
+        LDClient.return_value.variation.return_value = True
         self.user.rh_user_has_seat = False
         self._assert_event_not_sent(base_send_segment_event)
 
-    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
-    def test_send_segment_analytics_event_error_no_telemetry_enabled(self, base_send_segment_event):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    def test_send_segment_analytics_event_error_no_telemetry_enabled(
+        self, base_send_segment_event, LDClient
+    ):
+        LDClient.return_value.variation.return_value = False
         self._assert_event_not_sent(base_send_segment_event)
 
-    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
-    def test_send_segment_analytics_event_error_no_org(self, base_send_segment_event):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    def test_send_segment_analytics_event_error_no_org(self, base_send_segment_event, LDClient):
+        LDClient.return_value.variation.return_value = True
         self.user.organization = None
         self._assert_event_not_sent(base_send_segment_event)
 
-    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=True)
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    @patch("ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_no_org_telemetry_enabled(
-        self, base_send_segment_event
+        self, base_send_segment_event, LDClient
     ):
+        LDClient.return_value.variation.return_value = True
         self.user.organization.telemetry_opt_out = True
         self._assert_event_not_sent(base_send_segment_event)
 
     def _assert_event_not_sent(self, base_send_segment_event):
-        payload = Mock(return_value=AnalyticsProductFeedback("3", 123))
+        payload = Mock(return_value=AnalyticsProductFeedback(3, 123))
         send_segment_analytics_event(AnalyticsTelemetryEvents.PRODUCT_FEEDBACK, payload, self.user)
         payload.assert_not_called()
         base_send_segment_event.assert_not_called()

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -79,7 +79,9 @@ class FeatureFlags:
         if self.client:
             logger.debug(f"constructing User context for Organization '{org_id}'")
             logger.debug(f"retrieving feature flag '{WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED}'")
-            context = Context.builder(str(org_id)).set("org_id", org_id).build()
+            context = (
+                Context.builder(str(org_id)).kind("organization").set("org_id", org_id).build()
+            )
             return self.client.variation(WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, context, False)
         else:
             raise Exception("feature flag client is not initialized")

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os.path
 from enum import Enum
@@ -73,15 +74,20 @@ class FeatureFlags:
             logger.debug(f"retrieving feature flag {name}")
             return self.client.variation(name, user_context, default)
         else:
-            raise Exception("feature flag client is not initialized")
+            raise Exception("FeatureFlag client is not initialized")
 
-    def is_schema_2_telemetry_enabled(self, org_id: int) -> bool:
+    def check_flag(self, flag: str, query_dict: dict):
+        """
+        Generic LaunchDarkly check
+        :param flag: The LaunchDarkly 'feature flag' name
+        :param query_dict: The LaunchDarkly Context attributes.
+                           These must include both 'kind' and 'key'.
+        :return: The LaunchDarkly response or None
+        """
         if self.client:
-            logger.debug(f"constructing User context for Organization '{org_id}'")
-            logger.debug(f"retrieving feature flag '{WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED}'")
-            context = (
-                Context.builder(str(org_id)).kind("organization").set("org_id", org_id).build()
-            )
-            return self.client.variation(WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, context, False)
+            logger.debug(f"Constructing context for '{json.dumps(query_dict)}'")
+            context = Context.from_dict(query_dict)
+            logger.debug(f"Retrieving feature flag '{flag}'")
+            return self.client.variation(flag, context, None)
         else:
-            raise Exception("feature flag client is not initialized")
+            raise Exception("FeatureFlag client is not initialized")

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -56,19 +56,27 @@ class TestFeatureFlags(WisdomServiceAPITestCaseBase):
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_feature_flags_is_schema_2_telemetry_disabled(self, LDClient):
+    def test_feature_flags_check_flag_disabled(self, LDClient):
         LDClient.return_value.variation.return_value = False
 
         ff = feature_flags.FeatureFlags()
-        self.assertFalse(ff.is_schema_2_telemetry_enabled(123))
+        self.assertFalse(
+            ff.check_flag(
+                WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, {'kind': 'organization', 'org_id': 123}
+            )
+        )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_feature_flags_is_schema_2_telemetry_enabled(self, LDClient):
+    def test_feature_flags_check_flag_enabled(self, LDClient):
         LDClient.return_value.variation.return_value = True
 
         ff = feature_flags.FeatureFlags()
-        self.assertTrue(ff.is_schema_2_telemetry_enabled(123))
+        self.assertTrue(
+            ff.check_flag(
+                WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, {'kind': 'organization', 'key': '123'}
+            )
+        )
 
         args = LDClient.return_value.variation.call_args_list[0]
         name: str = args[0][0]
@@ -76,5 +84,4 @@ class TestFeatureFlags(WisdomServiceAPITestCaseBase):
         self.assertEqual(name, WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED)
         self.assertEqual(context.kind, 'organization')
         self.assertEqual(context.key, '123')
-        self.assertEqual(context.custom_attributes['org_id'], 123)
         self.assertFalse(args[0][2])

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -74,7 +74,7 @@ class TestFeatureFlags(WisdomServiceAPITestCaseBase):
         name: str = args[0][0]
         context: Context = args[0][1]
         self.assertEqual(name, WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED)
-        self.assertEqual(context.kind, 'user')
+        self.assertEqual(context.kind, 'organization')
         self.assertEqual(context.key, '123')
         self.assertEqual(context.custom_attributes['org_id'], 123)
         self.assertFalse(args[0][2])

--- a/ansible_wisdom/healthcheck/views.py
+++ b/ansible_wisdom/healthcheck/views.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime
 
-from ai.api.views import feature_flags
+from ai.feature_flags import FeatureFlags
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
@@ -22,10 +22,6 @@ from .version_info import VersionInfo
 
 logger = logging.getLogger(__name__)
 CACHE_TIMEOUT = 30
-
-
-def get_feature_flags():
-    return feature_flags
 
 
 class HealthCheckCustomView(MainView):
@@ -49,8 +45,8 @@ class HealthCheckCustomView(MainView):
         model_name = settings.ANSIBLE_AI_MODEL_NAME
         deployed_region = settings.DEPLOYED_REGION
         if settings.LAUNCHDARKLY_SDK_KEY:
-            feature_flags = get_feature_flags()
-            model_tuple = feature_flags.get("model_name", user, f".:.:{model_name}:.")
+            # Lazy instantiation of FeatureFlags to ensure it honours settings.LAUNCHDARKLY_SDK_KEY
+            model_tuple = FeatureFlags().get("model_name", user, f".:.:{model_name}:.")
             model_parts = model_tuple.split(':')
             if len(model_parts) == 4:
                 _, _, model_name, _ = model_parts

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -80,6 +80,3 @@ WCA_SECRET_BACKEND_TYPE = os.getenv("WCA_SECRET_BACKEND_TYPE", "dummy")  # or aw
 # WCA_SECRET_DUMMY_SECRETS=1009103:valid,11009104:not-valid
 WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
 WCA_CLIENT_BACKEND_TYPE = os.getenv("WCA_CLIENT_BACKEND_TYPE", "dummy")  # or wcaclient
-
-# Enable Telemetry Opt In/Out settings in the Admin Portal
-ADMIN_PORTAL_TELEMETRY_OPT_ENABLED = True

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -39,6 +39,3 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
-
-# Disable Telemetry Opt In/Out settings in the Admin Portal
-ADMIN_PORTAL_TELEMETRY_OPT_ENABLED = os.getenv('ADMIN_PORTAL_TELEMETRY_OPT_ENABLED', False)

--- a/ansible_wisdom/main/templates/console/console.html
+++ b/ansible_wisdom/main/templates/console/console.html
@@ -18,5 +18,5 @@
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
     <!-- Flag whether Telemetry settings is supported -->
-    <div id="telemetry_opt_enabled" hidden>{{telemetry_opt_enabled}}</div>
+    <div id="telemetry_schema_2_enabled" hidden>{{telemetry_schema_2_enabled}}</div>
 {% endblock content %}

--- a/ansible_wisdom/main/tests/test_urls.py
+++ b/ansible_wisdom/main/tests/test_urls.py
@@ -29,19 +29,9 @@ class TestUrls(TestCase):
         )
         self.assertIn("default-src 'self' data:", response.headers.get('Content-Security-Policy'))
 
-    def test_telemetry_patterns_when_enabled(self):
-        reload(main.urls)
+    def test_telemetry_patterns(self):
         r = compile("api/v0/telemetry/")
         patterns = list(
             filter(r.match, [str(pattern.pattern) for pattern in main.urls.urlpatterns])
         )
         self.assertEqual(1, len(patterns))
-
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
-    def test_telemetry_patterns_when_disabled(self):
-        reload(main.urls)
-        r = compile("api/v0/telemetry/")
-        patterns = list(
-            filter(r.match, [str(pattern.pattern) for pattern in main.urls.urlpatterns])
-        )
-        self.assertEqual(0, len(patterns))

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -58,14 +58,13 @@ urlpatterns = [
     path('console/<slug:slug1>/<slug:slug2>/', ConsoleView.as_view(), name='console'),
 ]
 
-if settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
-    urlpatterns += [
-        path(
-            f'api/{WISDOM_API_VERSION}/telemetry/',
-            TelemetrySettingsView.as_view(),
-            name='telemetry_settings',
-        ),
-    ]
+urlpatterns += [
+    path(
+        f'api/{WISDOM_API_VERSION}/telemetry/',
+        TelemetrySettingsView.as_view(),
+        name='telemetry_settings',
+    ),
+]
 
 if settings.DEBUG:
     urlpatterns += [

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -69,8 +69,11 @@ class ConsoleView(ProtectedTemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if self.request.user:
-            context["user_name"] = self.request.user.username
-            context["rh_org_has_subscription"] = self.request.user.rh_org_has_subscription
-            context["telemetry_opt_enabled"] = settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED
+        user = self.request.user
+        if user:
+            context["user_name"] = user.username
+            context["rh_org_has_subscription"] = user.rh_org_has_subscription
+            organization = user.organization
+            if organization:
+                context["telemetry_schema_2_enabled"] = organization.is_schema_2_telemetry_enabled
         return context

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -17,7 +17,10 @@ class Organization(models.Model):
             return False
 
         # Avoid circular dependency issue with lazy import
-        from ai.feature_flags import FeatureFlags
+        from ai.feature_flags import FeatureFlags, WisdomFlags
 
         feature_flags = FeatureFlags()
-        return feature_flags.is_schema_2_telemetry_enabled(self.id)
+        return feature_flags.check_flag(
+            WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED,
+            {'kind': 'organization', 'key': str(self.id)},
+        )

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -1,6 +1,8 @@
 import logging
 
+from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 
 logger = logging.getLogger(__name__)
 
@@ -8,3 +10,14 @@ logger = logging.getLogger(__name__)
 class Organization(models.Model):
     id = models.IntegerField(primary_key=True)
     telemetry_opt_out = models.BooleanField(default=False)
+
+    @cached_property
+    def is_schema_2_telemetry_enabled(self) -> bool:
+        if not settings.LAUNCHDARKLY_SDK_KEY:
+            return False
+
+        # Avoid circular dependency issue with lazy import
+        from ai.feature_flags import FeatureFlags
+
+        feature_flags = FeatureFlags()
+        return feature_flags.is_schema_2_telemetry_enabled(self.id)

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import ai.feature_flags as feature_flags
+from django.test import TestCase, override_settings
+from organizations.models import Organization
+
+
+class TestIsOrgLightspeedSubscriber(TestCase):
+    def test_org_with_telemetry_schema_2_enabled(self):
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    def test_org_with_telemetry_schema_2_disabled(self):
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags(self, LDClient):
+        LDClient.return_value.variation.return_value = ''
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = '999'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_override(self, LDClient):
+        LDClient.return_value.variation.return_value = '123'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_overrides(self, LDClient):
+        LDClient.return_value.variation.return_value = '000,999,123'
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -5,39 +5,45 @@ from django.test import TestCase, override_settings
 from organizations.models import Organization
 
 
-class TestIsOrgLightspeedSubscriber(TestCase):
-    def test_org_with_telemetry_schema_2_enabled(self):
+class TestOrganization(TestCase):
+    def test_org_with_telemetry_schema_2_opted_in(self):
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.telemetry_opt_out)
+        self.assertFalse(organization.is_schema_2_telemetry_enabled)
+
+    def test_org_with_telemetry_schema_2_opted_out(self):
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
-        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
-
-    def test_org_with_telemetry_schema_2_disabled(self):
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+        self.assertTrue(organization.telemetry_opt_out)
+        self.assertFalse(organization.is_schema_2_telemetry_enabled)
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_disabled_with_feature_flags(self, LDClient):
-        LDClient.return_value.variation.return_value = ''
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_override(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertTrue(organization.telemetry_opt_out)
+        self.assertTrue(organization.is_schema_2_telemetry_enabled)
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_no_override(self, LDClient):
-        LDClient.return_value.variation.return_value = '999'
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.is_schema_2_telemetry_override_enabled)
+    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = False
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertTrue(organization.telemetry_opt_out)
+        self.assertFalse(organization.is_schema_2_telemetry_enabled)
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_override(self, LDClient):
-        LDClient.return_value.variation.return_value = '123'
+    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_override(self, LDClient):
+        LDClient.return_value.variation.return_value = True
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)
+        self.assertFalse(organization.telemetry_opt_out)
+        self.assertTrue(organization.is_schema_2_telemetry_enabled)
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_disabled_with_feature_flags_with_overrides(self, LDClient):
-        LDClient.return_value.variation.return_value = '000,999,123'
+    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = False
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertTrue(organization.is_schema_2_telemetry_override_enabled)
+        self.assertFalse(organization.telemetry_opt_out)
+        self.assertFalse(organization.is_schema_2_telemetry_enabled)

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -6,6 +6,7 @@ from typing import Optional
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
+import ai.feature_flags as feature_flags
 from ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
@@ -555,7 +556,10 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertFalse(r.data.get('org_telemetry_opt_out'))
 
-    def test_rhsso_user_with_telemetry_opted_out(self):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_rhsso_user_with_telemetry_opted_out(self, LDClient):
+        LDClient.return_value.variation.return_value = True
         user = create_user(
             provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
             social_auth_extra_data={"login": "sso_username"},
@@ -567,8 +571,10 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertTrue(r.data.get('org_telemetry_opt_out'))
 
-    @override_settings(ADMIN_PORTAL_TELEMETRY_OPT_ENABLED=False)
-    def test_rhsso_user_with_telemetry_feature_disabled(self):
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_rhsso_user_with_telemetry_feature_disabled(self, LDClient):
+        LDClient.return_value.variation.return_value = False
         user = create_user(
             provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
             social_auth_extra_data={"login": "sso_username"},
@@ -580,10 +586,43 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertIsNone(r.data.get('org_telemetry_opt_out'))
 
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_rhsso_user_with_telemetry_feature_enabled_opted_out(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
+            social_auth_extra_data={"login": "sso_username"},
+            external_username="sso_username",
+            org_opt_out=True,
+        )
+        self.client.force_authenticate(user=user)
+        r = self.client.get(reverse('me'))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertTrue(r.data.get('org_telemetry_opt_out'))
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_rhsso_user_with_telemetry_feature_enabled_opted_in(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
+            social_auth_extra_data={"login": "sso_username"},
+            external_username="sso_username",
+            org_opt_out=False,
+        )
+        self.client.force_authenticate(user=user)
+        r = self.client.get(reverse('me'))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertFalse(r.data.get('org_telemetry_opt_out'))
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
     @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
     @patch.object(AcceptedTermsPermission, 'has_permission', return_value=True)
-    def test_rhsso_user_caching(self, *args):
+    @patch.object(feature_flags, 'LDClient')
+    def test_rhsso_user_caching(self, LDClient, *args):
+        LDClient.return_value.variation.return_value = True
         user = create_user(
             provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
             social_auth_extra_data={"login": "sso_username"},

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -77,10 +77,9 @@ class CurrentUserView(RetrieveAPIView):
         user_data = serializer.data
 
         # Enrich with Organisational data, if necessary
-        if settings.ADMIN_PORTAL_TELEMETRY_OPT_ENABLED:
-            organization = self.request.user.organization
-            if organization:
-                user_data["org_telemetry_opt_out"] = organization.telemetry_opt_out
+        organization = self.request.user.organization
+        if organization and organization.is_schema_2_telemetry_enabled:
+            user_data["org_telemetry_opt_out"] = organization.telemetry_opt_out
 
         return Response(user_data)
 

--- a/ansible_wisdom_console_react/public/index.html
+++ b/ansible_wisdom_console_react/public/index.html
@@ -11,6 +11,6 @@
 <div id="root" class="Root"></div>
 <script type="module" src="/src/index.tsx"></script>
 <div id="user_name" hidden>development-user</div>
-<div id="telemetry_opt_enabled" hidden>true</div>
+<div id="telemetry_schema_2_enabled" hidden>true</div>
 </body>
 </html>

--- a/ansible_wisdom_console_react/src/index.tsx
+++ b/ansible_wisdom_console_react/src/index.tsx
@@ -10,14 +10,14 @@ import "./i18n";
 import "./index.css";
 
 const userName = document.getElementById("user_name")?.innerText ?? "undefined";
-const telemetryOptEnabledInnerText = document.getElementById(
-  "telemetry_opt_enabled",
+const telemetrySchema2EnabledInnerText = document.getElementById(
+  "telemetry_schema_2_enabled",
 )?.innerText;
-const telemetryOptEnabled =
-  telemetryOptEnabledInnerText?.toLowerCase() === "true";
+const telemetrySchema2Enabled =
+  telemetrySchema2EnabledInnerText?.toLowerCase() === "true";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App userName={userName} telemetryOptEnabled={telemetryOptEnabled} />
+    <App userName={userName} telemetryOptEnabled={telemetrySchema2Enabled} />
   </StrictMode>,
 );


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20249

Replaces https://github.com/ansible/ansible-wisdom-service/pull/804

## Description
This PR moves the "Schema 2 Telemetry analytics" feature flag to LaunchDarkly.

Launch Darkly has a rule that checks whether the feature is enabled for a given `org_id`.

The feature flag controls:-
- Exposure of the "Telemetry" section in the Admin Console
- Enabling/disabling the "Schema 2 Telemetry" REST API endpoints
- Enabling/disabling sending "Schema 2 Telemetry" events to Segment.
- Including/excluding the "Schema 2 Telemetry" opt-in/out flag in the `api/v0/me` REST API endpoint.

## Testing
You can test locally; with a `flagdata.json` file locally.

See https://github.com/ansible/ansible-wisdom-service/pull/776 for details :tada: 

1) `"schema_2_telemetry_org_enabled": true`

Each of the items listed in the description should be enabled.

2) `"schema_2_telemetry_org_enabled": false`

Each of the items listed in the description should be disabled.

3) You can test using "Development" LaunchDarkly SDK key.

You may need to update the "schema_2_telemetry_org_enabled" rule to include your `org_id`.

### Steps to test
1. Pull down the PR
2. `make admin-portal-bundle`
3. `make start-backends`
4. `make create-application`
5. `make run-server` (or whatever you normally do)

### Scenarios tested
See "Testing" above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

I removed the system-wide environment variable `ADMIN_PORTAL_TELEMETRY_OPT_ENABLED`.

This needs to be removed in Staging Secret Manager too.