### PR TITLE
final wording and url for tech preview disabled

### DIFF
--- a/ansible_wisdom/main/templates/base.html
+++ b/ansible_wisdom/main/templates/base.html
@@ -25,7 +25,7 @@
             <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
           </div>
           <p class="pf-c-alert__title">
-             The Tech Preview is no longer available, please <a class="pf-l-level__item" href="https://www.ansible.com/blog/topic/ansible-lightspeed/" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span>read the blog</a> for further details.
+            The Ansible Lightspeed Technical Preview is no longer available. For continued access to the commercial service, please see <a class="pf-l-level__item" href="https://www.redhat.com/en/blog/getting-started-red-hat-ansible-lightspeed-ibm-watsonx-code-assistant" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span>Getting started with Red Hat Ansible Lightspeed with IBM watsonx Code Assistant</a>.
           </p>
         </div>
         <br />

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -83,7 +83,9 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
             response, "Your organization doesn't have access to Ansible Lightspeed."
         )
         self.assertNotContains(response, "You will be limited to features of the Lightspeed")
-        self.assertNotContains(response, "The Tech Preview is no longer available")
+        self.assertNotContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", False)
@@ -97,7 +99,9 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         self.assertNotContains(
             response, "Your organization doesn't have access to Ansible Lightspeed."
         )
-        self.assertContains(response, "The Tech Preview is no longer available")
+        self.assertContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
     @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
@@ -137,7 +141,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "fas fa-exclamation-circle")
         self.assertNotContains(response, "Admin Portal")
-        self.assertNotContains(response, "The Tech Preview is no longer available")
+        self.assertNotContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(WCA_SECRET_DUMMY_SECRETS='valid')
@@ -152,7 +158,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "fas fa-exclamation-circle")
         self.assertNotContains(response, "Admin Portal")
-        self.assertNotContains(response, "The Tech Preview is no longer available")
+        self.assertNotContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
@@ -166,7 +174,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "You do not have a licensed seat for Ansible Lightspeed")
         self.assertNotContains(response, "You will be limited to features of the Lightspeed")
         self.assertNotContains(response, "Admin Portal")
-        self.assertContains(response, "The Tech Preview is no longer available")
+        self.assertContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
     @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
@@ -212,7 +222,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
             response, "Your organization doesn't have access to Ansible Lightspeed."
         )
         self.assertContains(response, "fa-exclamation-circle")
-        self.assertContains(response, "The Tech Preview is no longer available")
+        self.assertContains(
+            response, "The Ansible Lightspeed Technical Preview is no longer available"
+        )
 
 
 @override_settings(AUTHZ_BACKEND_TYPE='dummy')


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-20371


## Description
Update the wording and URL in the banner for tech preview disabled. 

![image](https://github.com/ansible/ansible-wisdom-service/assets/3698180/ada4f3ff-f32f-494b-be4a-e3cde3252cf5)


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Set `"ANSIBLE_AI_ENABLE_TECH_PREVIEW": "False"` in your env vars
3. Start the service and access the main landing page at /
4. Confirm you see the text in the screen capture above and the URL links to https://www.redhat.com/en/blog/getting-started-red-hat-ansible-lightspeed-ibm-watsonx-code-assistant

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Described above, and unit tests were updated accordingly.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
