### PR TITLE
AAP-18650: Bypass the org check for special orgs

### DIFF
--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -19,8 +19,8 @@ class WisdomFlags(str, Enum):
     MODEL_NAME = "model_name"
     # Schema 2 Telemetry is enabled for an Organization
     SCHEMA_2_TELEMETRY_ORG_ENABLED = "schema_2_telemetry_org_enabled"
-    # Some organizations has unlimited access to WCA
-    SPECIAL_WCA_ACCESS_ORGS = "special_wca_access_orgs"
+    # For some organizations we can bypass the subscription check
+    BYPASS_AAP_SUBSCRIPTION_CHECK = "special_wca_access_orgs"
 
 
 class FeatureFlags:

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -302,6 +302,11 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        "organizations": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
     "root": {
         "handlers": ["console"],

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -21,11 +21,17 @@ class Organization(models.Model):
         )
 
     @cached_property
-    def is_unlimited_access_allowed(self) -> bool:
+    def is_subscription_check_should_be_bypassed(self) -> bool:
         # Avoid circular dependency issue with lazy import
         from ansible_wisdom.ai.feature_flags import WisdomFlags
 
-        return self.__make_organization_request_to_launchdarkly(WisdomFlags.SPECIAL_WCA_ACCESS_ORGS)
+        try:
+            return self.__make_organization_request_to_launchdarkly(
+                WisdomFlags.BYPASS_AAP_SUBSCRIPTION_CHECK
+            )
+        except Exception:
+            # User should not be blocked if LaunchDarkly fails.
+            return True
 
     def __make_organization_request_to_launchdarkly(self, flag: str) -> bool:
         if not settings.LAUNCHDARKLY_SDK_KEY:

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -54,11 +54,11 @@ class TestOrganization(TestCase):
     def test_org_with_unlimited_access_allowed_with_feature_flag_override(self, LDClient):
         LDClient.return_value.variation.return_value = True
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertTrue(organization.is_unlimited_access_allowed)
+        self.assertTrue(organization.is_subscription_check_should_be_bypassed)
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
     def test_org_with_no_unlimited_access_allowed_with_feature_flag_no_override(self, LDClient):
         LDClient.return_value.variation.return_value = False
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.is_unlimited_access_allowed)
+        self.assertFalse(organization.is_subscription_check_should_be_bypassed)

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -18,7 +18,7 @@ from .constants import (
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("organizations")
 
 
 class NonClashingForeignKey(models.ForeignKey):
@@ -87,8 +87,11 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
     def rh_org_has_subscription(self) -> bool:
         """True if the user is in unlimited group or
         comes from RHSSO and the associated org has access to Wisdom."""
-        if self.organization and self.organization.is_unlimited_access_allowed:
-            logger.warn(f"Organization check bypassed for user UUID: {self.uuid}")
+        if self.organization and self.organization.is_subscription_check_should_be_bypassed:
+            logger.info(
+                f"""Bypass organization check for organization ID {self.organization.id}
+ and user UUID: {self.uuid}."""
+            )
             return True
 
         if not self.is_oidc_user():

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -377,7 +377,7 @@ class TestUserSeat(WisdomAppsBackendMocking):
         with patch.object(apps.get_app_config('ai'), 'get_seat_checker', lambda: None):
             user = create_user(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
             org = Organization(None, None)
-            org.is_unlimited_access_allowed = True
+            org.is_subscription_check_should_be_bypassed = True
             user.organization = org
             self.assertTrue(user.rh_org_has_subscription)
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18650>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
To enable "special" RH SSO Orgs access to Lightspeed, and we don't have the ability to allocate AAP SKUs for the license check, we need a way to bypass the license check for a list of orgs. 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. On stage
2. Add user with org 17691404 or 17380863
3. Check that autocomplete is working
4. In console log present a message: "Organization check bypassed for user UUID: <UUID>"

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Tested mocked logic locally.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own

