### PR TITLE
Containerfile: use two targets to isolate the dev specific steps

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -71,6 +71,8 @@ jobs:
         build-args: |
           IMAGE_TAGS=${{ steps.tag_name.outputs.IMAGE_TAGS }}
           GIT_COMMIT=${{ steps.tag_name.outputs.sha-long }}
+        extra-args: |
+          --target=production
 
     - name: Scan Malware
       # Do not scan malware in PR builds

--- a/tools/configs/supervisord.conf
+++ b/tools/configs/supervisord.conf
@@ -28,19 +28,6 @@ stdout_logfile_maxbytes = 0
 stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
-[program:auto-reload]
-command = auto-reload.sh /var/www/ansible-wisdom-service/ 'supervisorctl restart wisdom-processes:*'
-autostart = true
-autorestart = true
-stopasgroup = true
-killasgroup = true
-stdout_logfile = /dev/stdout
-stdout_logfile_maxbytes = 0
-stderr_logfile = /dev/stderr
-stderr_logfile_maxbytes = 0
-stdout_events_enabled = true
-stderr_events_enabled = true
-
 ; [program:test]
 ; command = sleep infinity
 
@@ -56,3 +43,6 @@ serverurl = unix:///var/run/supervisor/supervisor.sock
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files = /etc/supervisor/supervisord.d/*.conf

--- a/tools/configs/supervisord.d/auto-reload.conf
+++ b/tools/configs/supervisord.d/auto-reload.conf
@@ -1,0 +1,12 @@
+[program:auto-reload]
+command = auto-reload.sh /var/www/ansible-wisdom-service/ 'supervisorctl restart wisdom-processes:*'
+autostart = true
+autorestart = true
+stopasgroup = true
+killasgroup = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
+stdout_events_enabled = true
+stderr_events_enabled = true

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -7,6 +7,7 @@ services:
     build:
       context: $PWD
       dockerfile: wisdom-service.Containerfile
+      target: devel
     depends_on:
       - db
     volumes:

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi:latest
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi:latest AS production
 
 ARG IMAGE_TAGS=image-tags-not-defined
 ARG GIT_COMMIT=git-commit-not-defined
@@ -25,11 +25,6 @@ RUN dnf install -y \
     npm
 
 RUN dnf module install -y nginx/common
-
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    dnf install -y inotify-tools && \
-    dnf remove -y epel-release && \
-    dnf clean all
 
 # Copy the ansible_wisdom package files
 COPY requirements.txt /var/www/ansible-wisdom-service/requirements.txt
@@ -69,7 +64,6 @@ RUN npm --prefix /tmp/ansible_wisdom_console_react run build
 
 # Copy configuration files
 COPY tools/scripts/launch-wisdom.sh /usr/bin/launch-wisdom.sh
-COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
 COPY tools/configs/nginx.conf /etc/nginx/nginx.conf
 COPY tools/configs/nginx-wisdom.conf /etc/nginx/conf.d/wisdom.conf
 COPY tools/configs/uwsgi.ini /etc/wisdom/uwsgi.ini
@@ -104,3 +98,14 @@ USER 1000
 EXPOSE 8000
 
 CMD /usr/bin/launch-wisdom.sh
+
+FROM production AS devel
+USER 0
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf install -y inotify-tools && \
+    dnf remove -y epel-release && \
+    dnf clean all
+COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
+RUN mkdir /etc/supervisor/supervisord.d/
+COPY tools/configs/supervisord.d/auto-reload.conf /etc/supervisor/supervisord.d/auto-reload.conf
+USER 1000


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-21218
<!-- This PR does not need a corresponding Jira item. -->

Use two different targets (https://docs.docker.com/compose/compose-file/build/#target) to isolate the steps that are specific to the development environment.

See: https://github.com/ansible/ansible-wisdom-service/pull/845
