### PR TITLE
AAP-20935: Console: Use correct Admin Dashboard URL

### DIFF
--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -54,3 +54,8 @@ WCA_SECRET_BACKEND_TYPE = os.getenv("WCA_SECRET_BACKEND_TYPE", "dummy")  # or aw
 # WCA_SECRET_DUMMY_SECRETS=1009103:valid,11009104:not-valid
 WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
 WCA_CLIENT_BACKEND_TYPE = os.getenv("WCA_CLIENT_BACKEND_TYPE", "dummy")  # or wcaclient
+
+# "Schema 2" Telemetry Admin Dashboard URL
+TELEMETRY_ADMIN_DASHBOARD_URL = (
+    "https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard"
+)

--- a/ansible_wisdom/main/settings/production.py
+++ b/ansible_wisdom/main/settings/production.py
@@ -10,3 +10,6 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
+
+# "Schema 2" Telemetry Admin Dashboard URL
+TELEMETRY_ADMIN_DASHBOARD_URL = "https://console.redhat.com/ansible/lightspeed-admin-dashboard"

--- a/ansible_wisdom/main/templates/console/console.html
+++ b/ansible_wisdom/main/templates/console/console.html
@@ -19,4 +19,6 @@
     <div id="user_name" hidden>{{user_name}}</div>
     <!-- Flag whether Telemetry settings is supported -->
     <div id="telemetry_schema_2_enabled" hidden>{{telemetry_schema_2_enabled}}</div>
+    <!-- Admin Dashboard URL -->
+    <div id="telemetry_schema_2_admin_dashboard_url" hidden>{{telemetry_schema_2_admin_dashboard_url}}</div>
 {% endblock content %}

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -88,6 +88,10 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         context = response.context_data
         # The default setting for tests is True
         self.assertTrue(context['telemetry_schema_2_enabled'])
+        self.assertEqual(
+            context['telemetry_schema_2_admin_dashboard_url'],
+            'https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard',
+        )
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
@@ -101,3 +105,4 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         self.assertIsInstance(response.context_data, dict)
         context = response.context_data
         self.assertFalse(context['telemetry_schema_2_enabled'])
+        self.assertIsNone(context.get('telemetry_schema_2_admin_dashboard_url'))

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -76,5 +76,12 @@ class ConsoleView(ProtectedTemplateView):
             context["rh_org_has_subscription"] = user.rh_org_has_subscription
             organization = user.organization
             if organization:
-                context["telemetry_schema_2_enabled"] = organization.is_schema_2_telemetry_enabled
+                is_schema_2_telemetry_enabled = organization.is_schema_2_telemetry_enabled
+                context["telemetry_schema_2_enabled"] = is_schema_2_telemetry_enabled
+
+                if is_schema_2_telemetry_enabled:
+                    context[
+                        "telemetry_schema_2_admin_dashboard_url"
+                    ] = settings.TELEMETRY_ADMIN_DASHBOARD_URL
+
         return context

--- a/ansible_wisdom_console_react/public/index.html
+++ b/ansible_wisdom_console_react/public/index.html
@@ -12,5 +12,6 @@
 <script type="module" src="/src/index.tsx"></script>
 <div id="user_name" hidden>development-user</div>
 <div id="telemetry_schema_2_enabled" hidden>true</div>
+<div id="telemetry_schema_2_admin_dashboard_url" hidden>https://console.redhat.com/ansible/lightspeed-admin-dashboard</div>
 </body>
 </html>

--- a/ansible_wisdom_console_react/public/static/console/static/locales/en/translation.json
+++ b/ansible_wisdom_console_react/public/static/console/static/locales/en/translation.json
@@ -56,7 +56,6 @@
   "TelemetryManageUsage": "Manage telemetry usage",
   "TelemetryManageUsageDescription": "Telemetry data is used to enable app usage and the ",
   "TelemetryManageUsageAdminDashboardURLText": "admin dashboard.",
-  "TelemetryManageUsageAdminDashboardURL": "http://www.redhat.com",
   "TelemetryManageUsageLearnMoreURLText": "Learn more about how Ansible Lightspeed uses data. ",
   "TelemetryManageUsageLearnMoreURL": "https://access.redhat.com/documentation/en-us/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/lightspeed-intro#training-data_lightspeed-intro",
   "TelemetryOptInLabel": "Admin dashboard telemetry data.",

