### PR TITLE
AAP-21173: Integrate custom models for telemetry

### DIFF
--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -17,13 +17,12 @@ class ModelMeshClient:
     def set_inference_url(self, inference_url):
         self._inference_url = inference_url
 
-    @abstractmethod
     def get_model_id(
         self,
         organization_id: Optional[int] = None,
         requested_model_id: str = '',
     ) -> str:
-        raise NotImplementedError
+        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME
 
     def timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None

--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Optional
 
 from django.conf import settings
 
@@ -15,6 +16,14 @@ class ModelMeshClient:
 
     def set_inference_url(self, inference_url):
         self._inference_url = inference_url
+
+    @abstractmethod
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        raise NotImplementedError
 
     def timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -2,6 +2,7 @@ import json
 import logging
 import secrets
 import time
+from typing import Optional
 
 import requests
 from django.conf import settings
@@ -18,7 +19,6 @@ class DummyClient(ModelMeshClient):
         self.headers = {"Content-Type": "application/json"}
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
-        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
         if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:
@@ -29,3 +29,10 @@ class DummyClient(ModelMeshClient):
         response_body = json.loads(settings.DUMMY_MODEL_RESPONSE_BODY)
         response_body['model_id'] = '_'
         return response_body
+
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -2,7 +2,6 @@ import json
 import logging
 import secrets
 import time
-from typing import Optional
 
 import requests
 from django.conf import settings
@@ -29,10 +28,3 @@ class DummyClient(ModelMeshClient):
         response_body = json.loads(settings.DUMMY_MODEL_RESPONSE_BODY)
         response_body['model_id'] = '_'
         return response_body
-
-    def get_model_id(
-        self,
-        organization_id: Optional[int] = None,
-        requested_model_id: str = '',
-    ) -> str:
-        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import grpc
 from django.conf import settings
@@ -29,7 +30,7 @@ class GrpcClient(ModelMeshClient):
         self._inference_stub = self.get_inference_stub()
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
-        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
+        model_id = self.get_model_id(None, model_id)
         logger.debug(f"Input prompt: {model_input}")
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")
@@ -55,3 +56,10 @@ class GrpcClient(ModelMeshClient):
             else:
                 logger.error(f"gRPC client error: {exc.details()}")
                 raise
+
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -1,8 +1,6 @@
 import logging
-from typing import Optional
 
 import grpc
-from django.conf import settings
 
 from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
 
@@ -56,10 +54,3 @@ class GrpcClient(ModelMeshClient):
             else:
                 logger.error(f"gRPC client error: {exc.details()}")
                 raise
-
-    def get_model_id(
-        self,
-        organization_id: Optional[int] = None,
-        requested_model_id: str = '',
-    ) -> str:
-        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -1,9 +1,7 @@
 import json
 import logging
-from typing import Optional
 
 import requests
-from django.conf import settings
 
 from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
 
@@ -39,10 +37,3 @@ class HttpClient(ModelMeshClient):
             return response
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
-
-    def get_model_id(
-        self,
-        organization_id: Optional[int] = None,
-        requested_model_id: str = '',
-    ) -> str:
-        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional
 
 import requests
 from django.conf import settings
@@ -19,7 +20,7 @@ class HttpClient(ModelMeshClient):
         self.headers = {"Content-Type": "application/json"}
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
-        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
+        model_id = self.get_model_id(None, model_id)
         self._prediction_url = f"{self._inference_url}/predictions/{model_id}"
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
@@ -38,3 +39,10 @@ class HttpClient(ModelMeshClient):
             return response
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
+
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/llamacpp_client.py
@@ -1,9 +1,7 @@
 import json
 import logging
-from typing import Optional
 
 import requests
-from django.conf import settings
 
 from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
 
@@ -80,10 +78,3 @@ class LlamaCPPClient(ModelMeshClient):
             return response
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
-
-    def get_model_id(
-        self,
-        organization_id: Optional[int] = None,
-        requested_model_id: str = '',
-    ) -> str:
-        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/llamacpp_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional
 
 import requests
 from django.conf import settings
