### PR TITLE
Containerfile: Enable nodejs 18 module stream

### DIFF
--- a/.github/workflows/Build_Push_Image.yml
+++ b/.github/workflows/Build_Push_Image.yml
@@ -73,6 +73,7 @@ jobs:
           GIT_COMMIT=${{ steps.tag_name.outputs.sha-long }}
         extra-args: |
           --target=production
+          --ulimit nofile=4096
 
     - name: Scan Malware
       # Do not scan malware in PR builds

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -12,7 +12,8 @@ ENV PROMETHEUS_MULTIPROC_DIR=/var/run/django_metrics
 ENV BUILD_PATH=/var/www/wisdom/public/static/console
 
 # Install dependencies
-RUN dnf install -y \
+RUN dnf module enable nodejs:18 -y && \
+    dnf install -y \
     git \
     python3-devel \
     gcc \


### PR DESCRIPTION
This replaces https://github.com/ansible/ansible-wisdom-service/pull/917

The current react UI requires nodejs >= 18 but the default nodejs version on RHEL 9 is nodejs 16.

https://github.com/ansible/ansible-wisdom-service/blob/main/ansible_wisdom_console_react/package.json#L7

Nodejs 18 is available on this platform via a module stream.

In the container image build logs, we can see
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'admin-portal@0.1.0',
npm WARN EBADENGINE   required: { node: '>=18.0.0', npm: '>=7.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'bfj@8.0.0',
npm WARN EBADENGINE   required: { node: '>= 18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit c89b6de8868e32d0a491a621a447e942e2e647a6)
