### PR TITLE
docker-compose: ignore an empty value for DJANGO_LOG_LEVEL

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -265,7 +265,7 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": os.getenv("DJANGO_LOG_LEVEL", "WARNING"),
+        "level": os.getenv("DJANGO_LOG_LEVEL") or "WARNING",
     },
 }
 


### PR DESCRIPTION
Follow-up to this recent change
https://github.com/ansible/ansible-wisdom-service/commit/103e4e917431f2cd5120b2797149519115db4ec1#diff-660079833ff43fc0a9a3c47a9fd0440565efffaa7fc4ef86012cb394cb40af1eR23
the `DJANGO_LOG_LEVEL` environment variable is always set by `podman-compose`.
However, depending on the local configuration, the value may be an empty string.

This change ensure that if we start with an empty value we continue to
fallback on `WARNING` like before.
