### PR TITLE
podman-compose: mount the volumes with the SELinux context

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -10,9 +10,9 @@ services:
     depends_on:
       - db
     volumes:
-      - $PWD/ansible_wisdom:/var/www/ansible-wisdom-service/ansible_wisdom
-      - $PWD/ari/kb:/etc/ari/kb
-      - $PWD/tools/scripts:/etc/wisdom/scripts
+      - $PWD/ansible_wisdom:/var/www/ansible-wisdom-service/ansible_wisdom:z
+      - $PWD/ari/kb:/etc/ari/kb:z
+      - $PWD/tools/scripts:/etc/wisdom/scripts:z
     ports:
       - "8000:8000"
     expose:

--- a/tools/docker-compose/pip-compile.yaml
+++ b/tools/docker-compose/pip-compile.yaml
@@ -4,6 +4,6 @@ services:
     platform: linux/x86_64
     image: registry.access.redhat.com/ubi9/ubi:latest
     volumes:
-      - $PWD:/var/www/wisdom
+      - $PWD:/var/www/wisdom:z
     command:
       - /var/www/wisdom/tools/scripts/pip-compile.sh


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-20606>
<!-- This PR does not need a corresponding Jira item. -->

## Description

By adding the `:z` flag, we avoid any permission problem when the container tries
to open the local shared directory.

See: https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5

## Testing

Start `podman-compose` or `docker-compose` and ensure everything is working as usual.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: