### PR TITLE
Admin Dashboard: [Feature flag] Drop -M-A-G-I-C- Organizations 

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -350,11 +350,7 @@ class FeedbackRequestSerializer(serializers.Serializer):
 
         if user.rh_user_has_seat is False:
             return value
-        if (
-            user.organization
-            and user.organization.is_schema_2_telemetry_enabled
-            and user.organization.telemetry_opt_out is False
-        ):
+        if user.organization and user.organization.telemetry_opt_out is False:
             return value
         else:
             raise serializers.ValidationError("invalid feedback type for user")

--- a/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
@@ -58,9 +58,6 @@ class TelemetrySettingsView(RetrieveAPIView, CreateAPIView):
             if not organization:
                 return Response(status=HTTP_400_BAD_REQUEST)
 
-            if not organization.is_schema_2_telemetry_enabled:
-                raise ServiceUnavailable()
-
             return Response(status=HTTP_200_OK, data={'optOut': organization.telemetry_opt_out})
 
         except ServiceUnavailable:
@@ -106,9 +103,6 @@ class TelemetrySettingsView(RetrieveAPIView, CreateAPIView):
             organization = request._request.user.organization
             if not organization:
                 return Response(status=HTTP_400_BAD_REQUEST)
-
-            if not organization.is_schema_2_telemetry_enabled:
-                raise ServiceUnavailable()
 
             # Extract Telemetry settings from request
             telemetry_settings_serializer = TelemetrySettingsRequestSerializer(data=request.data)

