### PR TITLE
Upgrade langchain-core to 0.1.34

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -32,8 +32,6 @@ ansible-lint==6.22.1
     # via -r requirements.in
 ansible-risk-insight==0.2.4
     # via -r requirements.in
-anyio==4.3.0
-    # via langchain-core
 argparse==1.4.0
     # via uwsgi-readiness-check
 asgiref==3.7.2
@@ -145,8 +143,6 @@ ecdsa==0.18.0
     # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
-exceptiongroup==1.2.0
-    # via anyio
 executing==2.0.1
     # via stack-data
 expiringdict==1.2.2
@@ -181,7 +177,6 @@ huggingface-hub==0.21.3
     #   transformers
 idna==3.6
     # via
-    #   anyio
     #   requests
     #   yarl
 importlib-resources==5.0.7
@@ -228,8 +223,9 @@ langchain==0.1.13
     # via -r requirements.in
 langchain-community==0.0.29
     # via langchain
-langchain-core==0.1.33
+langchain-core==0.1.34
     # via
+    #   -r requirements.in
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
@@ -474,8 +470,6 @@ smmap==5.0.1
     # via
     #   ansible-risk-insight
     #   gitdb
-sniffio==1.3.1
-    # via anyio
 social-auth-app-django==5.4.0
     # via -r requirements.in
 social-auth-core[openidconnect]==4.4.2
@@ -536,7 +530,6 @@ transformers==4.39.1
 typing-extensions==4.10.0
     # via
     #   ansible-compat
-    #   anyio
     #   asgiref
     #   black
     #   django-test-migrations

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -32,8 +32,6 @@ ansible-lint==6.22.1
     # via -r requirements.in
 ansible-risk-insight==0.2.4
     # via -r requirements.in
-anyio==4.3.0
-    # via langchain-core
 argparse==1.4.0
     # via uwsgi-readiness-check
 asgiref==3.7.2
@@ -145,8 +143,6 @@ ecdsa==0.18.0
     # via python-jose
 et-xmlfile==1.1.0
     # via openpyxl
-exceptiongroup==1.2.0
-    # via anyio
 executing==2.0.1
     # via stack-data
 expiringdict==1.2.2
@@ -181,7 +177,6 @@ huggingface-hub==0.21.3
     #   transformers
 idna==3.6
     # via
-    #   anyio
     #   requests
     #   yarl
 importlib-resources==5.0.7
@@ -228,8 +223,9 @@ langchain==0.1.13
     # via -r requirements.in
 langchain-community==0.0.29
     # via langchain
-langchain-core==0.1.33
+langchain-core==0.1.34
     # via
+    #   -r requirements.in
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
@@ -474,8 +470,6 @@ smmap==5.0.1
     # via
     #   ansible-risk-insight
     #   gitdb
-sniffio==1.3.1
-    # via anyio
 social-auth-app-django==5.4.0
     # via -r requirements.in
 social-auth-core[openidconnect]==4.4.2
@@ -536,7 +530,6 @@ transformers==4.39.1
 typing-extensions==4.10.0
     # via
     #   ansible-compat
-    #   anyio
     #   asgiref
     #   black
     #   django-test-migrations

--- a/requirements.in
+++ b/requirements.in
@@ -38,6 +38,10 @@ jwcrypto==1.5.6
 # pull a version of jwcrypto >= 3.1.3.
 jinja2==3.1.3
 langchain==0.1.13
+# pin langchain-core on 0.1.34 to address GHSA-q84m-rmw3-4382.
+# remove this once langchain is updated to properly pull a version of
+# langchain-core > 0.1.33.
+langchain-core==0.1.34
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
 protobuf==4.22.1


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
langchain-core | 0.1.33 | GHSA-q84m-rmw3-4382 | 0.1.34 | The XMLOutputParser in LangChain uses the etree module from the XML parser in the standard python library which has some XML vulnerabilities; see: https://docs.python.org/3/library/xml.html  This primarily affects users that combine an LLM (or agent) with the `XMLOutputParser` and expose the component via an endpoint on a web-service.   This would allow a malicious party to attempt to manipulate the LLM to produce a malicious payload for the parser that would compromise the availability of the service.  A successful attack is predicated on:  1. Usage of XMLOutputParser 2. Passing of malicious input into the XMLOutputParser either directly or by trying to manipulate an LLM to do so on the users behalf 3. Exposing the component via a web-service
```