### PR TITLE
compose: ensure we use PostgreSQL 15, like in production

### DIFF
--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -80,7 +80,7 @@ services:
       - dbnet
   db:
     platform: linux/amd64
-    image: docker.io/library/postgres:alpine
+    image: docker.io/library/postgres:15-alpine
     environment:
       - POSTGRES_PASSWORD=wisdom
       - POSTGRES_DB=wisdom


### PR DESCRIPTION
`docker.io/library/postgres:alpine` is actually pointing on PostgreSQL 16 which
is not the version we run in production.

By pinning on `15-alpine` we reduce the delta with our target environment and
reduce the risk of introducing some breaking changes in the future.
