### PR TITLE
AAP-20615: trialExpired event is redacted

### DIFF
--- a/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
@@ -273,4 +273,15 @@ ALLOW_LIST = {
         'opt_out': None,
         'timestamp': None,
     },
+    'trialExpired': {
+        'type': None,
+        'suggestionId': None,
+        'modelName': None,
+        'imageTags': None,
+        'hostname': None,
+        'groups': None,
+        'rh_user_has_seat': None,
+        'rh_user_org_id': None,
+        'timestamp': None,
+    },
 }

--- a/ansible_wisdom/ai/api/utils/tests/test_segment.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment.py
@@ -257,6 +257,29 @@ class TestSegment(TestCase):
             redact_seated_users_data(test_data, ALLOW_LIST['contentmatch']), expected_result
         )
 
+    def test_redact_trialExpired_response_data(self, *args):
+        test_data = {
+            'type': 'prediction',
+            'modelName': 'org-model-id',
+            'suggestionId': '1',
+            'rh_user_has_seat': True,
+            'rh_user_org_id': 101,
+            'groups': ['g1', 'g2'],
+        }
+
+        expected_result = {
+            'type': 'prediction',
+            'suggestionId': '1',
+            'modelName': 'org-model-id',
+            'groups': ['g1', 'g2'],
+            'rh_user_has_seat': True,
+            'rh_user_org_id': 101,
+        }
+
+        self.assertEqual(
+            redact_seated_users_data(test_data, ALLOW_LIST['trialExpired']), expected_result
+        )
+
     @mock.patch("ai.api.utils.segment.analytics.group")
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_send_segment_group(self, group_method):


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
* https://issues.redhat.com/browse/AAP-20615

## Description
Un-redact trialExpired event

## Testing
1. Pull down the PR
2. Use the staging source key as for SEGMENT_WRITE_KEY
3. Add `raise WcaUserTrialExpired()` here: https://github.com/ansible/ansible-wisdom-service/blob/792604a6c37cef684a1ed35694fb07b4e5b780bb/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py#L106
4. Run the service, Infer and check segment for the event

![Screenshot from 2024-02-09 21-50-45](https://github.com/ansible/ansible-wisdom-service/assets/4602417/d2ddfa65-2fa3-4b92-b9b7-9aab8fd99594)

### Scenarios tested
Localhost

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
