### PR TITLE
tools: add scripts to dump and restore the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ Create a local admin user:
 > For PyCharm, please look
 > at [this document](https://docs.google.com/document/d/1QkdvtthnvdHc4TKbWV00pxnEKRU8L8jHNC2IaQ950_E/edit?usp=sharing).
 
+## Backup/restore the database (Podman)
+
+You can do a backup and restore the database with the following scripts:
+
+- `./tools/scripts/dump-db.sh`
+- `./tools/scripts/restore-db.sh`
+
+E.g:
+
+```bash
+./tools/scripts/dump-db.sh /tmp/my-backup.dump
+./tools/scripts/restore-db.sh /tmp/my-backup.dump
+```
+
 ## Connect to a local model server
 
 To connect to the Mistal 7b Instruct model running on locally on [llama.cpp](https://github.com/ggerganov/llama.cpp) modelserver:

--- a/tools/scripts/dump-db.sh
+++ b/tools/scripts/dump-db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# helper script to dump the DB of a podman-compose env.
+export PGDATABASE=wisdom
+export PGHOST=localhost
+export PGUSER=wisdom
+export PGPASSWORD=wisdom
+
+file=$1
+
+if [ -z ${file} ]; then
+    echo "Usage: ${0} target-file.sql"
+    exit 1
+fi
+
+pg_dump -Fc --create --file=${file}

--- a/tools/scripts/restore-db.sh
+++ b/tools/scripts/restore-db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# helper script to restore the DB of a podman-compose env.
+export PGDATABASE=wisdom
+export PGHOST=localhost
+export PGUSER=wisdom
+export PGPASSWORD=wisdom
+
+file=$1
+
+if [ -z ${file} ]; then
+    echo "Usage: ${0} target-file.sql"
+    exit 1
+fi
+
+podman exec --user=root -it docker-compose_django_1 supervisorctl stop wisdom-processes:uwsgi
+psql -h localhost -U wisdom postgres -c 'DROP DATABASE wisdom;'
+psql -h localhost -U wisdom postgres -c 'CREATE DATABASE wisdom;'
+pg_restore --dbname ${PGDATABASE} ${file}
+podman exec --user=root -it docker-compose_django_1 supervisorctl start wisdom-processes:uwsgi


### PR DESCRIPTION
Add two scripts that can be used to save and restore a dev environment.

The goal was to be able to quickly restart `podman-compose` and restart from
a previous backup.