@@ -19,7 +20,7 @@ class LlamaCPPClient(ModelMeshClient):
         self.headers = {"Content-Type": "application/json"}
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
-        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
+        model_id = self.get_model_id(None, model_id)
         self._prediction_url = f"{self._inference_url}/completion"
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
@@ -79,3 +80,10 @@ class LlamaCPPClient(ModelMeshClient):
             return response
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
+
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        return requested_model_id or settings.ANSIBLE_AI_MODEL_NAME

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -81,6 +81,20 @@ class DummyWCAClient:
     def infer_from_parameters(self, *args, **kwargs):
         return ""
 
+    def get_model_id(
+        self,
+        organization_id: Optional[int],
+        requested_model_id: str = '',
+    ) -> str:
+        if requested_model_id:
+            # requested_model_id defined: let them use what they ask for
+            return requested_model_id
+
+        if settings.ANSIBLE_AI_MODEL_MESH_MODEL_NAME:
+            return settings.ANSIBLE_AI_MODEL_MESH_MODEL_NAME
+
+        raise WcaModelIdNotFound()
+
     def get_token(self, api_key):
         if api_key != "valid":
             raise WcaTokenFailure("I'm a fake WCA client and the only api_key I accept is 'valid'")

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -347,8 +347,8 @@ class WCAClient(BaseWCAClient):
         logger.error("Seated user's organization doesn't have default API Key set")
         raise WcaKeyNotFound
 
-    @staticmethod
     def get_model_id(
+        self,
         organization_id: Optional[int],
         requested_model_id: str = '',
     ) -> str:

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -83,13 +83,10 @@ class DummyWCAClient:
 
     def get_model_id(
         self,
-        organization_id: Optional[int],
+        organization_id: Optional[int] = None,
         requested_model_id: str = '',
     ) -> str:
-        if requested_model_id:
-            # requested_model_id defined: let them use what they ask for
-            return requested_model_id
-        return ""
+        return requested_model_id or ''
 
     def get_token(self, api_key):
         if api_key != "valid":
@@ -217,14 +214,6 @@ class BaseWCAClient(ModelMeshClient):
 
     @abstractmethod
     def get_api_key(self, organization_id: Optional[int]) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_model_id(
-        self,
-        organization_id: Optional[int],
-        requested_model_id: str = '',
-    ) -> str:
         raise NotImplementedError
 
     def codematch(self, model_input, model_id: str = ""):
@@ -359,7 +348,7 @@ class WCAClient(BaseWCAClient):
 
     def get_model_id(
         self,
-        organization_id: Optional[int],
+        organization_id: Optional[int] = None,
         requested_model_id: str = '',
     ) -> str:
         if settings.ANSIBLE_AI_MODEL_MESH_MODEL_NAME:
@@ -425,7 +414,7 @@ class WCAOnPremClient(BaseWCAClient):
 
     def get_model_id(
         self,
-        organization_id: Optional[int],
+        organization_id: Optional[int] = None,
         requested_model_id: str = '',
     ) -> str:
         if requested_model_id:

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -347,8 +347,8 @@ class WCAClient(BaseWCAClient):
         logger.error("Seated user's organization doesn't have default API Key set")
         raise WcaKeyNotFound
 
+    @staticmethod
     def get_model_id(
-        self,
         organization_id: Optional[int],
         requested_model_id: str = '',
     ) -> str:

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -89,11 +89,7 @@ class DummyWCAClient:
         if requested_model_id:
             # requested_model_id defined: let them use what they ask for
             return requested_model_id
-
-        if settings.ANSIBLE_AI_MODEL_MESH_MODEL_NAME:
-            return settings.ANSIBLE_AI_MODEL_MESH_MODEL_NAME
-
-        raise WcaModelIdNotFound()
+        return ""
 
     def get_token(self, api_key):
         if api_key != "valid":

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -342,6 +342,7 @@ class FeedbackRequestSerializer(serializers.Serializer):
     sentimentFeedback = SentimentFeedback(required=False)
     issueFeedback = IssueFeedback(required=False)
     metadata = Metadata(required=False)