--- a/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
@@ -42,15 +42,6 @@ class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
         for permission in required_permissions:
             self.assertTrue(permission in view.permission_classes)
 
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_get_settings_when_feature_disabled(self, LDClient, *args):
-        LDClient.return_value.variation.return_value = False
-        self.user.organization = Organization.objects.get_or_create(id=123)[0]
-        self.client.force_authenticate(user=self.user)
-        r = self.client.get(reverse('telemetry_settings'))
-        self.assertEqual(r.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
-
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_get_settings_without_org_id(self, *args):
         self.client.force_authenticate(user=self.user)
@@ -94,15 +85,6 @@ class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
         # self.client.force_authenticate(user=self.user)
         r = self.client.post(reverse('telemetry_settings'))
         self.assertEqual(r.status_code, HTTPStatus.UNAUTHORIZED)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_set_settings_when_feature_disabled(self, LDClient, *args):
-        LDClient.return_value.variation.return_value = False
-        self.user.organization = Organization.objects.get_or_create(id=123)[0]
-        self.client.force_authenticate(user=self.user)
-        r = self.client.get(reverse('telemetry_settings'))
-        self.assertEqual(r.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
 
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_set_settings_without_org_id(self, *args):

--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -188,22 +188,6 @@ class FeedbackRequestSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_commercial_user_not_telemetry_enabled_raises_exception_on_inlineSuggestion(self):
-        org = Mock(telemetry_opt_out=False)
-        user = Mock(rh_user_has_seat=True, organization=org)
-        request = Mock(user=user)
-        serializer = FeedbackRequestSerializer(
-            context={'request': request},
-            data={
-                "inlineSuggestion": {
-                    "latency": 1000,
-                    "userActionTime": 5155,
-                    "action": "0",
-                    "suggestionId": "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
-                }
-            },
-        )
-
         # inlineSuggestion feedback raises exception when seat and not telemetry enabled
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -189,7 +189,7 @@ class FeedbackRequestSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
 
     def test_commercial_user_not_telemetry_enabled_raises_exception_on_inlineSuggestion(self):
-        org = Mock(telemetry_opt_out=False, is_schema_2_telemetry_enabled=False)
+        org = Mock(telemetry_opt_out=False)
         user = Mock(rh_user_has_seat=True, organization=org)
         request = Mock(user=user)
         serializer = FeedbackRequestSerializer(
@@ -209,7 +209,7 @@ class FeedbackRequestSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
 
     def test_invalid_ansible_extension_version_on_inline_suggestion(self):
-        org = Mock(telemetry_opt_out=False, is_schema_2_telemetry_enabled=True)
+        org = Mock(telemetry_opt_out=False)
         user = Mock(rh_user_has_seat=True, organization=org)
         request = Mock(user=user)
         serializer = FeedbackRequestSerializer(
@@ -232,7 +232,7 @@ class FeedbackRequestSerializerTest(TestCase):
             serializer.is_valid(raise_exception=True)
 
     def test_commercial_user_not_opted_out_passes_on_inlineSuggestion(self):
-        org = Mock(telemetry_opt_out=False, is_schema_2_telemetry_enabled=True)
+        org = Mock(telemetry_opt_out=False)
         user = Mock(rh_user_has_seat=True, organization=org)
         request = Mock(user=user)
         serializer = FeedbackRequestSerializer(

--- a/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
@@ -60,10 +60,6 @@ def send_segment_analytics_event(
         logger.info("Analytics telemetry not active, because of no organization assigned for user.")
         return
 
-    if not organization.is_schema_2_telemetry_enabled:
-        logger.info(f"Analytics telemetry not active for organization '{organization.id}'.")
-        return
-
     if organization.telemetry_opt_out:
         logger.info(f"Organization '{organization.id}' has opted out of Analytics telemetry.")
         return

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -17,8 +17,6 @@ logger = logging.getLogger(__name__)
 class WisdomFlags(str, Enum):
     # model name selection
     MODEL_NAME = "model_name"
-    # Schema 2 Telemetry is enabled for an Organization
-    SCHEMA_2_TELEMETRY_ORG_ENABLED = "schema_2_telemetry_org_enabled"
     # For some organizations we can bypass the subscription check
     BYPASS_AAP_SUBSCRIPTION_CHECK = "special_wca_access_orgs"
 

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -3,12 +3,10 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.test import override_settings
-from ldclient import Context
 from ldclient.config import Config
 
 import ansible_wisdom.ai.feature_flags as feature_flags
 from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.ai.feature_flags import WisdomFlags
 
 
 class TestFeatureFlags(WisdomServiceAPITestCaseBase):
@@ -58,35 +56,3 @@ class TestFeatureFlags(WisdomServiceAPITestCaseBase):
         value = ff.get('model_name', self.user, 'default_value')
         self.assertEqual(ff.client.get_sdk_key(), 'sdk-key-123abc')
         self.assertEqual(value, 'dev_model')
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_feature_flags_check_flag_disabled(self, LDClient):
-        LDClient.return_value.variation.return_value = False
-
-        ff = feature_flags.FeatureFlags()
-        self.assertFalse(
-            ff.check_flag(
-                WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, {'kind': 'organization', 'org_id': 123}
-            )
-        )
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_feature_flags_check_flag_enabled(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-
-        ff = feature_flags.FeatureFlags()
-        self.assertTrue(
-            ff.check_flag(
-                WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED, {'kind': 'organization', 'key': '123'}
-            )
-        )
-
-        args = LDClient.return_value.variation.call_args_list[0]
-        name: str = args[0][0]
-        context: Context = args[0][1]
-        self.assertEqual(name, WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED)
-        self.assertEqual(context.kind, 'organization')
-        self.assertEqual(context.key, '123')
-        self.assertFalse(args[0][2])

--- a/ansible_wisdom/main/templates/console/console.html
+++ b/ansible_wisdom/main/templates/console/console.html
@@ -17,8 +17,6 @@
     <!-- It is safe to pass the value embedded in the host DOM -->
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
-    <!-- Flag whether Telemetry settings is supported -->
-    <div id="telemetry_schema_2_enabled" hidden>{{telemetry_schema_2_enabled}}</div>
     <!-- Admin Dashboard URL -->
     <div id="telemetry_schema_2_admin_dashboard_url" hidden>{{telemetry_schema_2_admin_dashboard_url}}</div>
 {% endblock content %}

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -86,7 +86,6 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         response = self.client.get(reverse('console'))
         self.assertIsInstance(response.context_data, dict)
         context = response.context_data
-        # The default setting for tests is True
         self.assertEqual(
             context['telemetry_schema_2_admin_dashboard_url'],
             'https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard',

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -79,7 +79,7 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    def test_extra_data_telemetry_feature_enabled(self, LDClient, *args):
+    def test_extra_data_telemetry_feature(self, LDClient, *args):
         LDClient.return_value.variation.return_value = True
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         self.client.force_authenticate(user=self.user)
@@ -87,22 +87,7 @@ class TestConsoleView(WisdomServiceAPITestCaseBase):
         self.assertIsInstance(response.context_data, dict)
         context = response.context_data
         # The default setting for tests is True
-        self.assertTrue(context['telemetry_schema_2_enabled'])
         self.assertEqual(
             context['telemetry_schema_2_admin_dashboard_url'],
             'https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard',
         )
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_extra_data_telemetry__feature_disabled(self, LDClient, *args):
-        LDClient.return_value.variation.return_value = False
-        self.user.organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[
-            0
-        ]
-        self.client.force_authenticate(user=self.user)
-        response = self.client.get(reverse('console'))
-        self.assertIsInstance(response.context_data, dict)
-        context = response.context_data
-        self.assertFalse(context['telemetry_schema_2_enabled'])
-        self.assertIsNone(context.get('telemetry_schema_2_admin_dashboard_url'))

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -82,12 +82,8 @@ class ConsoleView(ProtectedTemplateView):
             context["rh_org_has_subscription"] = user.rh_org_has_subscription
             organization = user.organization
             if organization:
-                is_schema_2_telemetry_enabled = organization.is_schema_2_telemetry_enabled
-                context["telemetry_schema_2_enabled"] = is_schema_2_telemetry_enabled
-
-                if is_schema_2_telemetry_enabled:
-                    context["telemetry_schema_2_admin_dashboard_url"] = (
-                        settings.TELEMETRY_ADMIN_DASHBOARD_URL
-                    )
+                context["telemetry_schema_2_admin_dashboard_url"] = (
+                    settings.TELEMETRY_ADMIN_DASHBOARD_URL
+                )
 
         return context

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -12,15 +12,6 @@ class Organization(models.Model):
     telemetry_opt_out = models.BooleanField(default=False)
 
     @cached_property
-    def is_schema_2_telemetry_enabled(self) -> bool:
-        # Avoid circular dependency issue with lazy import
-        from ansible_wisdom.ai.feature_flags import WisdomFlags
-
-        return self.__make_organization_request_to_launchdarkly(
-            WisdomFlags.SCHEMA_2_TELEMETRY_ORG_ENABLED
-        )
-
-    @cached_property
     def is_subscription_check_should_be_bypassed(self) -> bool:
         # Avoid circular dependency issue with lazy import
         from ansible_wisdom.ai.feature_flags import WisdomFlags

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -1,5 +1,8 @@
-from django.test import TestCase
+from unittest.mock import patch
 
+from django.test import TestCase, override_settings
+
+import ansible_wisdom.ai.feature_flags as feature_flags
 from ansible_wisdom.organizations.models import Organization
 
 
@@ -11,3 +14,45 @@ class TestOrganization(TestCase):
     def test_org_with_telemetry_schema_2_opted_out(self):
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
         self.assertTrue(organization.telemetry_opt_out)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_override(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertTrue(organization.telemetry_opt_out)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = False
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
+        self.assertTrue(organization.telemetry_opt_out)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_override(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.telemetry_opt_out)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = False
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.telemetry_opt_out)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_unlimited_access_allowed_with_feature_flag_override(self, LDClient):
+        LDClient.return_value.variation.return_value = True
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertTrue(organization.is_subscription_check_should_be_bypassed)
+
+    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
+    @patch.object(feature_flags, 'LDClient')
+    def test_org_with_no_unlimited_access_allowed_with_feature_flag_no_override(self, LDClient):
+        LDClient.return_value.variation.return_value = False
+        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
+        self.assertFalse(organization.is_subscription_check_should_be_bypassed)

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
+from django.test import TestCase
 
-from django.test import TestCase, override_settings
-
-import ansible_wisdom.ai.feature_flags as feature_flags
 from ansible_wisdom.organizations.models import Organization
 
 
@@ -10,55 +7,7 @@ class TestOrganization(TestCase):
     def test_org_with_telemetry_schema_2_opted_in(self):
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
         self.assertFalse(organization.telemetry_opt_out)
-        self.assertFalse(organization.is_schema_2_telemetry_enabled)
 
     def test_org_with_telemetry_schema_2_opted_out(self):
         organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
         self.assertTrue(organization.telemetry_opt_out)
-        self.assertFalse(organization.is_schema_2_telemetry_enabled)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_override(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
-        self.assertTrue(organization.telemetry_opt_out)
-        self.assertTrue(organization.is_schema_2_telemetry_enabled)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_opted_in_with_feature_flag_no_override(self, LDClient):
-        LDClient.return_value.variation.return_value = False
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=True)[0]
-        self.assertTrue(organization.telemetry_opt_out)
-        self.assertFalse(organization.is_schema_2_telemetry_enabled)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_override(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.telemetry_opt_out)
-        self.assertTrue(organization.is_schema_2_telemetry_enabled)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_telemetry_schema_2_opted_out_with_feature_flag_no_override(self, LDClient):
-        LDClient.return_value.variation.return_value = False
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.telemetry_opt_out)
-        self.assertFalse(organization.is_schema_2_telemetry_enabled)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_unlimited_access_allowed_with_feature_flag_override(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertTrue(organization.is_subscription_check_should_be_bypassed)
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_org_with_no_unlimited_access_allowed_with_feature_flag_no_override(self, LDClient):
-        LDClient.return_value.variation.return_value = False
-        organization = Organization.objects.get_or_create(id=123, telemetry_opt_out=False)[0]
-        self.assertFalse(organization.is_subscription_check_should_be_bypassed)

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -625,51 +625,6 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.assertTrue(r.data.get('org_telemetry_opt_out'))
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_rhsso_user_with_telemetry_feature_disabled(self, LDClient):
-        LDClient.return_value.variation.return_value = False
-        user = create_user(
-            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
-            social_auth_extra_data={"login": "sso_username"},
-            external_username="sso_username",
-            org_opt_out=True,
-        )
-        self.client.force_authenticate(user=user)
-        r = self.client.get(reverse('me'))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertIsNone(r.data.get('org_telemetry_opt_out'))
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_rhsso_user_with_telemetry_feature_enabled_opted_out(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-        user = create_user(
-            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
-            social_auth_extra_data={"login": "sso_username"},
-            external_username="sso_username",
-            org_opt_out=True,
-        )
-        self.client.force_authenticate(user=user)
-        r = self.client.get(reverse('me'))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertTrue(r.data.get('org_telemetry_opt_out'))
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
-    @patch.object(feature_flags, 'LDClient')
-    def test_rhsso_user_with_telemetry_feature_enabled_opted_in(self, LDClient):
-        LDClient.return_value.variation.return_value = True
-        user = create_user(
-            provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,
-            social_auth_extra_data={"login": "sso_username"},
-            external_username="sso_username",
-            org_opt_out=False,
-        )
-        self.client.force_authenticate(user=user)
-        r = self.client.get(reverse('me'))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertFalse(r.data.get('org_telemetry_opt_out'))
-
-    @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
     @patch.object(IsOrganisationLightspeedSubscriber, 'has_permission', return_value=True)
     @patch.object(AcceptedTermsPermission, 'has_permission', return_value=True)

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -79,7 +79,7 @@ class CurrentUserView(RetrieveAPIView):
 
         # Enrich with Organisational data, if necessary
         organization = self.request.user.organization
-        if organization and organization.is_schema_2_telemetry_enabled:
+        if organization:
             user_data["org_telemetry_opt_out"] = organization.telemetry_opt_out
 
         return Response(user_data)

--- a/ansible_wisdom_console_react/package-lock.json
+++ b/ansible_wisdom_console_react/package-lock.json
@@ -5804,13 +5804,13 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "devOptional": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -5818,7 +5818,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -6431,9 +6431,9 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "devOptional": true,
       "engines": {
         "node": ">= 0.6"
@@ -8560,17 +8560,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "devOptional": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -15791,9 +15791,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "devOptional": true,
       "dependencies": {
         "bytes": "3.1.2",

--- a/ansible_wisdom_console_react/package-lock.json
+++ b/ansible_wisdom_console_react/package-lock.json
@@ -18452,9 +18452,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "devOptional": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/ansible_wisdom_console_react/src/App.tsx
+++ b/ansible_wisdom_console_react/src/App.tsx
@@ -8,13 +8,12 @@ import { PageApp } from "./PageApp";
 
 export interface AppProps {
   readonly userName: string;
-  readonly telemetryOptEnabled: boolean;
   readonly adminDashboardUrl: string;
 }
 
 export function App(props: AppProps) {
   const { t } = useTranslation();
-  const { userName, telemetryOptEnabled, adminDashboardUrl } = props;
+  const { userName, adminDashboardUrl } = props;
 
   const navigationItems = useMemo<PageNavigationItem[]>(() => {
     const items = [
@@ -24,15 +23,13 @@ export function App(props: AppProps) {
         path: "settings",
         element: <ModelSettings />,
       },
-    ];
-    if (telemetryOptEnabled) {
-      items.push({
+      {
         // Telemetry
         label: t("Telemetry"),
         path: "telemetry",
         element: <TelemetrySettings adminDashboardUrl={adminDashboardUrl} />,
-      });
-    }
+      },
+    ];
     return [
       {
         // Admin portal
@@ -41,7 +38,7 @@ export function App(props: AppProps) {
         children: items,
       },
     ];
-  }, [t, telemetryOptEnabled, adminDashboardUrl]);
+  }, [t, adminDashboardUrl]);
 
   return (
     <PageApp

--- a/ansible_wisdom_console_react/src/__tests__/App.test.tsx
+++ b/ansible_wisdom_console_react/src/__tests__/App.test.tsx
@@ -8,7 +8,6 @@ describe("App", () => {
     render(
       <App
         userName={"Batman"}
-        telemetryOptEnabled={true}
         adminDashboardUrl={"http://admin_dashboard-url/"}
       />,
     );

--- a/ansible_wisdom_console_react/src/index.tsx
+++ b/ansible_wisdom_console_react/src/index.tsx
@@ -10,21 +10,12 @@ import "./i18n";
 import "./index.css";
 
 const userName = document.getElementById("user_name")?.innerText ?? "undefined";
-const telemetrySchema2EnabledInnerText = document.getElementById(
-  "telemetry_schema_2_enabled",
-)?.innerText;
-const telemetrySchema2Enabled =
-  telemetrySchema2EnabledInnerText?.toLowerCase() === "true";
 const adminDashboardUrl =
   document.getElementById("telemetry_schema_2_admin_dashboard_url")
     ?.innerText ?? "";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App
-      userName={userName}
-      telemetryOptEnabled={telemetrySchema2Enabled}
-      adminDashboardUrl={adminDashboardUrl}
-    />
+    <App userName={userName} adminDashboardUrl={adminDashboardUrl} />
   </StrictMode>,
 );


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-21992>

## Description
Drop the use of the is_schema_2_enabled flag, from both wisdom-service, admin dashboard, and finally in LaunchDarkly.
PS: This PR basically reverts some work from https://github.com/ansible/ansible-wisdom-service/pull/814

## Testing
### Steps to test
1. Pull down the PR
2. Start the wisdom-service locally
3. Login by using a licensed user
4. Perform inference or sentiment feedback
5. Look at Segment and see events flowing for schema2, in case your org is opted-in
6. Also run the Admin Portal (`ansible_wisdom_console_react`) and check you can also see and access the Telemetry settings page
7. Tested also opting-in/out

### Scenarios tested
Locally, as described above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

**Remove** the (no longer used) flag [schema_2_telemetry_org_enabled](https://app.launchdarkly.com/wisdom/development/features/schema_2_telemetry_org_enabled) in **Launch Darkly**, for all Dev, Stage and Prod environments.
