### PR TITLE
multitasks: also convert the prompt to low-case

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -294,7 +294,8 @@ def is_multi_task_prompt(prompt):
 def strip_task_preamble_from_multi_task_prompt(prompt):
     if is_multi_task_prompt(prompt):
         prompt_split = prompt.split('#', 1)
-        return f"{prompt_split[0]}# {' & '.join(get_task_names_from_prompt(prompt))}"
+        aggregated = ' & '.join(p.lower() for p in get_task_names_from_prompt(prompt))
+        return f"{prompt_split[0]}# {aggregated}"
     return prompt
 
 

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -512,7 +512,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
             suggestion_id=str(DEFAULT_SUGGESTION_ID),
             request_id=str(DEFAULT_SUGGESTION_ID),
             prompt="# - name: install ffmpeg on Red Hat Enterprise Linux",
-            codegen_prompt="# install ffmpeg on Red Hat Enterprise Linux\n",
+            codegen_prompt="# install ffmpeg on red hat enterprise linux\n",
         )
 
 

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -437,6 +437,11 @@ var3: value3
         after = "    # install ffmpeg & start ffmpeg"
         self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
 
+    def test_strip_task_preamble_from_multi_task_prompt_remove_upper_case(self):
+        before = "    # - name: install ffmpeg & - name: start FFMPEG"
+        after = "    # install ffmpeg & start ffmpeg"
+        self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
+
     def test_get_fqcn_module_from_prediction(self):
         self.assertEqual(
             "ansible.builtin.package",


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-21078>

Follow up to af0b1b757e1463ef7958baa3fc29b9a46a1c4d75, our single-task prompts
are always lower-case. However it was not the case for the multi-tasks prompts.

- Fully covered by unit-tests

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