--- a/ansible_wisdom_console_react/src/App.tsx
+++ b/ansible_wisdom_console_react/src/App.tsx
@@ -9,11 +9,12 @@ import { PageApp } from "./PageApp";
 export interface AppProps {
   readonly userName: string;
   readonly telemetryOptEnabled: boolean;
+  readonly adminDashboardUrl: string;
 }
 
 export function App(props: AppProps) {
   const { t } = useTranslation();
-  const { userName, telemetryOptEnabled } = props;
+  const { userName, telemetryOptEnabled, adminDashboardUrl } = props;
 
   const navigationItems = useMemo<PageNavigationItem[]>(() => {
     const items = [
@@ -29,7 +30,7 @@ export function App(props: AppProps) {
         // Telemetry
         label: t("Telemetry"),
         path: "telemetry",
-        element: <TelemetrySettings />,
+        element: <TelemetrySettings adminDashboardUrl={adminDashboardUrl} />,
       });
     }
     return [
@@ -40,7 +41,7 @@ export function App(props: AppProps) {
         children: items,
       },
     ];
-  }, [t, telemetryOptEnabled]);
+  }, [t, telemetryOptEnabled, adminDashboardUrl]);
 
   return (
     <PageApp

--- a/ansible_wisdom_console_react/src/TelemetrySettings.tsx
+++ b/ansible_wisdom_console_react/src/TelemetrySettings.tsx
@@ -41,8 +41,13 @@ import { useTelemetry } from "./hooks/useTelemetryAPI";
 import { BusyButton } from "./BusyButton";
 import { Alerts, AlertsHandle } from "./Alerts";
 
-export function TelemetrySettings() {
+export interface TelemetrySettingsProps {
+  readonly adminDashboardUrl: string;
+}
+
+export function TelemetrySettings(props: TelemetrySettingsProps) {
   const { t } = useTranslation();
+  const { adminDashboardUrl } = props;
 
   const [telemetry, setTelemetry] = useState<Telemetry>({
     status: "NOT_ASKED",
@@ -141,7 +146,10 @@ export function TelemetrySettings() {
                     <Text component={"h3"}>{t("TelemetryManageUsage")}</Text>
                     <Text component={"p"}>
                       {t("TelemetryManageUsageDescription")}
-                      <a href={t("TelemetryManageUsageAdminDashboardURL")}>
+                      <a
+                        data-testid={"telemetry-settings__admin_dashboard_url"}
+                        href={adminDashboardUrl}
+                      >
                         {t("TelemetryManageUsageAdminDashboardURLText")}
                       </a>
                     </Text>

--- a/ansible_wisdom_console_react/src/__tests__/App.test.tsx
+++ b/ansible_wisdom_console_react/src/__tests__/App.test.tsx
@@ -5,7 +5,13 @@ import { App } from "../App";
 describe("App", () => {
   it("Rendering::With Username", async () => {
     window.history.pushState({}, "Test page", "/console");
-    render(<App userName={"Batman"} telemetryOptEnabled={true} />);
+    render(
+      <App
+        userName={"Batman"}
+        telemetryOptEnabled={true}
+        adminDashboardUrl={"http://admin_dashboard-url/"}
+      />,
+    );
     const accountMenu = await screen.findByTestId("page-masthead-dropdown");
     expect(accountMenu).toBeInTheDocument();
     expect(accountMenu).toHaveTextContent("Batman");

--- a/ansible_wisdom_console_react/src/__tests__/TelemetrySettings.test.tsx
+++ b/ansible_wisdom_console_react/src/__tests__/TelemetrySettings.test.tsx
@@ -15,7 +15,9 @@ describe("TelemetrySettings", () => {
 
   it("Loading", async () => {
     (axios.get as jest.Mock).mockResolvedValue({ optOut: "false" });
-    render(<TelemetrySettings />);
+    render(
+      <TelemetrySettings adminDashboardUrl={"http://admin_dashboard-url/"} />,
+    );
     expect(axios.get as jest.Mock).toBeCalledWith(API_TELEMETRY_PATH);
     expect(
       await screen.findByTestId("telemetry-settings__telemetry-loading"),
@@ -24,7 +26,9 @@ describe("TelemetrySettings", () => {
 
   it("Loaded::Found", async () => {
     (axios.get as jest.Mock).mockResolvedValue({ data: { optOut: true } });
-    render(<TelemetrySettings />);
+    render(
+      <TelemetrySettings adminDashboardUrl={"http://admin_dashboard-url/"} />,
+    );
     expect(axios.get as jest.Mock).toBeCalledWith(API_TELEMETRY_PATH);
     expect(
       await screen.findByTestId("telemetry-settings__opt_in_radiobutton"),
@@ -43,13 +47,21 @@ describe("TelemetrySettings", () => {
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton.disabled).toBeFalsy();
     expect(cancelButton.disabled).toBeTruthy();
+
+    const adminDashboardUrl: HTMLAnchorElement = await screen.findByTestId(
+      "telemetry-settings__admin_dashboard_url",
+    );
+    expect(adminDashboardUrl).toBeInTheDocument();
+    expect(adminDashboardUrl.href).toEqual("http://admin_dashboard-url/");
   });
 
   it("Click::Save::Success", async () => {
     (axios.get as jest.Mock).mockResolvedValue({ data: { optOut: false } });
     (axios.post as jest.Mock).mockResolvedValue({});
 
-    render(<TelemetrySettings />);
+    render(
+      <TelemetrySettings adminDashboardUrl={"http://admin_dashboard-url/"} />,
+    );
 
     // Check initial settings
     let optInRadioButton: HTMLInputElement = await screen.findByTestId(
@@ -100,7 +112,9 @@ describe("TelemetrySettings", () => {
     (axios.get as jest.Mock).mockResolvedValue({ data: { optOut: false } });
     (axios.post as jest.Mock).mockRejectedValue({ response: { status: 500 } });
 
-    render(<TelemetrySettings />);
+    render(
+      <TelemetrySettings adminDashboardUrl={"http://admin_dashboard-url/"} />,
+    );
 
     // Emulate click on "Opt Out" radio button
     const optOutRadioButton: HTMLInputElement = await screen.findByTestId(
@@ -128,7 +142,9 @@ describe("TelemetrySettings", () => {
   it("Click::Cancel", async () => {
     (axios.get as jest.Mock).mockResolvedValue({ data: { optOut: false } });
 
-    render(<TelemetrySettings />);
+    render(
+      <TelemetrySettings adminDashboardUrl={"http://admin_dashboard-url/"} />,
+    );
 
     // Check initial settings
     let optInRadioButton: HTMLInputElement = await screen.findByTestId(

--- a/ansible_wisdom_console_react/src/index.tsx
+++ b/ansible_wisdom_console_react/src/index.tsx
@@ -15,9 +15,16 @@ const telemetrySchema2EnabledInnerText = document.getElementById(
 )?.innerText;
 const telemetrySchema2Enabled =
   telemetrySchema2EnabledInnerText?.toLowerCase() === "true";
+const adminDashboardUrl =
+  document.getElementById("telemetry_schema_2_admin_dashboard_url")
+    ?.innerText ?? "";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App userName={userName} telemetryOptEnabled={telemetrySchema2Enabled} />
+    <App
+      userName={userName}
+      telemetryOptEnabled={telemetrySchema2Enabled}
+      adminDashboardUrl={adminDashboardUrl}
+    />
   </StrictMode>,
 );


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20935

## Description
Fix the URL shown in the "Console" for the "Admin Dashboard".

## Testing
Login to Lightspeed with an Org Admin for which "Schema 2 telemetry" is enabled. Navigate to the "Console".

The URL for the "admin dashboard" should be for consoledot/HCC.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. `npm --prefix ./ansible_wisdom_console_react install`
5. `make admin-portal-bundle`
6. Start `wisdom-service` in whatever way you normally do.
7. Login with an Org Admin user for which "Schema 2 telemetry" is enabled.
8. Navigate to the "Console"
9. Navigate to the "Telemetry" section
10. Check the "admin dashboard" URL.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
