### PR TITLE
Upgrade idna to 3.7

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -158,8 +158,9 @@ huggingface-hub==0.21.3
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.6
+idna==3.7
     # via
+    #   -r requirements.in
     #   requests
     #   yarl
 inflection==0.5.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -158,8 +158,9 @@ huggingface-hub==0.21.3
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.6
+idna==3.7
     # via
+    #   -r requirements.in
     #   requests
     #   yarl
 inflection==0.5.1

--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,10 @@ django-test-migrations==1.3.0
 djangorestframework==3.14.0
 drf-spectacular==0.25.1
 grpcio==1.60.1
+# pin idna on 3.7 to address GHSA-jjg7-2v4v-x38h
+# remove this once requests and yarl is updated to properly
+# pull a version of idna >= 3.7.
+idna==3.7
 ipython==8.10.0
 # pin jwcrypto on 1.5.6 to address GHSA-j857-7rvv-vj97
 # remove this once django-oauth-toolkit is updated to properly


### PR DESCRIPTION
This PR does not need a corresponding Jira item.
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
idna | 3.6 | GHSA-jjg7-2v4v-x38h | 3.7 | ### Impact A specially crafted argument to the `idna.encode()` function could consume significant resources. This may lead to a denial-of-service.  ### Patches The function has been refined to reject such strings without the associated resource consumption in version 3.7.  ### Workarounds Domain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the `idna.encode()` function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application.  ### References * https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb
```