### PR TITLE
pip-compile shouldn't know where it runs

### DIFF
--- a/tools/docker-compose/pip-compile.yaml
+++ b/tools/docker-compose/pip-compile.yaml
@@ -3,6 +3,7 @@ services:
   pip-compile:
     platform: linux/x86_64
     image: registry.access.redhat.com/ubi9/ubi:latest
+    working_dir: /var/www/wisdom
     volumes:
       - $PWD:/var/www/wisdom
     command:

--- a/tools/scripts/pip-compile.sh
+++ b/tools/scripts/pip-compile.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -o errexit
 
-cd /var/www/wisdom
 /usr/bin/python3 -m venv /var/www/venv
 /var/www/venv/bin/python3 -m pip --no-cache-dir install pip-tools
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: N/A
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

Make it easier to invoke pip-compile from other places (precursor to another PR).

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. make pip-compile
3. tools/scripts/pip-compile.sh

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
