### PR TITLE
log ari changes only for WCA requests

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -209,31 +209,32 @@ def completion_post_process(context: CompletionContext):
                     {"name": tasks[index]["name"], "rule_details": ari_result["rule_details"]}
                 )
 
-            # Test for changes to the recommendation and if so log as warn.
-            # WCA is already running ARI so we expect no changes.
-            # Ignore any whitespace and single vs double quote changes.
-            pp = (
-                postprocessed_yaml.replace(" ", "")
-                .replace("\n", "")
-                .replace("\"", "")
-                .replace("'", "")
-            )
-            orig = (
-                recommendation_yaml.replace(" ", "")
-                .replace("\n", "")
-                .replace("\"", "")
-                .replace("'", "")
-            )
-            if pp != orig:
-                ari_changes_logger = logging.getLogger("ari_changes")
-                ari_changes_logger.info(
-                    f"ARI CHANGES DETECTED. suggestion_id: [{suggestion_id}] "
-                    f"recommendation_yaml: [{repr(recommendation_yaml)}] "
-                    f"postprocessed_yaml: [{repr(postprocessed_yaml)}] "
-                    f"original_prompt: [{repr(original_prompt)}] "
-                    f"payload_context: [{repr(payload_context)}] "
-                    f"postprocess_details: [{json.dumps(postprocess_details)}] "
+            if user.rh_user_has_seat:
+                # Test for changes to the recommendation and if so log as warn.
+                # WCA is already running ARI so we expect no changes.
+                # Ignore any whitespace and single vs double quote changes.
+                pp = (
+                    postprocessed_yaml.replace(" ", "")
+                    .replace("\n", "")
+                    .replace("\"", "")
+                    .replace("'", "")
                 )
+                orig = (
+                    recommendation_yaml.replace(" ", "")
+                    .replace("\n", "")
+                    .replace("\"", "")
+                    .replace("'", "")
+                )
+                if pp != orig:
+                    ari_changes_logger = logging.getLogger("ari_changes")
+                    ari_changes_logger.info(
+                        f"ARI CHANGES DETECTED. suggestion_id: [{suggestion_id}] "
+                        f"recommendation_yaml: [{repr(recommendation_yaml)}] "
+                        f"postprocessed_yaml: [{repr(postprocessed_yaml)}] "
+                        f"original_prompt: [{repr(original_prompt)}] "
+                        f"payload_context: [{repr(payload_context)}] "
+                        f"postprocess_details: [{json.dumps(postprocess_details)}] "
+                    )
 
             logger.debug(
                 f"suggestion id: {suggestion_id}, "


### PR DESCRIPTION
Jira Issue: [AAP-20754](https://issues.redhat.com/browse/AAP-20754)

## Description
One-liner to only dump ARI change details if user is seated (i.e. request went to ARI).

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR and run the service
2. Make a request as a seated user with the dummy WCA background
3. Confirm a delta is printed (since dummy WCA doesn't have ARI rules in play)

### Scenarios tested
Above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
