### PR TITLE
update webpack to fix security issue

### DIFF
--- a/ansible_wisdom_console_react/package-lock.json
+++ b/ansible_wisdom_console_react/package-lock.json
@@ -18452,9 +18452,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "devOptional": true,
       "dependencies": {
         "colorette": "^2.0.10",


### PR DESCRIPTION
>webpack-dev-middleware  <=5.3.3
Severity: high
Path traversal in webpack-dev-middleware - [https://github.com/advisories/GHSA-wr3j-pwj9-hqq](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6)