### PR TITLE
tests: add missing setUp()/tearDown() calls

### DIFF
--- a/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
@@ -26,6 +26,7 @@ class TestWcaApiKeyClient(APITestCase, WisdomServiceLogAwareTestCase):
         pass
 
     def setUp(self):
+        super().setUp()
         self.m_boto3_client = Mock()
         self.m_boto3_client.exceptions.ResourceNotFoundException = MockResourceNotFoundException
         self.m_boto3_client.exceptions.InvalidParameterException = MockInvalidParameterException

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -503,6 +503,7 @@ class TestWCACodematch(WisdomServiceLogAwareTestCase):
 
     def tearDown(self):
         self.now_patcher.stop()
+        super().tearDown()
 
     @assert_call_count_metrics(metric=wca_codematch_hist)
     def test_codematch(self):
@@ -667,6 +668,7 @@ class TestDummySecretManager(TestCase):
 
     def tearDown(self):
         self.now_patcher.stop()
+        super().tearDown()
 
     def test_load_secrets(self):
         expectation = {

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -92,6 +92,7 @@ class TestAcceptedTermsPermission(WisdomAppsBackendMocking):
 
     def tearDown(self):
         self.user.delete()
+        super().tearDown()
 
     def test_ensure_community_user_with_no_tc_is_blocked(self):
         self.user.community_terms_accepted = False
@@ -128,6 +129,7 @@ class TestBlockUserWithoutSeatAndWCAReadyOrg(WisdomAppsBackendMocking):
 
     def tearDown(self):
         self.user.delete()
+        super().tearDown()
 
     def test_ensure_user_with_no_org_are_allowed(self):
         self.user.organization = None
@@ -154,6 +156,7 @@ class TestBlockUserWithSeatButWCANotReady(WisdomAppsBackendMocking):
 
     def tearDown(self):
         self.user.delete()
+        super().tearDown()
 
     def test_non_redhat_users_are_allowed(self):
         self.user.organization = None
@@ -181,6 +184,7 @@ class TestBlockUserWithoutSeat(WisdomAppsBackendMocking):
 
     def tearDown(self):
         self.user.delete()
+        super().tearDown()
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_no_seat_users_are_allowed_with_tech_preview(self):

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -117,6 +117,7 @@ class WisdomServiceAPITestCaseBase(APITransactionTestCase, WisdomServiceLogAware
         segment_analytics_telemetry.send = False  # do not send data to segment from unit tests
 
     def setUp(self):
+        super().setUp()
         self.username = 'u' + "".join(random.choices(string.digits, k=5))
         self.password = 'secret'
         email = 'user@example.com'

--- a/ansible_wisdom/ansible_lint/tests/test_lintpostprocessing.py
+++ b/ansible_wisdom/ansible_lint/tests/test_lintpostprocessing.py
@@ -29,6 +29,7 @@ class TestLintPostprocessing(WisdomServiceLogAwareTestCase):
     """Test AnsibleLintCaller that is used for ansible-lint postprocessing"""
 
     def setUp(self):
+        super().setUp()
         self.ansibleLintCaller = AnsibleLintCaller()
 
     def test_ansible_lint_caller(self):

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -506,6 +506,7 @@ class TestToken(WisdomServiceLogAwareTestCase):
 
 class TestDummy(TestCase):
     def setUp(self):
+        super().setUp()
         self.checker = DummyCheck()
 
     def test_self_test(self):

--- a/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
@@ -11,6 +11,7 @@ from users.management.commands.fix_users_with_two_sso_providers import Command
 
 class TestFixUsersWithTwoSSOProviders(WisdomServiceLogAwareTestCase):
     def setUp(self):
+        super().setUp()
         self.sso_user = get_user_model().objects.create_user(
             username="sso-user",
             email="sso@user.nowhere",
@@ -21,6 +22,7 @@ class TestFixUsersWithTwoSSOProviders(WisdomServiceLogAwareTestCase):
 
     def tearDown(self):
         self.sso_user.delete()
+        super().tearDown()
 
     def test_without_fix_paramter(self):
         base = Mock()

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -54,6 +54,7 @@ class DummyRHBackend:
 @override_settings(AUTHZ_BACKEND_TYPE="dummy")
 class TestExtraData(WisdomServiceLogAwareTestCase):
     def setUp(self):
+        super().setUp()
         self.rh_user = get_user_model().objects.create_user(
             username="rh-user",
             email="sso@user.nowhere",
@@ -87,6 +88,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def tearDown(self):
         self.rh_user.delete()
         self.github_user.delete()
+        super().tearDown()
 
     def test_load_extra_data(self):
         load_extra_data(

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -70,6 +70,7 @@ def create_user(
 @override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
 class TestUsers(APITransactionTestCase, WisdomServiceLogAwareTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.password = "somepassword"
         self.user = create_user(
             password=self.password,
@@ -108,6 +109,7 @@ class TestUsers(APITransactionTestCase, WisdomServiceLogAwareTestCase):
 @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
 class TestTermsAndConditions(WisdomServiceLogAwareTestCase):
     def setUp(self) -> None:
+        super().setUp()
         class MockSession(dict):
             def save(self):
                 pass
@@ -385,6 +387,7 @@ class TestUserSeat(WisdomAppsBackendMocking):
 
 class TestUsername(WisdomServiceLogAwareTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.local_user = create_user(
             username="local-user",
             password="bar",
@@ -401,6 +404,7 @@ class TestUsername(WisdomServiceLogAwareTestCase):
     def tearDown(self) -> None:
         self.local_user.delete()
         self.sso_user.delete()
+        super().tearDown()
 
     def test_username_from_sso(self) -> None:
         self.assertEqual(self.sso_user.external_username, "babar")
@@ -502,6 +506,7 @@ class TestThirdPartyAuthentication(WisdomAppsBackendMocking, APITransactionTestC
 
 class TestUserModelMetrics(APITransactionTestCase):
     def setUp(self) -> None:
+        super().setUp()
         cache.clear()
 
     def test_user_model_metrics(self):
@@ -531,6 +536,7 @@ class TestUserModelMetrics(APITransactionTestCase):
 
 class TestTelemetryOptInOut(APITransactionTestCase):
     def setUp(self) -> None:
+        super().setUp()
         cache.clear()
         feature_flags.FeatureFlags.instance = None
 

--- a/ansible_wisdom/wildcard_oauth2/tests/test_wildcard_oauth2.py
+++ b/ansible_wisdom/wildcard_oauth2/tests/test_wildcard_oauth2.py
@@ -21,6 +21,7 @@ redirect_uris = [
 
 class WildcardOAuth2Test(TestCase):
     def setUp(self):
+        super().setUp()
         self.app = Application(redirect_uris=' '.join(redirect_uris))
 
     def test_standalone_vscode_callback_uri(self):


### PR DESCRIPTION
Class Constructors are supposed the upper `setUp()` methods. It's the same for the `tearDown()`.
