### PR TITLE
relax scope check to allow additional scopes on RHSSO access token

### DIFF
--- a/ansible_wisdom/users/auth.py
+++ b/ansible_wisdom/users/auth.py
@@ -65,7 +65,7 @@ class RHSSOAuthentication(authentication.BaseAuthentication):
         )
 
         scope = decoded_token.get("scope")
-        if scope != RHSSO_LIGHTSPEED_SCOPE:
+        if RHSSO_LIGHTSPEED_SCOPE not in scope.split():
             raise ValueError(f"Unexpected scope: {scope}")
 
         social_user_id = decoded_token.get('sub')

--- a/ansible_wisdom/users/tests/test_auth.py
+++ b/ansible_wisdom/users/tests/test_auth.py
@@ -77,6 +77,22 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
         self.assertEqual(user.id, self.rh_user.id)
 
     @patch('ansible_wisdom.users.auth.load_backend')
+    def test_authenticate_succeeds_with_extra_scopes(self, mock_load_backend):
+        backend = DummyRHBackend()
+        mock_load_backend.return_value = backend
+        access_token = build_access_token(
+            private_key=backend.rsa_private_key,
+            issuer=backend.issuer,
+            payload={'sub': self.rh_usa.uid},
+            scope='openid api.lightspeed',
+        )
+
+        request = Mock(headers={'Authorization': f"Bearer {access_token}"})
+        user, _ = self.authentication.authenticate(request)
+
+        self.assertEqual(user.id, self.rh_user.id)
+
+    @patch('ansible_wisdom.users.auth.load_backend')
     def test_authenticate_returns_none_on_invalid_scope(self, mock_load_backend):
         backend = DummyRHBackend()
         mock_load_backend.return_value = backend
@@ -95,7 +111,6 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
         access_token = build_access_token(
             private_key=backend.rsa_private_key,
             issuer=backend.issuer,
-            scope='bogus-scope',
             payload={'sub': self.rh_usa.uid},
         )
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-21175

## Description
The current RHSSO access token scope check allows ONLY api.lightspeed scope. We should allow additional scopes on the token, e.g. openid will also be on the token when coming from the vscode RHSSO authentication extension.

## Testing

### Steps to test
Follow steps in https://github.com/ansible/ansible-wisdom-service/pull/901, using `openid api.lightspeed` as scope. Auth should still work.

### Scenarios tested
Unit tests plus steps above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
