### PR TITLE
Upgrade versions of ansible-core and django

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,11 +6,11 @@ aiohttp==3.9.3
 # remove this once ansible-risk-insight is updated to properly
 # pull a version of ansible >= 8.5.0.
 ansible==8.5.0
-# pin ansible-core on 2.15.8 to address GHSA-7j69-qfc3-2fq9
+# pin ansible-core on 2.15.9 to address GHSA-7j69-qfc3-2fq9 and GHSA-h24r-m9qc-pvpg.
 # remove this once ansible-anonymizer, ansible-risk-insight and
 # ansible-lint are updated to properly pull a version of
-# ansible-core > 2.15.0.
-ansible-core==2.15.8
+# ansible-core > 2.15.8.
+ansible-core==2.15.9
 ansible-anonymizer==1.5.0
 ansible-risk-insight==0.2.4
 ansible-lint==6.22.1
@@ -18,7 +18,8 @@ boto3==1.26.84
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==42.0.2
 datasets==2.10.1
-Django==4.2.7
+# pin Django on 4.2.10 to address PYSEC-2024-28.
+Django==4.2.10
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ ansible-anonymizer==1.5.0
     # via -r requirements.in
 ansible-compat==4.1.10
     # via ansible-lint
-ansible-core==2.15.8
+ansible-core==2.15.9
     # via
     #   -r requirements.in
     #   ansible
@@ -94,7 +94,7 @@ dill==0.3.6
     # via
     #   datasets
     #   multiprocess
-django==4.2.7
+django==4.2.10
     # via
     #   -r requirements.in
     #   django-allow-cidr


### PR DESCRIPTION
This PR does not need a corresponding Jira item.
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
ansible-core | 2.15.8 | GHSA-h24r-m9qc-pvpg | 2.14.14,2.15.9,2.16.3 | An information disclosure flaw was found in ansible-core due to a failure to respect the `ANSIBLE_NO_LOG` configuration in some scenarios. It was discovered that information is still included in the output in certain tasks, such as loop items. Depending on the task, this issue may include sensitive information, such as decrypted secret values.
django | 4.2.7 | PYSEC-2024-28 | 3.2.24,4.2.10,5.0.2 | An issue was discovered in Django 3.2 before 3.2.24, 4.2 before 4.2.10, and Django 5.0 before 5.0.2. The intcomma template filter was subject to a potential denial-of-service attack when used with very long strings.
```