### PR TITLE
add instructions for enabling multi-arch support in podman/QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,35 @@ pre-commit autoupdate && pre-commit run -a
 ## Updating the Python dependencies
 
 We are now using pip-compile in order to manage our Python
-dependencies.
+dependencies for the x86_64 and ARM64/AArch64 architectures.
+
+In order to generate requirements.txt files for both architectures,
+you must use a multi-arch capable virtual machine emulator (like QEMU)
+and enable multi-arch support.
+
+To enable multi-arch support, run the instructions for your container
+engine and emulator from this table:
+
+<table>
+<tr>
+<td>Container Engine</td>
+<td>Emulator</td>
+<td>Instructions</td>
+</tr>
+<tr>
+<td>podman</td>
+<td>QEMU</td>
+<td>
+
+```bash
+podman machine ssh
+sudo rpm-ostree install qemu-user-static
+sudo systemctl reboot
+```
+
+</td>
+</tr>
+</table>
 
 The specification of what packages we need now live in the
 requirements.in and requirements-dev.in files. Use your preferred


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: N/A
<!-- This PR does not need a corresponding Jira item. -->

## Description
Add instructions for enabling multi-arch support for podman + QEMU

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the commands in the README
3. Ensure the following files are created with the appropriate `torch` and `torchvision` package:
  - requirements-x86_64.txt
  - requirements-dev-x86_64.txt
  - requirements-aarch64.txt
  - requirements-dev-aarch64.txt
 
The `aarch64` files should have the following `torch` (and similar `torchvision`) entry:
```
torch @ https://download.pytorch.org/whl/torch-2.0.1-cp39-cp39-manylinux2014_aarch64.whl ; platform_machine == "aarch64"
```

The `x86_64` files should have the following `torch` (and similar `torchvision`) entry:
```
torch @ https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp39-cp39-linux_x86_64.whl ; platform_machine == "x86_64"
```

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
