### PR TITLE
VS Code extension provides wrong message on some 204s

### DIFF
--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -108,6 +108,7 @@ class SegmentMiddleware:
                     # Clean up response.data for 204
                     if response.status_code == 204:
                         response.data = None
+                        response['Content-Length'] = 0
                     # For other error cases, remove 'model' in response data
                     elif response.status_code >= 400:
                         response_data.pop('model', None)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [AAP-16862](https://issues.redhat.com/browse/AAP-16862)
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
When completions responds with 204, the extension should show  "Ansible Lightspeed does not have a suggestion based on your input.". Sometimes it instead shows "Failed to fetch inline suggestion from Ansible Lightspeed. Try again after some time." 

Issue was caused by AXIOS library which throw exception if 204 response has data in it or has header Content-Length != 0.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Apply diff (or make server return invalid suggestion in other way)
```diff
diff --git a/ansible_wisdom/ai/api/model_client/wca_client.py b/ansible_wisdom/ai/api/model_client/wca_client.py
index 56cd038..c88e286 100644
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -86,7 +86,7 @@ class DummyWCAClient:
     def infer(self, *args, suggestion_id=None, **kwargs):
         return {
             "model_id": "mocked_wca_client",
-            "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
+            "predictions": ["            loop:\n        - R80\n        -"]
         }
```
4. Deploy with docker
5. Login with unseated user
6. Try to complete
7. You will see correct error message

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Described above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
