### PR TITLE
settings: Ensure ANSIBLE_AI_MODEL_NAME is defined

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -20,7 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
-ANSIBLE_AI_MODEL_NAME = os.getenv("ANSIBLE_AI_MODEL_NAME", "wisdom")
+ANSIBLE_AI_MODEL_NAME = os.getenv("ANSIBLE_AI_MODEL_NAME") or "wisdom"
 
 ANSIBLE_AI_MODEL_MESH_API_KEY = os.getenv('ANSIBLE_AI_MODEL_MESH_API_KEY')
 ANSIBLE_AI_MODEL_MESH_MODEL_NAME = os.getenv('ANSIBLE_AI_MODEL_MESH_MODEL_NAME')


### PR DESCRIPTION
Follow up to 103e4e917431f2cd5120b2797149519115db4ec1, the environment variable is
defined by `{podman,docker}-compose` but remains empty. As a result
`os.getenv("ANSIBLE_AI_MODEL_NAME", "wisdom")` will return an empty string now.

This commit reverts back this to the original behaviour.
