### PR TITLE
requirements: drop datasets

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -6,8 +6,6 @@
 #
 aiohttp==3.9.3
     # via
-    #   datasets
-    #   fsspec
     #   langchain
     #   langchain-community
 aiosignal==1.3.1
@@ -87,8 +85,6 @@ dataclasses-json==0.6.4
     # via
     #   langchain
     #   langchain-community
-datasets==2.18.0
-    # via -r requirements.in
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -98,10 +94,6 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-dill==0.3.7
-    # via
-    #   datasets
-    #   multiprocess
 django==4.2.11
     # via
     #   -r requirements.in
@@ -151,7 +143,6 @@ filelock==3.13.1
     # via
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   huggingface-hub
     #   torch
     #   transformers
@@ -159,10 +150,8 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2023.10.0
-    # via
-    #   datasets
-    #   huggingface-hub
+fsspec==2023.10.0
+    # via huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
 greenlet==3.0.3
@@ -171,7 +160,6 @@ grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.21.3
     # via
-    #   datasets
     #   sentence-transformers
     #   tokenizers
     #   transformers
@@ -260,8 +248,6 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-multiprocess==0.70.15
-    # via datasets
 mypy-extensions==1.0.0
     # via
     #   black
@@ -270,11 +256,8 @@ networkx==3.2.1
     # via torch
 numpy==1.26.4
     # via
-    #   datasets
     #   langchain
     #   langchain-community
-    #   pandas
-    #   pyarrow
     #   scikit-learn
     #   scipy
     #   sentence-transformers
@@ -299,14 +282,11 @@ packaging==23.2
     #   ansible-core
     #   ansible-lint
     #   black
-    #   datasets
     #   django-allow-cidr
     #   huggingface-hub
     #   langchain-core
     #   marshmallow
     #   transformers
-pandas==2.2.1
-    # via datasets
 parso==0.8.3
     # via jedi
 pathspec==0.12.1
@@ -338,10 +318,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==14.0.1
-    # via datasets
-pyarrow-hotfix==0.6
-    # via datasets
 pyasn1==0.5.1
     # via
     #   python-jose
@@ -371,7 +347,6 @@ pyrfc3339==1.1
 python-dateutil==2.9.0.post0
     # via
     #   botocore
-    #   pandas
     #   segment-analytics-python
 python-jose==3.3.0
     # via social-auth-core
@@ -381,7 +356,6 @@ pytz==2024.1
     # via
     #   -r requirements.in
     #   djangorestframework
-    #   pandas
     #   pyrfc3339
 pyyaml==6.0
     # via
@@ -390,7 +364,6 @@ pyyaml==6.0
     #   ansible-core
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   drf-spectacular
     #   huggingface-hub
     #   langchain
@@ -412,9 +385,7 @@ requests==2.31.0
     #   -r requirements.in
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   django-oauth-toolkit
-    #   fsspec
     #   huggingface-hub
     #   langchain
     #   langchain-community
@@ -515,7 +486,6 @@ torchvision @ https://download.pytorch.org/whl/torchvision-0.15.2-cp39-cp39-many
 tqdm==4.64.1
     # via
     #   -r requirements.in
-    #   datasets
     #   huggingface-hub
     #   sentence-transformers
     #   transformers
@@ -543,8 +513,6 @@ typing-extensions==4.10.0
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
-tzdata==2024.1
-    # via pandas
 uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.18
@@ -566,8 +534,6 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xxhash==3.4.1
-    # via datasets
 yamllint==1.35.1
     # via ansible-lint
 yarl==1.9.4

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -6,8 +6,6 @@
 #
 aiohttp==3.9.3
     # via
-    #   datasets
-    #   fsspec
     #   langchain
     #   langchain-community
 aiosignal==1.3.1
@@ -87,8 +85,6 @@ dataclasses-json==0.6.4
     # via
     #   langchain
     #   langchain-community
-datasets==2.18.0
-    # via -r requirements.in
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -98,10 +94,6 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-dill==0.3.7
-    # via
-    #   datasets
-    #   multiprocess
 django==4.2.11
     # via
     #   -r requirements.in
@@ -151,7 +143,6 @@ filelock==3.13.1
     # via
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   huggingface-hub
     #   torch
     #   transformers
@@ -159,10 +150,8 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2023.10.0
-    # via
-    #   datasets
-    #   huggingface-hub
+fsspec==2023.10.0
+    # via huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
 greenlet==3.0.3
@@ -171,7 +160,6 @@ grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.21.3
     # via
-    #   datasets
     #   sentence-transformers
     #   tokenizers
     #   transformers
@@ -260,8 +248,6 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-multiprocess==0.70.15
-    # via datasets
 mypy-extensions==1.0.0
     # via
     #   black
@@ -270,11 +256,8 @@ networkx==3.2.1
     # via torch
 numpy==1.26.4
     # via
-    #   datasets
     #   langchain
     #   langchain-community
-    #   pandas
-    #   pyarrow
     #   scikit-learn
     #   scipy
     #   sentence-transformers
@@ -299,14 +282,11 @@ packaging==23.2
     #   ansible-core
     #   ansible-lint
     #   black
-    #   datasets
     #   django-allow-cidr
     #   huggingface-hub
     #   langchain-core
     #   marshmallow
     #   transformers
-pandas==2.2.1
-    # via datasets
 parso==0.8.3
     # via jedi
 pathspec==0.12.1
@@ -338,10 +318,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyarrow==14.0.1
-    # via datasets
-pyarrow-hotfix==0.6
-    # via datasets
 pyasn1==0.5.1
     # via
     #   python-jose
@@ -371,7 +347,6 @@ pyrfc3339==1.1
 python-dateutil==2.9.0.post0
     # via
     #   botocore
-    #   pandas
     #   segment-analytics-python
 python-jose==3.3.0
     # via social-auth-core
@@ -381,7 +356,6 @@ pytz==2024.1
     # via
     #   -r requirements.in
     #   djangorestframework
-    #   pandas
     #   pyrfc3339
 pyyaml==6.0
     # via
@@ -390,7 +364,6 @@ pyyaml==6.0
     #   ansible-core
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   drf-spectacular
     #   huggingface-hub
     #   langchain
@@ -412,9 +385,7 @@ requests==2.31.0
     #   -r requirements.in
     #   ansible-lint
     #   ansible-risk-insight
-    #   datasets
     #   django-oauth-toolkit
-    #   fsspec
     #   huggingface-hub
     #   langchain
     #   langchain-community
@@ -515,7 +486,6 @@ torchvision @ https://download.pytorch.org/whl/cpu/torchvision-0.15.2%2Bcpu-cp39
 tqdm==4.64.1
     # via
     #   -r requirements.in
-    #   datasets
     #   huggingface-hub
     #   sentence-transformers
     #   transformers
@@ -543,8 +513,6 @@ typing-extensions==4.10.0
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
-tzdata==2024.1
-    # via pandas
 uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.18
@@ -566,8 +534,6 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xxhash==3.4.1
-    # via datasets
 yamllint==1.35.1
     # via ansible-lint
 yarl==1.9.4

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,6 @@ boto3==1.26.84
 black==24.3.0
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==42.0.4
-datasets==2.18.0
 # pin Django on 4.2.11 to address PYSEC-2024-47.
 Django==4.2.11
 django-deprecate-fields==0.1.1


### PR DESCRIPTION
Jira Issue: None

Remove `datasets` from our `requirements.in` since we don't need the
package in the container.

`datasets` is only used by `tools/scripts/search/index_dataset.py` which
we use to initialize the OpenSearch cluster and don't call from the container.

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
