### PR TITLE
fix singleton launchdarkly client

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -11,15 +11,12 @@ from ai.api.pipelines.common import (
 )
 from ai.api.pipelines.completion_context import CompletionContext
 from ai.api.utils.segment import send_segment_event
-from ai.feature_flags import FeatureFlags
 from django.apps import apps
 from django_prometheus.conf import NAMESPACE
 from prometheus_client import Histogram
 from yaml.error import MarkedYAMLError
 
 logger = logging.getLogger(__name__)
-
-feature_flags = FeatureFlags()
 
 STRIP_YAML_LINE = '---\n'
 

--- a/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
@@ -18,6 +18,10 @@ from rest_framework.permissions import IsAuthenticated
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
 class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
+    def setUp(self):
+        super().setUp()
+        feature_flags.FeatureFlags.instance = None
+
     def test_get_settings_authentication_error(self, *args):
         # self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('telemetry_settings'))

--- a/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -28,6 +28,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
         self.user.rh_user_has_seat = True
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         self.user.organization.telemetry_opt_out = False
+        feature_flags.FeatureFlags.instance = None
 
     @staticmethod
     def on_segment_error(self, error, items):

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -22,6 +22,7 @@ class WisdomFlags(str, Enum):
 
 class FeatureFlags:
     instance = None
+    client = None
 
     # Ensure FeatureFlags is a Singleton
     def __new__(cls):
@@ -32,7 +33,8 @@ class FeatureFlags:
             return inst
 
     def __init__(self):
-        self.client = None
+        if self.client is not None:
+            return
         if settings.LAUNCHDARKLY_SDK_KEY:
             if os.path.exists(settings.LAUNCHDARKLY_SDK_KEY):
                 data_source_callback = Files.new_data_source(

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -11,6 +11,10 @@ from ldclient.config import Config
 
 
 class TestFeatureFlags(WisdomServiceAPITestCaseBase):
+    def setUp(self):
+        super().setUp()
+        feature_flags.FeatureFlags.instance = None
+
     @override_settings(LAUNCHDARKLY_SDK_KEY=None)
     def test_feature_flags_without_sdk_key(self):
         ff = feature_flags.FeatureFlags()

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -16,6 +16,10 @@ from rest_framework.permissions import IsAuthenticated
 
 
 class TestConsoleView(WisdomServiceAPITestCaseBase):
+    def setUp(self):
+        super().setUp()
+        feature_flags.FeatureFlags.instance = None
+
     def test_authentication_error(self, *args):
         # self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('console'))

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -532,6 +532,7 @@ class TestUserModelMetrics(APITransactionTestCase):
 class TestTelemetryOptInOut(APITransactionTestCase):
     def setUp(self) -> None:
         cache.clear()
+        feature_flags.FeatureFlags.instance = None
 
     def test_github_user(self):
         user = create_user(


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20655

## Description
completions fail after some time during our test suite runs with `RuntimeError: can't start new thread`. One thing I noticed that might help here is that, while our FeatureFlags class was updated to be singleton, the LDClient is recreated every time we call the FeatureFlags constructor. This results in three threads being used instead of one. 

## Testing

### Steps to test
1. Pull down the PR
2. Run the wisdom-service in debug with a breakpoint in FeatureFlags init.
3. Confirm the LDClient is created just once.

### Scenarios tested
Unit tests, steps above, and ran a completion.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
