### PR TITLE
Containerfile: Enable nodejs 18 module stream

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -12,7 +12,8 @@ ENV PROMETHEUS_MULTIPROC_DIR=/var/run/django_metrics
 ENV BUILD_PATH=/var/www/wisdom/public/static/console
 
 # Install dependencies
-RUN dnf install -y \
+RUN dnf module enable nodejs:18 -y && \
+    dnf install -y \
     git \
     python3-devel \
     gcc \


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

The current react UI requires nodejs >= 18 but the default nodejs version on RHEL 9 is nodejs 16.

https://github.com/ansible/ansible-wisdom-service/blob/main/ansible_wisdom_console_react/package.json#L7

Nodejs 18 is available on this platform via a module stream.

In the container image build logs, we can see

```console
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'admin-portal@0.1.0',
npm WARN EBADENGINE   required: { node: '>=18.0.0', npm: '>=7.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'bfj@8.0.0',
npm WARN EBADENGINE   required: { node: '>= 18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Build the wisdom service container image

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
