### PR TITLE
AAP-21571: Lightspeed on-prem to check AAP license

### DIFF
--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -111,3 +111,15 @@ class BlockUserWithoutSeat(permissions.BasePermission):
             return True
 
         return user.rh_user_has_seat
+
+
+class BlockUserWithExpiredOnprem(permissions.BasePermission):
+    """
+    Block access to users when on prem license expired
+    """
+
+    code = 'permission_denied__license_expired'
+    message = "Onprem License expired."
+
+    def has_permission(self, request, view):
+        return not request.user.is_onprem_license_expired

--- a/ansible_wisdom/users/auth.py
+++ b/ansible_wisdom/users/auth.py
@@ -23,6 +23,8 @@ class AAPOAuth2(BaseOAuth2):
     SCOPE_SEPARATOR = ','
     EXTRA_DATA = [('id', 'id'), ('expires', 'expires')]
 
+    is_license_expired = False
+
     def get_user_details(self, response):
         """Return user details"""
         return {
@@ -37,3 +39,22 @@ class AAPOAuth2(BaseOAuth2):
         url = f'{settings.AAP_API_URL}/v2/me/'
         resp_data = self.get_json(url, headers={"Authorization": f"bearer {access_token}"})
         return resp_data.get('results')[0]
+
+    def user_configs(self, access_token, *args, **kwargs):
+        """Loads user data from service"""
+        url = f'{settings.AAP_API_URL}/v2/config/'
+        resp_data = self.get_json(url, headers={"Authorization": f"bearer {access_token}"})
+        return resp_data
+
+    def check_license_expiration(self, access_token, *args, **kwargs):
+        data = self.user_configs(access_token, *args, **kwargs)
+        return data['license_info']['date_expired']
+
+    def auth_complete(self, *args, **kwargs):
+        user = super().auth_complete(*args, **kwargs)
+        user.is_onprem_license_expired = self.is_license_expired
+        return user
+
+    def do_auth(self, access_token, *args, **kwargs):
+        self.is_license_expired = self.check_license_expiration(access_token, *args, **kwargs)
+        return super().do_auth(access_token, *args, **kwargs)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-21571>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Lightspeed on-prem will use AAP as the SSO provider.  We will also need to check if the AAP license is still valid.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run in on prem mode
3. Log in and try to use Lightspeed in VS Code
    * If user has valid license code completion should work
    * If user's license is expired, VS Code should show an License expired error.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
