### PR TITLE
Upgrade langchain-core to 0.1.35

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -223,7 +223,7 @@ langchain==0.1.13
     # via -r requirements.in
 langchain-community==0.0.29
     # via langchain
-langchain-core==0.1.34
+langchain-core==0.1.35
     # via
     #   -r requirements.in
     #   langchain

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -223,7 +223,7 @@ langchain==0.1.13
     # via -r requirements.in
 langchain-community==0.0.29
     # via langchain
-langchain-core==0.1.34
+langchain-core==0.1.35
     # via
     #   -r requirements.in
     #   langchain

--- a/requirements.in
+++ b/requirements.in
@@ -38,10 +38,10 @@ jwcrypto==1.5.6
 # pull a version of jwcrypto >= 3.1.3.
 jinja2==3.1.3
 langchain==0.1.13
-# pin langchain-core on 0.1.34 to address GHSA-q84m-rmw3-4382.
+# pin langchain-core on 0.1.35 to address GHSA-q84m-rmw3-4382.
 # remove this once langchain is updated to properly pull a version of
-# langchain-core > 0.1.33.
-langchain-core==0.1.34
+# langchain-core > 0.1.35.
+langchain-core==0.1.35
 launchdarkly-server-sdk==8.1.1
 opensearch-py==2.1.1
 protobuf==4.22.1


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
langchain-core | 0.1.34 | GHSA-q84m-rmw3-4382 | 0.1.35 | The XMLOutputParser in LangChain uses the etree module from the XML parser in the standard python library which has some XML vulnerabilities; see: https://docs.python.org/3/library/xml.html  This primarily affects users that combine an LLM (or agent) with the `XMLOutputParser` and expose the component via an endpoint on a web-service.   This would allow a malicious party to attempt to manipulate the LLM to produce a malicious payload for the parser that would compromise the availability of the service.  A successful attack is predicated on:  1. Usage of XMLOutputParser 2. Passing of malicious input into the XMLOutputParser either directly or by trying to manipulate an LLM to do so on the users behalf 3. Exposing the component via a web-service
```