### PR TITLE
AAP-22393: ContentMatches: Use WCA codematch for 'onprem'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env*
+.env
 .venv
 env/
 venv/

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -1737,6 +1737,7 @@ class TestContentMatchesWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCa
         self.assertEqual(content_match["license"], license)
         self.assertEqual(content_match["data_source_description"], "Ansible Galaxy roles")
 
+    @override_settings(DEPLOYMENT_MODE="saas")
     @patch('ansible_wisdom.ai.search.search')
     def test_wca_contentmatch_with_unseated_user_verify_single_task(self, mock_search):
         self.user.rh_user_has_seat = False
@@ -1773,8 +1774,17 @@ class TestContentMatchesWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCa
 
         mock_search.assert_called_with(payload["suggestions"][0], None)
 
+    @override_settings(DEPLOYMENT_MODE="saas")
     def test_wca_contentmatch_with_seated_user_single_task(self):
         self.user.rh_user_has_seat = True
+        self._test_wca_contentmatch_single_task()
+
+    @override_settings(DEPLOYMENT_MODE="onprem")
+    def test_wca_contentmatch_with_unseated_user_onprem_single_task(self):
+        self.user.rh_user_has_seat = False
+        self._test_wca_contentmatch_single_task()
+
+    def _test_wca_contentmatch_single_task(self):
         self.user.organization = Organization.objects.get_or_create(id=1)[0]
         self.client.force_authenticate(user=self.user)
         payload = {
@@ -1860,8 +1870,17 @@ class TestContentMatchesWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCa
         self.assertEqual(content_match["license"], license)
         self.assertEqual(content_match["data_source_description"], data_source_description)
 
+    @override_settings(DEPLOYMENT_MODE="saas")
     def test_wca_contentmatch_with_seated_user_multi_task(self):
         self.user.rh_user_has_seat = True
+        self._test_wca_contentmatch_multi_task()
+
+    @override_settings(DEPLOYMENT_MODE="onprem")
+    def test_wca_contentmatch_with_unseated_user_onprem_multi_task(self):
+        self.user.rh_user_has_seat = False
+        self._test_wca_contentmatch_multi_task()
+
+    def _test_wca_contentmatch_multi_task(self):
         self.user.organization = Organization.objects.get_or_create(id=1)[0]
         self.client.force_authenticate(user=self.user)
         payload = {

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -454,7 +454,12 @@ class ContentMatches(GenericAPIView):
         model_id = str(request_data.get('model', ''))
 
         try:
-            if request.user.rh_user_has_seat:
+            # This is getting ugly.
+            # Ideally we'd just call ModelMeshClient.codematch(..) and let the
+            # different implementations call into WCA or OpenSearch. We'd validate the
+            # combinations of Seats, DEPLOYMENT_MODE and ANSIBLE_AI_MODEL_MESH_API_TYPE
+            # in ansible_wisdom.ai.apps.AiConfig at start-up.
+            if request.user.rh_user_has_seat or settings.DEPLOYMENT_MODE == "onprem":
                 response_serializer = self.perform_content_matching(
                     model_id, suggestion_id, request.user, request_data
                 )


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-22393

## Description
When `DEPLOYMENT_MODE=="onprem"` OpenSearch was being used for Content Matches.

In this scenario we should use `ModelMeshClient.codematch(..)`.
 
## Testing
Configure VSCode to use an "on prem" instance of `wisdom-service` (details can be obtained from @manstis).

Complete a _Completions_ request and then try to view the Content Matches on the Ansible tab.

### Steps to test
1. Pull down the PR
2. Without deploying a new `wisdom-service` instance to an "on prem" installation there is little to test.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
