### PR TITLE
AAP-19228: Refactor error handling in wisdom service and vscode extension. Ignore missing model_id's

### DIFF
--- a/ansible_wisdom/main/exception_handler.py
+++ b/ansible_wisdom/main/exception_handler.py
@@ -21,7 +21,7 @@ def exception_handler_with_error_type(exc, context):
                 response.data.pop('detail')
 
         # Extract 'model_id' from Exception
-        _model_id = {'model': exc.model_id} if hasattr(exc, 'model_id') else {'model': ''}
+        _model_id = {'model': exc.model_id} if hasattr(exc, 'model_id') else {}
 
         # Append 'code' and 'message' to the response data to enable the client
         # to be able to properly present the error to the user; based on 'code'.


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-19228

## Description
Further to #888 this fixes some failing tests in `ansible-wisdom-testing`.
```
>       assert b'{"suggestion":["This field may not be blank."]}' in response.content
E       assert b'{"suggestion":["This field may not be blank."]}' in b'{"suggestion":["This field may not be blank."],"model":""}'
```