+    model = serializers.CharField(required=False)
 
     def validate_inlineSuggestion(self, value):
         user = self.context.get('request').user

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -7,6 +7,7 @@ import string
 import time
 import uuid
 from http import HTTPStatus
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import requests
@@ -118,6 +119,13 @@ class MockedMeshClient(ModelMeshClient):
         time.sleep(0.1)  # w/o this line test_rate_limit() fails...
         # i.e., still receives 200 after 10 API calls...
         return self.response_data
+
+    def get_model_id(
+        self,
+        organization_id: Optional[int] = None,
+        requested_model_id: str = '',
+    ) -> str:
+        return requested_model_id or ''
 
 
 class WisdomServiceAPITestCaseBase(APITransactionTestCase, WisdomServiceLogAwareTestCase):

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -1204,6 +1204,7 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 "title": "This is a test issue",
                 "description": "This is a test issue description",
             },
+            "model": str(uuid.uuid4()),
         }
         with self.assertLogs(logger='root', level='DEBUG') as log:
             self.client.force_authenticate(user=self.user)
@@ -1288,6 +1289,30 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 self.assertTrue('rh_user_org_id' in properties)
                 self.assertEqual(hostname, properties['hostname'])
                 self.assertIsNotNone(event['timestamp'])
+
+    def test_feedback_segment_events_with_custom_model(self):
+        model_name = str(uuid.uuid4())
+        payload = {
+            "inlineSuggestion": {
+                "latency": 1000,
+                "userActionTime": 3500,
+                "documentUri": "file:///home/user/ansible.yaml",
+                "action": "0",
+                "suggestionId": str(uuid.uuid4()),
+            },
+            "model": model_name,
+        }
+        self.client.force_authenticate(user=self.user)
+        with self.assertLogs(logger='root', level='DEBUG') as log:
+            r = self.client.post(reverse('feedback'), payload, format='json')
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+
+            segment_events = self.extractSegmentEventsFromLog(log)
+            self.assertTrue(len(segment_events) > 0)
+            for event in segment_events:
+                properties = event['properties']
+                self.assertTrue('modelName' in properties)
+                self.assertEqual(model_name, properties['modelName'])
 
     def test_feedback_segment_inline_suggestion_feedback_error(self):
         payload = {

--- a/ansible_wisdom/ai/api/utils/analytics_telemetry_model.py
+++ b/ansible_wisdom/ai/api/utils/analytics_telemetry_model.py
@@ -46,6 +46,7 @@ class AnalyticsProductFeedback:
         validator=[validators.instance_of(int), validators.in_([1, 2, 3, 4, 5])], converter=int
     )
     rh_user_org_id: int = field(validator=validators.instance_of(int), converter=int, default=0)
+    model_name: str = field(default='')
     timestamp: str = field(
         default=Factory(lambda self: timezone.now().isoformat(), takes_self=True)
     )

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -49,7 +49,6 @@ from .data.data_model import (
     ContentMatchResponseDto,
 )
 from .model_client.exceptions import ModelTimeoutError
-from .model_client.wca_client import WCAClient
 from .permissions import (
     AcceptedTermsPermission,
     BlockUserWithoutSeat,
@@ -212,7 +211,8 @@ class Feedback(APIView):
             "ansibleExtensionVersion", None
         )
         org_id = getattr(user, 'org_id', None)
-        model_name = WCAClient.get_model_id(org_id, str(validated_data.get('model', '')))
+        wca_client = apps.get_app_config("ai").get_wca_client()
+        model_name = wca_client.get_model_id(org_id, str(validated_data.get('model', '')))
 
         if inline_suggestion_data:
             event = {

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -211,8 +211,8 @@ class Feedback(APIView):
             "ansibleExtensionVersion", None
         )
         org_id = getattr(user, 'org_id', None)
-        wca_client = apps.get_app_config("ai").get_wca_client()
-        model_name = wca_client.get_model_id(org_id, str(validated_data.get('model', '')))
+        model_mesh_client = apps.get_app_config("ai").model_mesh_client
+        model_name = model_mesh_client.get_model_id(org_id, str(validated_data.get('model', '')))
 
         if inline_suggestion_data:
             event = {

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -49,6 +49,7 @@ from .data.data_model import (
     ContentMatchResponseDto,
 )
 from .model_client.exceptions import ModelTimeoutError
+from .model_client.wca_client import WCAClient
 from .permissions import (
     AcceptedTermsPermission,
     BlockUserWithoutSeat,
@@ -210,12 +211,16 @@ class Feedback(APIView):
         ansible_extension_version = validated_data.get("metadata", {}).get(
             "ansibleExtensionVersion", None
         )
+        org_id = getattr(user, 'org_id', None)
+        model_name = WCAClient.get_model_id(org_id, str(validated_data.get('model', '')))
+
         if inline_suggestion_data:
             event = {
                 "latency": inline_suggestion_data.get('latency'),
                 "userActionTime": inline_suggestion_data.get('userActionTime'),
                 "action": inline_suggestion_data.get('action'),
                 "suggestionId": str(inline_suggestion_data.get('suggestionId', '')),
+                "modelName": model_name,
                 "activityId": str(inline_suggestion_data.get('activityId', '')),
                 "exception": exception is not None,
             }
@@ -225,7 +230,7 @@ class Feedback(APIView):
                 lambda: AnalyticsRecommendationAction(
                     action=inline_suggestion_data.get('action'),
                     suggestion_id=inline_suggestion_data.get('suggestionId', ''),
-                    rh_user_org_id=getattr(user, 'org_id', None),
+                    rh_user_org_id=org_id,
                 ),
                 user,
                 ansible_extension_version,
@@ -235,6 +240,7 @@ class Feedback(APIView):
                 "content": ansible_content_data.get('content'),
                 "documentUri": ansible_content_data.get('documentUri'),
                 "trigger": ansible_content_data.get('trigger'),
+                "modelName": model_name,
                 "activityId": str(ansible_content_data.get('activityId', '')),
                 "exception": exception is not None,
             }
@@ -245,6 +251,7 @@ class Feedback(APIView):
                 "providedSuggestion": suggestion_quality_data.get('providedSuggestion'),
                 "expectedSuggestion": suggestion_quality_data.get('expectedSuggestion'),
                 "additionalComment": suggestion_quality_data.get('additionalComment'),
+                "modelName": model_name,
                 "exception": exception is not None,
             }
             send_segment_event(event, "suggestionQualityFeedback", user)
@@ -252,6 +259,7 @@ class Feedback(APIView):
             event = {
                 "value": sentiment_feedback_data.get('value'),
                 "feedback": sentiment_feedback_data.get('feedback'),
+                "modelName": model_name,
                 "exception": exception is not None,
             }
             send_segment_event(event, "sentimentFeedback", user)
@@ -259,7 +267,8 @@ class Feedback(APIView):
                 AnalyticsTelemetryEvents.PRODUCT_FEEDBACK,
                 lambda: AnalyticsProductFeedback(
                     value=sentiment_feedback_data.get('value'),
-                    rh_user_org_id=getattr(user, 'org_id', None),
+                    rh_user_org_id=org_id,
+                    model_name=model_name,
                 ),
                 user,
                 ansible_extension_version,
@@ -269,6 +278,7 @@ class Feedback(APIView):
                 "type": issue_feedback_data.get('type'),
                 "title": issue_feedback_data.get('title'),
                 "description": issue_feedback_data.get('description'),
+                "modelName": model_name,
                 "exception": exception is not None,
             }
             send_segment_event(event, "issueFeedback", user)

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -722,6 +722,8 @@ components:
           $ref: '#/components/schemas/IssueFeedback'
         metadata:
           $ref: '#/components/schemas/Metadata'
+        model:
+          type: string
     InlineSuggestionFeedback:
       type: object
       properties:


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-21173>

## Description
Adding a new `model` field for the feedback request, which comes from the [VSCode request](https://issues.redhat.com/browse/AAP-21329), see [PR here](https://github.com/ansible/vscode-ansible/pull/1131), and propagating it into telemetry events.
It applies for both:
- `schema1` => All feedback events feedback events
- `schema2` =>  Just adding the model field into the `Product Feedback` (sentiment), as it is already present for `Recommendation Generated`, which correlates with the `Recommendation Action` one.

## Testing
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
