### PR TITLE
AAP-21736: Analytics Telemetry: Fix resulting empty modules for Recommendation Generated / Completion events

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -355,3 +355,33 @@ def restore_original_task_names(output_yaml, prompt):
                 break
 
     return output_yaml
+
+
+# RegExp Pattern based on ARI sources, see ansible_risk_insight/finder.py
+ansible_fqcn_declaration_pattern = re.compile(r"(([a-z0-9_]+)\.([a-z0-9_]+)\.([a-z0-9_]+)):")
+ansible_module_declaration_pattern = re.compile(r"([a-z0-9_.]+):")
+
+
+def get_fqcn_from_prediction(prediction):
+    return parse_module_from_prediction(ansible_fqcn_declaration_pattern, prediction)
+
+
+def get_module_from_prediction(prediction):
+    return parse_module_from_prediction(ansible_module_declaration_pattern, prediction)
+
+
+def parse_module_from_prediction(re, prediction):
+    try:
+        first = next(re.finditer(prediction))
+        if first:
+            return first.group(1)
+    except StopIteration:
+        pass
+    return None
+
+
+def get_fqcn_or_module_from_prediction(prediction):
+    fqcn = get_fqcn_from_prediction(prediction)
+    if fqcn is None:
+        fqcn = get_module_from_prediction(prediction)
+    return fqcn

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -339,6 +339,10 @@ def completion_post_process(context: CompletionContext):
         if ari_results is not None:
             ari_result = ari_results[i]
             fqcn_module = ari_result["fqcn_module"]
+            if fqcn_module is None or fqcn_module == "":
+                # In case the module is not part of the collections, ARI does not handle it.
+                # This way, parsing the module from the prediction instead.
+                fqcn_module = fmtr.get_fqcn_or_module_from_prediction(task["prediction"])
             if fqcn_module is not None:
                 task["module"] = fqcn_module
                 index = fqcn_module.rfind(".")

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -437,6 +437,115 @@ var3: value3
         after = "    # install ffmpeg & start ffmpeg"
         self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
 
+    def test_get_fqcn_module_from_prediction(self):
+        self.assertEqual(
+            "ansible.builtin.package",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      ansible.builtin.package:\n"
+                "        name: docker\n"
+                "        state: present\n"
+            ),
+        )
+        self.assertEqual(
+            "ansible.builtin.import_tasks",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      ansible.builtin.import_tasks: first_basic_.yml\n"
+            ),
+        )
+        self.assertEqual(
+            "ansible.builtin.include_tasks",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      ansible.builtin.include_tasks:\n" "        file: ../common/tasks/setup.yml\n"
+            ),
+        )
+        self.assertEqual(
+            "community.general.s3_facts",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      community.general.s3_facts:\n"
+                "        bucket: my-ansible-bucket\n"
+                "        object: /my-ansible-bucket/requirements.txt\n"
+                "        mode: get\n"
+            ),
+        )
+        self.assertEqual(
+            "ansible.builtin.include_role",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      ansible.builtin.include_role:\n"
+                "        name: redhat.rhel_system_roles.cockpit\n"
+            ),
+        )
+        self.assertEqual(
+            "docker_image",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      docker_image:\n"
+                "        name: rabbitmq:3.7.13\n"
+                "        source: pull\n"
+                "      when: image_facts.images | length == 0\n"
+            ),
+        )
+        self.assertEqual(
+            "servicenow.itsm.change_info",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      servicenow.itsm.change_info:\n"
+                "        sys_id: \"{{ item.sys_id }}\"\n"
+                "        register: change_info\n"
+                "        loop: \"{{ change_list }}\"\n"
+            ),
+        )
+        self.assertEqual(
+            "ansible.builtin.include_role",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      ansible.builtin.include_role:\n"
+                "          name: pcs.azure.recovery_services_vault\n"
+                "        vars:\n"
+                "          recovery_service_vault_resource_group: "
+                "\"{{ resource_group_name.sys_id }}\"\n"
+                "          recovery_service_vault_name: "
+                "\"{{ recovery_service_vault_name.sys_id }}\"\n"
+                "          recovery_service_vault_state: absent\n"
+            ),
+        )
+        self.assertEqual(
+            "community.general.maven_map",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      community.general.maven_map:\n"
+                "        name: dto\n"
+                "        version: 3d38c886-0c6d-4b1a-907e-76a0b9a8f996\n"
+                "        repository_url: https://repo.maven.org/maven2\n"
+                "        state: present\n"
+            ),
+        )
+        self.assertEqual(
+            "community.general.maven_map",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      community.general.maven_map:\n"
+                "        name: dto\n"
+                "        version: 1\n"
+                "        repository_url: https://repo.maven.org/maven2:1234\n"
+                "        state: present\n"
+            ),
+        )
+        self.assertEqual(
+            "community.general.maven_map",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      community.general.maven_map:\n"
+                "        name: dto\n"
+                "        version: 1\n"
+                "        repository_url: https://repo.maven.org/maven2:\"{{ port }}\"\n"
+                "        state: present\n"
+            ),
+        )
+        self.assertEqual(
+            "amazon.aws.ec2_vpc_api",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      amazon.aws.ec2_vpc_api:\n"
+                "          state: present\n"
+                "        subnets:\n"
+                "          cidr: 00.01.0.99/24\n"
+                "          az: us-east-1r\n"
+            ),
+        )
+
 
 if __name__ == "__main__":
     tests = AnsibleDumperTestCase()
@@ -466,3 +575,4 @@ if __name__ == "__main__":
     tests.test_strip_task_preamble_from_multi_task_prompt_no_preamble_unchanged_single()
     tests.test_strip_task_preamble_from_multi_task_prompt_one_preamble_changed()
     tests.test_strip_task_preamble_from_multi_task_prompt_two_preambles_changed()
+    tests.test_get_fqcn_module_from_prediction()


### PR DESCRIPTION
Hey @robinbobbitt @TamiTakamiya 

Jira Issue: <https://issues.redhat.com/browse/AAP-21736>

## Description
This PR fixes the cases where `module`/`collection` are not being properly sent for `completion`/`Recommendation Generated` events, such as when ARI fails or when the module is not part of any Ansible Collection.

## Testing
Tested MOST of the [prompts](https://redhat.enterprise.slack.com/files/U04MT6GPZKR/F06RJQU45Q9/no_module_examples_2.txt) provided by @TamiTakamiya , which were causing this issue.

![Screenshot from 2024-03-28 01-09-24](https://github.com/ansible/ansible-wisdom-service/assets/4602417/fe8cf503-00c4-435b-816e-5b40c33dc6e4)

Environment:
- Wisdom-service at localhost
- Ansible VScode extension v`1.86.1`  on localhost
- Targeting Segment staging account

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

Thanks!