### PR TITLE
refactor compose-backends.yaml into db and prom-grafana to save resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,18 +68,25 @@ run-server-containerized:
 docker-compose:
 	${COMPOSE_RUNTIME} -f tools/docker-compose/compose.yaml up --remove-orphans
 
-# DEPRECATED: Please use start-backends instead
-run-backends: start-backends DEPRECATED
+.PHONY: start-db
+# Run db in container for running Django application from source
+start-db:
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml up --remove-orphans -d
+
+.PHONY: stop-db
+# stop db container
+stop-db:
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml up down
 
 .PHONY: start-backends
 # Run backend services in container for running Django application from source
 start-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml up --remove-orphans -d
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml -f tools/docker-compose/compose-prom-grafana.yaml up --remove-orphans -d
 
 .PHONY: stop-backends
 # Stop backend services
 stop-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-backends.yaml down
+	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml -f tools/docker-compose/compose-prom-grafana.yaml down
 
 .PHONY: update-openapi-schema
 # Update OpenAPI 3.0 schema while running the service in development env

--- a/tools/docker-compose/compose-db.yaml
+++ b/tools/docker-compose/compose-db.yaml
@@ -15,29 +15,5 @@ services:
 #      - $PWD/db_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-  prometheus:
-    platform: linux/amd64
-    image: docker.io/prom/prometheus
-    command:
-      - --config.file=/opt/prometheus/prometheus.yaml
-      - --web.enable-lifecycle
-    volumes:
-      - $PWD/prometheus/:/opt/prometheus/
-    ports:
-      - "9090:9090"
-    networks:
-      - dbnet
-  grafana:
-    platform: linux/amd64
-    image: docker.io/grafana/grafana:7.5.17
-    environment:
-      - GF_LOG_LEVEL=warn
-    ports:
-      - "13000:3000"
-    volumes:
-      - $PWD/grafana:/var/lib/grafana
-    networks:
-      - dbnet
-
 networks:
   dbnet:

--- a/tools/docker-compose/compose-prom-grafana.yaml
+++ b/tools/docker-compose/compose-prom-grafana.yaml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  prometheus:
+    platform: linux/amd64
+    image: docker.io/prom/prometheus
+    command:
+      - --config.file=/opt/prometheus/prometheus.yaml
+      - --web.enable-lifecycle
+    volumes:
+      - $PWD/prometheus/:/opt/prometheus/
+    ports:
+      - "9090:9090"
+    networks:
+      - dbnet
+  grafana:
+    platform: linux/amd64
+    image: docker.io/grafana/grafana:7.5.17
+    environment:
+      - GF_LOG_LEVEL=warn
+    ports:
+      - "13000:3000"
+    volumes:
+      - $PWD/grafana:/var/lib/grafana
+    networks:
+      - dbnet
+
+networks:
+  dbnet:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-22471


## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Normally we don't need the prom/grafana pods in day2day dev.  Now adding
`make start-db` and `make stop-db` for ligher backend

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. run `make start-db` and `make stop-db` to test if db is up/down accordingly


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
