### PR TITLE
disable seat assignment check from wisdom service

### DIFF
--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -334,6 +334,8 @@ class TestTermsAndConditions(WisdomServiceLogAwareTestCase):
             self.assertInLog('GET TermsOfService was invoked without partial_token', log)
 
 
+@override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+@override_settings(WCA_SECRET_DUMMY_SECRETS='1981:valid')
 @override_settings(AUTHZ_BACKEND_TYPE="dummy")
 @override_settings(AUTHZ_DUMMY_USERS_WITH_SEAT="seated")
 @override_settings(AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION="1981")
@@ -381,6 +383,37 @@ class TestUserSeat(WisdomAppsBackendMocking):
 
         self.assertTrue(user.rh_user_has_seat)
         self.assertEqual(user.org_id, FAUX_COMMERCIAL_USER_ORG_ID)
+
+    def test_rh_user_org_with_sub_but_no_seat_in_ams(self):
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
+            rh_user_id="seated-user-id",
+            rh_org_id=1981,
+            external_username="no-seated",
+        )
+        self.assertTrue(user.rh_user_has_seat)
+
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='')
+    def test_rh_user_org_with_sub_but_no_sec_and_tech_preview(self):
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
+            rh_user_id="seated-user-id",
+            rh_org_id=1981,
+            external_username="no-seated",
+        )
+        self.assertFalse(user.rh_user_has_seat)
+
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
+    @override_settings(WCA_SECRET_DUMMY_SECRETS='')
+    def test_rh_user_org_with_sub_but_no_sec_after_tech_preview(self):
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
+            rh_user_id="seated-user-id",
+            rh_org_id=1981,
+            external_username="no-seated",
+        )
+        self.assertTrue(user.rh_user_has_seat)
 
 
 class TestUsername(WisdomServiceLogAwareTestCase):


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-19864>
<!-- This PR does not need a corresponding Jira item. -->

## Description

This PR removes the seat check and accepts all the users from RHOrgs with sub as commercial users.

## Testing

- Start the service with:
  ```shell
  ANSIBLE_AI_ENABLE_TECH_PREVIEW="true" <----- You can switch this flag, it should not impact the result
  AUTHZ_BACKEND_TYPE="dummy"
  AUTHZ_DUMMY_USERS_WITH_SEAT=""
  AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION="11009103" <---- Your Org ID
  ```
- Try to connect to a org with sub as an unseated user.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: