### PR TITLE
playbook explanation branch

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -21,5 +21,5 @@ jobs:
         python-version: '3.11'
     - name: install
       run: |
-        pip install pyright django boto3 requests prometheus_client backoff django_prometheus
+        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain
         pyright

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -98,7 +98,7 @@ class BAMClient(ModelMeshClient):
         )
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
-        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
+        model_id = self.get_model_id(None, model_id)
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -1,17 +1,10 @@
 import json
 import logging
 import re
+from typing import Any, Callable, List, Optional
 
 import requests
 from django.conf import settings
-
-from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
-
-from .base import ModelMeshClient
-from .exceptions import ModelTimeoutError
-
-from typing import Any, List, Optional, Callable
-
 from langchain_core.language_models.chat_models import SimpleChatModel
 from langchain_core.messages.chat import ChatMessage
 from langchain_core.prompts.chat import (
@@ -19,6 +12,9 @@ from langchain_core.prompts.chat import (
     HumanMessagePromptTemplate,
     SystemMessagePromptTemplate,
 )
+
+from .base import ModelMeshClient
+from .exceptions import ModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +120,7 @@ class BAMClient(ModelMeshClient):
 
         try:
             # messages = chat_template.format_messages(prompt=full_prompt)
-            chain = chat_template | self.llm
+            chain = chat_template | llm
             message = chain.invoke({"prompt": full_prompt})
 
             task = message.content

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -1,0 +1,80 @@
+import json
+import logging
+import re
+
+import requests
+from django.conf import settings
+
+from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
+
+from .base import ModelMeshClient
+from .exceptions import ModelTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+class BAMClient(ModelMeshClient):
+    def __init__(self, inference_url):
+        super().__init__(inference_url=inference_url)
+        self.session = requests.Session()
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {settings.ANSIBLE_AI_MODEL_MESH_API_KEY}"
+        }
+
+    def infer(self, model_input, model_id=None, suggestion_id=None):
+        model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
+        #self._prediction_url = f"{self._inference_url}/v2/text/generation?version=2024-01-10"
+        self._prediction_url = f"{self._inference_url}/v2/text/chat?version=2024-01-10"
+
+        prompt = model_input.get("instances", [{}])[0].get("prompt", "")
+        context = model_input.get("instances", [{}])[0].get("context", "")
+
+        logger.info(f"prompt: '{prompt}'")
+        logger.info(f"context: '{context}'")
+
+        full_prompt = f"{context}{prompt}\n"
+        logger.info(f"full prompt: {full_prompt}")
+
+        params = {
+            "model_id": model_id,
+            "messages": [{
+                "role": "system",
+                "content": "You are an Ansible expert. Return a single task that best completes the partial playbook. Return only the task as YAML. Do not return multiple tasks. Do not explain your response. Do not include the prompt in your response."
+            },{
+                "role": "user",
+                "content": full_prompt,
+            }],
+            "parameters": {
+                "temperature": 0.1,
+                "decoding_method": "greedy",
+                "repetition_penalty": 1.05,
+                "min_new_tokens": 1,
+                "max_new_tokens": 2048
+            }
+        }
+
+        logger.info(f"request: {params}")
+
+        try:
+            # TODO(rg): implement multitask here with a loop
+            task_count = len(get_task_names_from_prompt(prompt))
+            result = self.session.post(
+                self._prediction_url,
+                headers=self.headers,
+                json=params,
+                timeout=self.timeout(task_count),
+            )
+            result.raise_for_status()
+            body = json.loads(result.text)
+            logger.info(f"response: {body}")
+            task = body.get("results", [{}])[0].get("generated_text", "")
+            # TODO(rg): fragile and not always correct; remove when we've created a better tune
+            task = task.split("```yaml")[-1]
+            task = re.split(r'- name: .+\n', task)[-1]
+            task = task.split("```")[0]
+            response = {"predictions": [task], "model_id": body["model_id"]}
+
+            return response
+        except requests.exceptions.Timeout:
+            raise ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -10,21 +10,87 @@ from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
 from .base import ModelMeshClient
 from .exceptions import ModelTimeoutError
 
+from typing import Any, List, Optional, Callable
+
+from langchain_core.language_models.chat_models import SimpleChatModel
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.messages.chat import ChatMessage
+from langchain_core.prompts.chat import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
+
 logger = logging.getLogger(__name__)
+
+SYSTEM_MESSAGE_TEMPLATE = "You are an Ansible expert. Return a single task that best completes the partial playbook. Return only the task as YAML. Do not return multiple tasks. Do not explain your response. Do not include the prompt in your response."
+HUMAN_MESSAGE_TEMPLATE = "{prompt}"
+
+
+class ChatBAM(SimpleChatModel):
+    api_key: str
+    model_id: str
+    prediction_url: str
+    timeout: Callable[[int], int]
+
+    @property
+    def _llm_type(self) -> str:
+        return "BAM"
+
+    def _call(
+        self,
+        messages: List[ChatMessage],
+        stop: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        if stop is not None:
+            raise ValueError("stop kwargs are not permitted.")
+
+        bam_messages = list(
+            map(lambda x: {"role": x.additional_kwargs['role'], "content": x.content}, messages)
+        )
+        session = requests.Session()
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        params = {
+            "model_id": self.model_id,
+            "messages": bam_messages,
+            "parameters": {
+                "temperature": 0.1,
+                "decoding_method": "greedy",
+                "repetition_penalty": 1.05,
+                "min_new_tokens": 1,
+                "max_new_tokens": 2048,
+            },
+        }
+
+        logger.info(f"request: {params}")
+
+        # TODO(rg): implement multitask
+        # task_count = len(get_task_names_from_prompt(prompt))
+        result = session.post(
+            self.prediction_url,
+            headers=headers,
+            json=params,
+            # timeout=self.timeout(task_count),
+            timeout=self.timeout(1),
+        )
+        result.raise_for_status()
+        body = json.loads(result.text)
+        logger.info(f"response: {body}")
+        response = body.get("results", [{}])[0].get("generated_text", "")
+        return response
 
 
 class BAMClient(ModelMeshClient):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
-        self.session = requests.Session()
-        self.headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {settings.ANSIBLE_AI_MODEL_MESH_API_KEY}"
-        }
 
     def infer(self, model_input, model_id=None, suggestion_id=None):
         model_id = model_id or settings.ANSIBLE_AI_MODEL_NAME
-        #self._prediction_url = f"{self._inference_url}/v2/text/generation?version=2024-01-10"
         self._prediction_url = f"{self._inference_url}/v2/text/chat?version=2024-01-10"
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
@@ -36,45 +102,38 @@ class BAMClient(ModelMeshClient):
         full_prompt = f"{context}{prompt}\n"
         logger.info(f"full prompt: {full_prompt}")
 
-        params = {
-            "model_id": model_id,
-            "messages": [{
-                "role": "system",
-                "content": "You are an Ansible expert. Return a single task that best completes the partial playbook. Return only the task as YAML. Do not return multiple tasks. Do not explain your response. Do not include the prompt in your response."
-            },{
-                "role": "user",
-                "content": full_prompt,
-            }],
-            "parameters": {
-                "temperature": 0.1,
-                "decoding_method": "greedy",
-                "repetition_penalty": 1.05,
-                "min_new_tokens": 1,
-                "max_new_tokens": 2048
-            }
-        }
+        llm = ChatBAM(
+            api_key=settings.ANSIBLE_AI_MODEL_MESH_API_KEY,
+            model_id=model_id,
+            prediction_url=self._prediction_url,
+            timeout=self.timeout,
+        )
 
-        logger.info(f"request: {params}")
+        chat_template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(
+                    SYSTEM_MESSAGE_TEMPLATE, additional_kwargs={"role": "system"}
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    HUMAN_MESSAGE_TEMPLATE, additional_kwargs={"role": "user"}
+                ),
+            ]
+        )
 
         try:
-            # TODO(rg): implement multitask here with a loop
-            task_count = len(get_task_names_from_prompt(prompt))
-            result = self.session.post(
-                self._prediction_url,
-                headers=self.headers,
-                json=params,
-                timeout=self.timeout(task_count),
-            )
-            result.raise_for_status()
-            body = json.loads(result.text)
-            logger.info(f"response: {body}")
-            task = body.get("results", [{}])[0].get("generated_text", "")
+            # messages = chat_template.format_messages(prompt=full_prompt)
+            chain = chat_template | llm
+            message = chain.invoke({"prompt": full_prompt})
+
+            task = message.content
+
             # TODO(rg): fragile and not always correct; remove when we've created a better tune
             task = task.split("```yaml")[-1]
             task = re.split(r'- name: .+\n', task)[-1]
             task = task.split("```")[0]
-            response = {"predictions": [task], "model_id": body["model_id"]}
+            response = {"predictions": [task], "model_id": model_id}
 
             return response
+
         except requests.exceptions.Timeout:
             raise ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -18,7 +18,11 @@ from .exceptions import ModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_MESSAGE_TEMPLATE = "You are an Ansible expert. Return a single task that best completes the partial playbook. Return only the task as YAML. Do not return multiple tasks. Do not explain your response. Do not include the prompt in your response."
+SYSTEM_MESSAGE_TEMPLATE = (
+    "You are an Ansible expert. Return a single task that best completes the "
+    "partial playbook. Return only the task as YAML. Do not return multiple tasks. "
+    "Do not explain your response. Do not include the prompt in your response."
+)
 HUMAN_MESSAGE_TEMPLATE = "{prompt}"
 
 
@@ -123,7 +127,8 @@ class BAMClient(ModelMeshClient):
             chain = chat_template | llm
             message = chain.invoke({"prompt": full_prompt})
 
-            task = message.content
+            # Ollama answers with just a string
+            task = message.content if hasattr(message, "content") else message
 
             # TODO(rg): fragile and not always correct; remove when we've created a better tune
             task = task.split("```yaml")[-1]

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -13,7 +13,6 @@ from .exceptions import ModelTimeoutError
 from typing import Any, List, Optional, Callable
 
 from langchain_core.language_models.chat_models import SimpleChatModel
-from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages.chat import ChatMessage
 from langchain_core.prompts.chat import (
     ChatPromptTemplate,

--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -126,12 +126,7 @@ class BAMClient(ModelMeshClient):
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")
 
-        logger.info(f"prompt: '{prompt}'")
-        logger.info(f"context: '{context}'")
-
         full_prompt = f"{context}{prompt}\n"
-        logger.info(f"full prompt: {full_prompt}")
-
         llm = self.get_chat_model(model_id)
 
         chat_template = ChatPromptTemplate.from_messages(

--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from django.conf import settings
 
@@ -11,7 +11,7 @@ class ModelMeshClient:
         self._timeout = int(i) if i is not None else None
 
     @abstractmethod
-    def infer(self, model_input, model_id="wisdom", suggestion_id=None):  # pragma: no cover
+    def infer(self, model_input, model_id: str = "", suggestion_id=None) -> Dict[str, Any]:
         pass
 
     def codematch(self, model_input, model_id):

--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -29,3 +29,6 @@ class ModelMeshClient:
 
     def timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None
+
+    def get_chat_model(self, model_id):
+        raise NotImplementedError

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -17,7 +17,7 @@ class DummyClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_id=None, suggestion_id=None):
+    def infer(self, model_input, model_id="", suggestion_id=None):
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
         if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -27,7 +27,7 @@ class GrpcClient(ModelMeshClient):
         super().set_inference_url(inference_url=inference_url)
         self._inference_stub = self.get_inference_stub()
 
-    def infer(self, model_input, model_id=None, suggestion_id=None):
+    def infer(self, model_input, model_id="", suggestion_id=None):
         model_id = self.get_model_id(None, model_id)
         logger.debug(f"Input prompt: {model_input}")
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -17,7 +17,7 @@ class HttpClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_id=None, suggestion_id=None):
+    def infer(self, model_input, model_id="", suggestion_id=None):
         model_id = self.get_model_id(None, model_id)
         self._prediction_url = f"{self._inference_url}/predictions/{model_id}"
 

--- a/ansible_wisdom/ai/api/model_client/ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/ollama_client.py
@@ -16,7 +16,6 @@ class OllamaClient(BAMClient):
 
     def get_chat_model(self, model_id):
         return Ollama(
-            # base_url=self._prediction_url,
-            base_url="http://192.168.1.191:11434",
+            base_url=self._prediction_url,
             model=model_id,
         )

--- a/ansible_wisdom/ai/api/model_client/ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/ollama_client.py
@@ -1,0 +1,22 @@
+import logging
+
+from langchain_community.llms import Ollama
+
+from .bam_client import BAMClient
+
+logger = logging.getLogger(__name__)
+
+
+# NOTE Heavily inspired by bam_client.py and we should ultimately merge the
+# two drivers to create a generic one.
+class OllamaClient(BAMClient):
+    def __init__(self, inference_url):
+        super().__init__(inference_url=inference_url)
+        self._prediction_url = self._inference_url
+
+    def get_chat_model(self, model_id):
+        return Ollama(
+            # base_url=self._prediction_url,
+            base_url="http://192.168.1.191:11434",
+            model=model_id,
+        )

--- a/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
@@ -1,0 +1,127 @@
+import json
+from textwrap import dedent
+
+import responses
+from django.test import TestCase, override_settings
+from langchain_core.messages.base import BaseMessage
+from responses import matchers
+
+from ansible_wisdom.ai.api.model_client.bam_client import BAMClient, unwrap_answer
+
+
+class TestUnwrapAnswer(TestCase):
+    def setUp(self):
+        self.expectation = "ansible.builtin.debug:\n  msg: something went wrong"
+
+    def test_unwrap_markdown_answer(self):
+        answer = """
+        I'm a model and I'm saying stuff
+
+
+        ```yaml
+
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+
+        ```
+
+        Some more blabla
+        """
+        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+
+    def test_unwrap_just_task(self):
+        answer = """
+        ----
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+
+
+
+        """
+        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+
+    def test_unwrap_class_with_content_key(self):
+        _content = """
+        ----
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+        """
+
+        class MyMessage(BaseMessage):
+            pass
+
+        message = MyMessage(content=_content, type="whatever")
+        self.assertEqual(unwrap_answer(message), self.expectation)
+
+
+class TestBam(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.inference_url = "http://localhost"
+        self.prediction_url = f"{self.inference_url}/v2/text/chat?version=2024-01-10"
+        self.model_input = {
+            "instances": [
+                {
+                    "context": "",
+                    "prompt": "- name: hey siri, return a task that installs ffmpeg",
+                }
+            ]
+        }
+
+        self.expected_task_body = "ansible.builtin.debug:\n  msg: something went wrong"
+        self.expected_response = {
+            "predictions": [self.expected_task_body],
+            "model_id": "test",
+        }
+
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY="my_key")
+    @override_settings(ANSIBLE_AI_MODEL_NAME="test")
+    @responses.activate
+    def test_infer(self):
+        model = "test"
+        model_client = BAMClient(self.inference_url)
+        responses.post(
+            self.prediction_url,
+            match=[
+                matchers.header_matcher({"Content-Type": "application/json"}),
+                matchers.json_params_matcher(
+                    {
+                        "model_id": "test",
+                        "messages": [
+                            {
+                                "content": (
+                                    "You are an Ansible expert. Return a single task that "
+                                    "best completes the partial playbook. Return only the "
+                                    "task as YAML. Do not return multiple tasks. Do not explain "
+                                    "your response. Do not include the prompt in your response."
+                                ),
+                                "role": "system",
+                            },
+                            {
+                                "content": "- name: hey siri, return a task that installs ffmpeg\n",
+                                "role": "user",
+                            },
+                        ],
+                        "parameters": {
+                            "temperature": 0.1,
+                            "decoding_method": "greedy",
+                            "repetition_penalty": 1.05,
+                            "min_new_tokens": 1,
+                            "max_new_tokens": 2048,
+                        },
+                    },
+                    strict_match=False,
+                ),
+            ],
+            json={
+                "results": [
+                    {"generated_text": "ansible.builtin.debug:\n  msg: something went wrong"}
+                ],
+            },
+        )
+
+        response = model_client.infer(self.model_input, model_id=model)
+        self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
@@ -1,0 +1,36 @@
+import json
+from textwrap import indent
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from ansible_wisdom.ai.api.model_client.ollama_client import OllamaClient
+
+
+class TestOllama(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.model_input = {
+            "instances": [
+                {
+                    "context": "",
+                    "prompt": "- name: hey siri, return a task that installs ffmpeg",
+                }
+            ]
+        }
+
+        self.expected_task_body = "ansible.builtin.debug:\n  msg: something went wrong"
+        self.expected_response = {
+            "predictions": [self.expected_task_body],
+            "model_id": "test",
+        }
+
+    @patch("ansible_wisdom.ai.api.model_client.ollama_client.Ollama")
+    def test_infer(self, m_ollama):
+        def final(_):
+            return f"- name: Vache volante!\n{indent(self.expected_task_body, '  ')}"
+
+        m_ollama.return_value = final
+        model_client = OllamaClient("http://localhost")
+        response = model_client.infer(self.model_input, model_id="test")
+        self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -333,7 +333,7 @@ class WCAClient(BaseWCAClient):
             raise WcaKeyNotFound
 
         try:
-            secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
+            secret_manager = apps.get_app_config("ai").get_wca_secret_manager()  # type: ignore
             api_key = secret_manager.get_secret(organization_id, Suffixes.API_KEY)
             if api_key is not None:
                 return api_key["SecretString"]
@@ -366,7 +366,7 @@ class WCAClient(BaseWCAClient):
             return requested_model_id
 
         try:
-            secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
+            secret_manager = apps.get_app_config("ai").get_wca_secret_manager()  # type: ignore
             model_id = secret_manager.get_secret(organization_id, Suffixes.MODEL_ID)
             if model_id is not None:
                 return model_id["SecretString"]

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -131,9 +131,10 @@ class CompletionRequestSerializer(serializers.Serializer):
 
     def validate_model(self, value):
         user = self.context.get('request').user
+        # TODO(rg): handle this properly
         # While tech preview is available, custom models remain commercial-only
-        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.rh_user_has_seat is False:
-            raise serializers.ValidationError("user is not entitled to customized model")
+        #if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.rh_user_has_seat is False:
+        #    raise serializers.ValidationError("user is not entitled to customized model")
         return value
 
     def validate(self, data):

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -131,10 +131,8 @@ class CompletionRequestSerializer(serializers.Serializer):
 
     def validate_model(self, value):
         user = self.context.get('request').user
-        # TODO(rg): handle this properly
-        # While tech preview is available, custom models remain commercial-only
-        #if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.rh_user_has_seat is False:
-        #    raise serializers.ValidationError("user is not entitled to customized model")
+        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and user.rh_user_has_seat is False:
+            raise serializers.ValidationError("user is not entitled to customized model")
         return value
 
     def validate(self, data):

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -395,6 +395,39 @@ class AttributionRequestSerializer(serializers.Serializer):
     metadata = Metadata(required=False)
 
 
+class ExplanationRequestSerializer(serializers.Serializer):
+    class Meta:
+        fields = ['content', 'explanationId', 'ansibleExtensionVersion']
+
+    content = serializers.CharField(
+        required=True,
+        label="Playbook content",
+        help_text=("The playbook that needs to be explained."),
+    )
+    explanationId = serializers.UUIDField(
+        format='hex_verbose',
+        required=False,
+        label="Explanation ID",
+        help_text=(
+            "A UUID that identifies the particular explanation data is being requested for."
+        ),
+    )
+    metadata = Metadata(required=False)
+
+
+class ExplanationResponseSerializer(serializers.Serializer):
+    content = serializers.CharField()
+    format = serializers.CharField()
+    explanationId = serializers.UUIDField(
+        format='hex_verbose',
+        required=False,
+        label="Explanation ID",
+        help_text=(
+            "A UUID that identifies the particular explanation data is being requested for."
+        ),
+    )
+
+
 class ContentMatchRequestSerializer(serializers.Serializer):
     class Meta:
         fields = ['suggestions', 'suggestionId', 'model', 'ansibleExtensionVersion']

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -132,7 +132,7 @@ class MockedMeshClient(ModelMeshClient):
 
         self.response_data = response_data
 
-    def infer(self, data, model_id=None, suggestion_id=None):
+    def infer(self, data, model_id="", suggestion_id=None):
         if self.test_inference_match:
             self.test.assertEqual(data, self.expects)
         time.sleep(0.1)  # w/o this line test_rate_limit() fails...

--- a/ansible_wisdom/ai/api/urls.py
+++ b/ansible_wisdom/ai/api/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import Attributions, Completions, ContentMatches, Feedback
+from .views import Attributions, Completions, ContentMatches, Explanation, Feedback
 
 urlpatterns = [
-    path('completions/', Completions.as_view(), name='completions'),
-    path('feedback/', Feedback.as_view(), name='feedback'),
     path('attributions/', Attributions.as_view(), name='attributions'),
+    path('completions/', Completions.as_view(), name='completions'),
     path('contentmatches/', ContentMatches.as_view(), name='contentmatches'),
+    path('explanations/', Explanation.as_view(), name='explanations'),
+    path('feedback/', Feedback.as_view(), name='feedback'),
 ]

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -776,8 +776,6 @@ class Explanation(APIView):
         chain = chat_template | llm
 
         output = chain.invoke({"playbook": request.data["content"]})
-        output = output.content if hasattr(output, "content") else output
-
         answer = {"content": output, "format": "markdown"}
         if "explanationId" in request.data:
             answer["explanationId"] = request.data["explanationId"]

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 import time
 from http import HTTPStatus
 
@@ -7,6 +8,11 @@ from django.apps import apps
 from django.conf import settings
 from django_prometheus.conf import NAMESPACE
 from drf_spectacular.utils import OpenApiResponse, extend_schema
+from langchain_core.prompts.chat import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
 from prometheus_client import Histogram
 from rest_framework import serializers
 from rest_framework import status as rest_framework_status
@@ -67,6 +73,8 @@ from .serializers import (
     CompletionResponseSerializer,
     ContentMatchRequestSerializer,
     ContentMatchResponseSerializer,
+    ExplanationRequestSerializer,
+    ExplanationResponseSerializer,
     FeedbackRequestSerializer,
     InlineSuggestionFeedback,
     IssueFeedback,
@@ -701,3 +709,80 @@ class ContentMatches(GenericAPIView):
             "metadata": metadata,
         }
         send_segment_event(event, "contentmatch", user)
+
+
+class Explanation(APIView):
+    """
+    Returns a text that explains a playbook.
+    """
+
+    from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+    from rest_framework import permissions
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+        IsAuthenticatedOrTokenHasScope,
+        AcceptedTermsPermission,
+        BlockUserWithoutSeat,
+        BlockUserWithoutSeatAndWCAReadyOrg,
+        BlockUserWithSeatButWCANotReady,
+    ]
+    required_scopes = ['read', 'write']
+
+    throttle_cache_key_suffix = '_explanation'
+
+    @extend_schema(
+        request=ExplanationRequestSerializer,
+        responses={
+            200: ExplanationResponseSerializer,
+            204: OpenApiResponse(description='Empty response'),
+            400: OpenApiResponse(description='Bad Request'),
+            401: OpenApiResponse(description='Unauthorized'),
+            429: OpenApiResponse(description='Request was throttled'),
+            503: OpenApiResponse(description='Service Unavailable'),
+        },
+        summary="Inline code suggestions",
+    )
+    def post(self, request) -> Response:
+        SYSTEM_MESSAGE_TEMPLATE = """
+        You're an Ansible expert.
+        You only answer with text paragraphs.
+        Write one paragraph per Ansible task.
+        Write a title before every paragraph.
+        Do not return any YAML or Ansible in the output.
+        Please format the output with Markdown.
+        Give a lot of details regarding the parameters of each Ansible plugin.
+        """
+
+        HUMAN_MESSAGE_TEMPLATE = """Please explain the following Ansible playbook:
+
+        {playbook}"
+        """
+
+        model_client = apps.get_app_config("ai").model_mesh_client
+        llm = model_client.get_chat_model(settings.ANSIBLE_AI_MODEL_NAME)
+
+        chat_template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(
+                    textwrap.dedent(SYSTEM_MESSAGE_TEMPLATE), additional_kwargs={"role": "system"}
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    textwrap.dedent(HUMAN_MESSAGE_TEMPLATE), additional_kwargs={"role": "user"}
+                ),
+            ]
+        )
+
+        chain = chat_template | llm
+
+        output = chain.invoke({"playbook": request.data["content"]})
+        output = output.content if hasattr(output, "content") else output
+
+        answer = {"content": output, "format": "markdown"}
+        if "explanationId" in request.data:
+            answer["explanationId"] = request.data["explanationId"]
+
+        return Response(
+            answer,
+            status=rest_framework_status.HTTP_200_OK,
+        )

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 
 from ansible_risk_insight.scanner import Config
 from django.apps import AppConfig
@@ -135,7 +136,7 @@ class AiConfig(AppConfig):
 
         return self._seat_checker
 
-    def get_wca_secret_manager(self):
+    def get_wca_secret_manager(self) -> Union[AWSSecretManager, DummySecretManager]:
         backends = {
             "aws_sm": AWSSecretManager,
             "dummy": DummySecretManager,
@@ -144,10 +145,9 @@ class AiConfig(AppConfig):
         try:
             expected_backend = backends[settings.WCA_SECRET_BACKEND_TYPE]
         except KeyError:
-            logger.error(
+            logger.exception(
                 "Unexpected WCA_SECRET_BACKEND_TYPE value: '%s'", settings.WCA_SECRET_BACKEND_TYPE
             )
-            return None
 
         if self._wca_secret_manager is UNINITIALIZED:
             self._wca_secret_manager = expected_backend(

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -66,11 +66,12 @@ class AiConfig(AppConfig):
             self.model_mesh_client = BAMClient(
                 inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
             )
-        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE in ["dummy", "mock"]:
-            if settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock":
-                logger.error(
-                    'ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock" is deprecated, use "dummy" instead'
-                )
+        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "ollama":
+            from .api.model_client.ollama_client import OllamaClient
+
+            self.model_mesh_client = OllamaClient(
+                inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
+            )
         else:
             raise ValueError(
                 f"Invalid model mesh client type: {settings.ANSIBLE_AI_MODEL_MESH_API_TYPE}"

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -60,6 +60,17 @@ class AiConfig(AppConfig):
             self.model_mesh_client = DummyClient(
                 inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
             )
+        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "bam":
+            from .api.model_client.bam_client import BAMClient
+
+            self.model_mesh_client = BAMClient(
+                inference_url=settings.ANSIBLE_AI_MODEL_MESH_INFERENCE_URL,
+            )
+        elif settings.ANSIBLE_AI_MODEL_MESH_API_TYPE in ["dummy", "mock"]:
+            if settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock":
+                logger.error(
+                    'ANSIBLE_AI_MODEL_MESH_API_TYPE == "mock" is deprecated, use "dummy" instead'
+                )
         else:
             raise ValueError(
                 f"Invalid model mesh client type: {settings.ANSIBLE_AI_MODEL_MESH_API_TYPE}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ skip-string-normalization = true
 profile = "black"
 
 [tool.pyright]
-include = ["ansible_wisdom/ai/api/aws/wca_secret_manager.py", "ansible_wisdom/users/authz_checker.py", "ansible_wisdom/ai/api/model_client/wca_client.py"]
+include = ["ansible_wisdom/ai/api/aws/wca_secret_manager.py", "ansible_wisdom/users/authz_checker.py", "ansible_wisdom/ai/api/model_client/wca_client.py", "ansible_wisdom/ai/api/model_client/bam_client.py", "ansible_wisdom/ai/api/model_client/ollama_client.py"]
 exclude = ["**/test_*.py", "ansible_wisdom/*/migrations/*.py"]
 
 reportMissingImports = true

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -8,6 +8,8 @@ aiohttp==3.9.3
     # via
     #   datasets
     #   fsspec
+    #   langchain
+    #   langchain-community
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.6.0
@@ -39,7 +41,9 @@ asgiref==3.7.2
 asttokens==2.4.1
     # via stack-data
 async-timeout==4.0.3
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   langchain
 attrs==23.2.0
     # via
     #   aiohttp
@@ -81,6 +85,10 @@ cryptography==42.0.4
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
+dataclasses-json==0.6.4
+    # via
+    #   langchain
+    #   langchain-community
 datasets==2.18.0
     # via -r requirements.in
 decorator==5.1.1
@@ -161,6 +169,8 @@ fsspec[http]==2023.10.0
     #   huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.21.3
@@ -196,7 +206,9 @@ joblib==1.3.2
     #   ansible-risk-insight
     #   scikit-learn
 jsonpatch==1.33
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-core
 jsonpickle==3.0.3
     # via ansible-risk-insight
 jsonpointer==2.4
@@ -212,10 +224,22 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain-core==0.1.30
+langchain==0.1.13
     # via -r requirements.in
+langchain-community==0.0.29
+    # via langchain
+langchain-core==0.1.33
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.0.1
+    # via langchain
 langsmith==0.1.22
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 launchdarkly-server-sdk==8.1.1
     # via -r requirements.in
 levenshtein==0.25.0
@@ -226,6 +250,8 @@ markuppy==1.14
     # via tablib
 markupsafe==2.1.5
     # via jinja2
+marshmallow==3.21.1
+    # via dataclasses-json
 matplotlib-inline==0.1.6
     # via ipython
 mdurl==0.1.2
@@ -241,12 +267,16 @@ multidict==6.0.5
 multiprocess==0.70.15
     # via datasets
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   black
+    #   typing-inspect
 networkx==3.2.1
     # via torch
 numpy==1.26.4
     # via
     #   datasets
+    #   langchain
+    #   langchain-community
     #   pandas
     #   pyarrow
     #   scikit-learn
@@ -277,6 +307,7 @@ packaging==23.2
     #   django-allow-cidr
     #   huggingface-hub
     #   langchain-core
+    #   marshmallow
     #   transformers
 pandas==2.2.1
     # via datasets
@@ -322,7 +353,11 @@ pyasn1==0.5.1
 pycparser==2.21
     # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   langchain
+    #   langchain-core
+    #   langsmith
 pydantic-core==2.16.3
     # via pydantic
 pygit2==1.14.1
@@ -362,6 +397,8 @@ pyyaml==6.0
     #   datasets
     #   drf-spectacular
     #   huggingface-hub
+    #   langchain
+    #   langchain-community
     #   langchain-core
     #   tablib
     #   transformers
@@ -383,6 +420,8 @@ requests==2.31.0
     #   django-oauth-toolkit
     #   fsspec
     #   huggingface-hub
+    #   langchain
+    #   langchain-community
     #   langchain-core
     #   langsmith
     #   opensearch-py
@@ -443,6 +482,10 @@ social-auth-core[openidconnect]==4.4.2
     # via
     #   -r requirements.in
     #   social-auth-app-django
+sqlalchemy==2.0.28
+    # via
+    #   langchain
+    #   langchain-community
 sqlparse==0.4.4
     # via django
 stack-data==0.6.3
@@ -458,7 +501,10 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0
 tabulate==0.9.0
     # via ansible-risk-insight
 tenacity==8.2.3
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 threadpoolctl==3.3.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -499,7 +545,11 @@ typing-extensions==4.10.0
     #   psycopg
     #   pydantic
     #   pydantic-core
+    #   sqlalchemy
     #   torch
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 tzdata==2024.1
     # via pandas
 uritemplate==4.1.1

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -30,6 +30,8 @@ ansible-lint==6.22.1
     # via -r requirements.in
 ansible-risk-insight==0.2.4
     # via -r requirements.in
+anyio==4.3.0
+    # via langchain-core
 argparse==1.4.0
     # via uwsgi-readiness-check
 asgiref==3.7.2
@@ -135,6 +137,8 @@ ecdsa==0.18.0
     # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
+exceptiongroup==1.2.0
+    # via anyio
 executing==2.0.1
     # via stack-data
 expiringdict==1.2.2
@@ -167,6 +171,7 @@ huggingface-hub==0.21.3
     #   transformers
 idna==3.6
     # via
+    #   anyio
     #   requests
     #   yarl
 importlib-resources==5.0.7
@@ -190,8 +195,12 @@ joblib==1.3.2
     # via
     #   ansible-risk-insight
     #   scikit-learn
+jsonpatch==1.33
+    # via langchain-core
 jsonpickle==3.0.3
     # via ansible-risk-insight
+jsonpointer==2.4
+    # via jsonpatch
 jsonschema==4.21.1
     # via
     #   ansible-compat
@@ -203,6 +212,10 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
+langchain-core==0.1.30
+    # via -r requirements.in
+langsmith==0.1.22
+    # via langchain-core
 launchdarkly-server-sdk==8.1.1
     # via -r requirements.in
 levenshtein==0.25.0
@@ -252,6 +265,8 @@ openpyxl==3.1.2
     # via tablib
 opensearch-py==2.1.1
     # via -r requirements.in
+orjson==3.9.15
+    # via langsmith
 packaging==23.2
     # via
     #   ansible-compat
@@ -261,6 +276,7 @@ packaging==23.2
     #   datasets
     #   django-allow-cidr
     #   huggingface-hub
+    #   langchain-core
     #   transformers
 pandas==2.2.1
     # via datasets
@@ -346,6 +362,7 @@ pyyaml==6.0
     #   datasets
     #   drf-spectacular
     #   huggingface-hub
+    #   langchain-core
     #   tablib
     #   transformers
     #   yamllint
@@ -366,6 +383,8 @@ requests==2.31.0
     #   django-oauth-toolkit
     #   fsspec
     #   huggingface-hub
+    #   langchain-core
+    #   langsmith
     #   opensearch-py
     #   requests-oauthlib
     #   segment-analytics-python
@@ -416,6 +435,8 @@ smmap==5.0.1
     # via
     #   ansible-risk-insight
     #   gitdb
+sniffio==1.3.1
+    # via anyio
 social-auth-app-django==5.4.0
     # via -r requirements.in
 social-auth-core[openidconnect]==4.4.2
@@ -436,6 +457,8 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
 tabulate==0.9.0
     # via ansible-risk-insight
+tenacity==8.2.3
+    # via langchain-core
 threadpoolctl==3.3.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -467,6 +490,7 @@ transformers==4.36.0
 typing-extensions==4.10.0
     # via
     #   ansible-compat
+    #   anyio
     #   asgiref
     #   black
     #   django-test-migrations

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -8,6 +8,8 @@ aiohttp==3.9.3
     # via
     #   datasets
     #   fsspec
+    #   langchain
+    #   langchain-community
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.6.0
@@ -39,7 +41,9 @@ asgiref==3.7.2
 asttokens==2.4.1
     # via stack-data
 async-timeout==4.0.3
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   langchain
 attrs==23.2.0
     # via
     #   aiohttp
@@ -81,6 +85,10 @@ cryptography==42.0.4
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
+dataclasses-json==0.6.4
+    # via
+    #   langchain
+    #   langchain-community
 datasets==2.18.0
     # via -r requirements.in
 decorator==5.1.1
@@ -161,6 +169,8 @@ fsspec[http]==2023.10.0
     #   huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.21.3
@@ -196,7 +206,9 @@ joblib==1.3.2
     #   ansible-risk-insight
     #   scikit-learn
 jsonpatch==1.33
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-core
 jsonpickle==3.0.3
     # via ansible-risk-insight
 jsonpointer==2.4
@@ -212,10 +224,22 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain-core==0.1.30
+langchain==0.1.13
     # via -r requirements.in
+langchain-community==0.0.29
+    # via langchain
+langchain-core==0.1.33
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.0.1
+    # via langchain
 langsmith==0.1.22
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 launchdarkly-server-sdk==8.1.1
     # via -r requirements.in
 levenshtein==0.25.0
@@ -226,6 +250,8 @@ markuppy==1.14
     # via tablib
 markupsafe==2.1.5
     # via jinja2
+marshmallow==3.21.1
+    # via dataclasses-json
 matplotlib-inline==0.1.6
     # via ipython
 mdurl==0.1.2
@@ -241,12 +267,16 @@ multidict==6.0.5
 multiprocess==0.70.15
     # via datasets
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   black
+    #   typing-inspect
 networkx==3.2.1
     # via torch
 numpy==1.26.4
     # via
     #   datasets
+    #   langchain
+    #   langchain-community
     #   pandas
     #   pyarrow
     #   scikit-learn
@@ -277,6 +307,7 @@ packaging==23.2
     #   django-allow-cidr
     #   huggingface-hub
     #   langchain-core
+    #   marshmallow
     #   transformers
 pandas==2.2.1
     # via datasets
@@ -322,7 +353,11 @@ pyasn1==0.5.1
 pycparser==2.21
     # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   langchain
+    #   langchain-core
+    #   langsmith
 pydantic-core==2.16.3
     # via pydantic
 pygit2==1.14.1
@@ -362,6 +397,8 @@ pyyaml==6.0
     #   datasets
     #   drf-spectacular
     #   huggingface-hub
+    #   langchain
+    #   langchain-community
     #   langchain-core
     #   tablib
     #   transformers
@@ -383,6 +420,8 @@ requests==2.31.0
     #   django-oauth-toolkit
     #   fsspec
     #   huggingface-hub
+    #   langchain
+    #   langchain-community
     #   langchain-core
     #   langsmith
     #   opensearch-py
@@ -443,6 +482,10 @@ social-auth-core[openidconnect]==4.4.2
     # via
     #   -r requirements.in
     #   social-auth-app-django
+sqlalchemy==2.0.28
+    # via
+    #   langchain
+    #   langchain-community
 sqlparse==0.4.4
     # via django
 stack-data==0.6.3
@@ -458,7 +501,10 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0
 tabulate==0.9.0
     # via ansible-risk-insight
 tenacity==8.2.3
-    # via langchain-core
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 threadpoolctl==3.3.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -499,7 +545,11 @@ typing-extensions==4.10.0
     #   psycopg
     #   pydantic
     #   pydantic-core
+    #   sqlalchemy
     #   torch
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 tzdata==2024.1
     # via pandas
 uritemplate==4.1.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -30,6 +30,8 @@ ansible-lint==6.22.1
     # via -r requirements.in
 ansible-risk-insight==0.2.4
     # via -r requirements.in
+anyio==4.3.0
+    # via langchain-core
 argparse==1.4.0
     # via uwsgi-readiness-check
 asgiref==3.7.2
@@ -135,6 +137,8 @@ ecdsa==0.18.0
     # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
+exceptiongroup==1.2.0
+    # via anyio
 executing==2.0.1
     # via stack-data
 expiringdict==1.2.2
@@ -167,6 +171,7 @@ huggingface-hub==0.21.3
     #   transformers
 idna==3.6
     # via
+    #   anyio
     #   requests
     #   yarl
 importlib-resources==5.0.7
@@ -190,8 +195,12 @@ joblib==1.3.2
     # via
     #   ansible-risk-insight
     #   scikit-learn
+jsonpatch==1.33
+    # via langchain-core
 jsonpickle==3.0.3
     # via ansible-risk-insight
+jsonpointer==2.4
+    # via jsonpatch
 jsonschema==4.21.1
     # via
     #   ansible-compat
@@ -203,6 +212,10 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
+langchain-core==0.1.30
+    # via -r requirements.in
+langsmith==0.1.22
+    # via langchain-core
 launchdarkly-server-sdk==8.1.1
     # via -r requirements.in
 levenshtein==0.25.0
@@ -252,6 +265,8 @@ openpyxl==3.1.2
     # via tablib
 opensearch-py==2.1.1
     # via -r requirements.in
+orjson==3.9.15
+    # via langsmith
 packaging==23.2
     # via
     #   ansible-compat
@@ -261,6 +276,7 @@ packaging==23.2
     #   datasets
     #   django-allow-cidr
     #   huggingface-hub
+    #   langchain-core
     #   transformers
 pandas==2.2.1
     # via datasets
@@ -346,6 +362,7 @@ pyyaml==6.0
     #   datasets
     #   drf-spectacular
     #   huggingface-hub
+    #   langchain-core
     #   tablib
     #   transformers
     #   yamllint
@@ -366,6 +383,8 @@ requests==2.31.0
     #   django-oauth-toolkit
     #   fsspec
     #   huggingface-hub
+    #   langchain-core
+    #   langsmith
     #   opensearch-py
     #   requests-oauthlib
     #   segment-analytics-python
@@ -416,6 +435,8 @@ smmap==5.0.1
     # via
     #   ansible-risk-insight
     #   gitdb
+sniffio==1.3.1
+    # via anyio
 social-auth-app-django==5.4.0
     # via -r requirements.in
 social-auth-core[openidconnect]==4.4.2
@@ -436,6 +457,8 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0
     # via django-import-export
 tabulate==0.9.0
     # via ansible-risk-insight
+tenacity==8.2.3
+    # via langchain-core
 threadpoolctl==3.3.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -467,6 +490,7 @@ transformers==4.36.0
 typing-extensions==4.10.0
     # via
     #   ansible-compat
+    #   anyio
     #   asgiref
     #   black
     #   django-test-migrations

--- a/requirements.in
+++ b/requirements.in
@@ -37,6 +37,7 @@ jwcrypto==1.5.6
 # remove this once ansible-core is updated to properly
 # pull a version of jwcrypto >= 3.1.3.
 jinja2==3.1.3
+langchain_core==0.1.30
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
 protobuf==4.22.1

--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ jwcrypto==1.5.6
 # remove this once ansible-core is updated to properly
 # pull a version of jwcrypto >= 3.1.3.
 jinja2==3.1.3
-langchain_core==0.1.30
+langchain==0.1.13
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
 protobuf==4.22.1

--- a/tools/openapi-schema/ansible-wisdom-service.yaml
+++ b/tools/openapi-schema/ansible-wisdom-service.yaml
@@ -148,6 +148,47 @@ paths:
           description: Request was throttled
         '503':
           description: Service Unavailable
+  /api/v0/ai/explanations/:
+    post:
+      operationId: ai_explanations_create
+      description: Returns a text that explains a playbook.
+      summary: Inline code suggestions
+      tags:
+      - ai
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExplanationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ExplanationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ExplanationRequest'
+        required: true
+      security:
+      - oauth2:
+        - read
+        - write
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExplanationResponse'
+          description: ''
+        '204':
+          description: Empty response
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '429':
+          description: Request was throttled
+        '503':
+          description: Service Unavailable
   /api/v0/ai/feedback/:
     post:
       operationId: ai_feedback_create
@@ -707,6 +748,39 @@ components:
             $ref: '#/components/schemas/ContentMatchList'
       required:
       - contentmatches
+    ExplanationRequest:
+      type: object
+      properties:
+        content:
+          type: string
+          title: Playbook content
+          description: The playbook that needs to be explained.
+        explanationId:
+          type: string
+          format: uuid
+          title: Explanation ID
+          description: A UUID that identifies the particular explanation data is being
+            requested for.
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+      required:
+      - content
+    ExplanationResponse:
+      type: object
+      properties:
+        content:
+          type: string
+        format:
+          type: string
+        explanationId:
+          type: string
+          format: uuid
+          title: Explanation ID
+          description: A UUID that identifies the particular explanation data is being
+            requested for.
+      required:
+      - content
+      - format
     FeedbackRequest:
       type: object
       properties:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-20955>

Based on @gebhardtr's https://github.com/ansible/ansible-wisdom-service/pull/862


## Description

In addition to the (rebased) bam driver, this branch adds:

- a ollama model drive
- a hande point for the playbook explanation

## Testing

The feature can be used with either BAM or Ollama:

### BAM

```
ANSIBLE_AI_MODEL_MESH_INFERENCE_URL="http://192.168.1.191:11434"  <--- adjust to match the location of your Ollama server
ANSIBLE_AI_MODEL_MESH_API_TYPE="ollama"
ANSIBLE_AI_MODEL_NAME="mistral"  <--- The code was tested with Mistral but you can use a different model like llama2
```


### Ollama

```
ANSIBLE_AI_MODEL_MESH_INFERENCE_URL="https://blabla.ibm.com"   <--- adjust to match your API end-point
ANSIBLE_AI_MODEL_MESH_API_KEY="blabla"  <--- your API key
ANSIBLE_AI_MODEL_MESH_API_TYPE="bam"
ANSIBLE_AI_MODEL_NAME="ibm/granite-20b-code-instruct-v2"
```

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own but won't do anything. The user of model with the feature and an update of the VSCode extension is still required.