### PR TITLE
rename strip_task_preamble_from_multi_task_prompt

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -291,7 +291,8 @@ def is_multi_task_prompt(prompt):
     return False
 
 
-def strip_task_preamble_from_multi_task_prompt(prompt):
+def normalize_multi_task_prompt(prompt):
+    """Remove the `- name: ` from the multi_task prompts and convert it to lower case."""
     if is_multi_task_prompt(prompt):
         prompt_split = prompt.split('#', 1)
         aggregated = ' & '.join(p.lower() for p in get_task_names_from_prompt(prompt))

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -14,7 +14,7 @@ from requests.exceptions import HTTPError
 
 from ansible_wisdom.ai.api.formatter import (
     get_task_names_from_prompt,
-    strip_task_preamble_from_multi_task_prompt,
+    normalize_multi_task_prompt,
 )
 from ansible_wisdom.ai.api.model_client.wca_utils import (
     ContentMatchContext,
@@ -143,7 +143,7 @@ class BaseWCAClient(ModelMeshClient):
 
         # WCA codegen fails if a multitask prompt includes the task preamble
         # https://github.com/rh-ibm-synergy/wca-feedback/issues/34
-        prompt = strip_task_preamble_from_multi_task_prompt(prompt)
+        prompt = normalize_multi_task_prompt(prompt)
 
         # WCA codegen endpoint requires prompt to end with \n
         if prompt.endswith('\n') is False:

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -419,28 +419,28 @@ var3: value3
                 "There is no match for the enumerated prompt task in the suggestion yaml", log
             )
 
-    def test_strip_task_preamble_from_multi_task_prompt_no_preamble_unchanged_multi(self):
+    def test_normalize_multi_task_prompt_no_preamble_unchanged_multi(self):
         prompt = "    # install ffmpeg"
-        self.assertEqual(prompt, fmtr.strip_task_preamble_from_multi_task_prompt(prompt))
+        self.assertEqual(prompt, fmtr.normalize_multi_task_prompt(prompt))
 
-    def test_strip_task_preamble_from_multi_task_prompt_no_preamble_unchanged_single(self):
+    def test_normalize_multi_task_prompt_no_preamble_unchanged_single(self):
         prompt = "    - name: install ffmpeg"
-        self.assertEqual(prompt, fmtr.strip_task_preamble_from_multi_task_prompt(prompt))
+        self.assertEqual(prompt, fmtr.normalize_multi_task_prompt(prompt))
 
-    def test_strip_task_preamble_from_multi_task_prompt_one_preamble_changed(self):
+    def test_normalize_multi_task_prompt_one_preamble_changed(self):
         before = "    # - name: install ffmpeg"
         after = "    # install ffmpeg"
-        self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
+        self.assertEqual(after, fmtr.normalize_multi_task_prompt(before))
 
-    def test_strip_task_preamble_from_multi_task_prompt_two_preambles_changed(self):
+    def test_normalize_multi_task_prompt_two_preambles_changed(self):
         before = "    # - name: install ffmpeg & - name: start ffmpeg"
         after = "    # install ffmpeg & start ffmpeg"
-        self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
+        self.assertEqual(after, fmtr.normalize_multi_task_prompt(before))
 
-    def test_strip_task_preamble_from_multi_task_prompt_remove_upper_case(self):
+    def test_normalize_multi_task_prompt_remove_upper_case(self):
         before = "    # - name: install ffmpeg & - name: start FFMPEG"
         after = "    # install ffmpeg & start ffmpeg"
-        self.assertEqual(after, fmtr.strip_task_preamble_from_multi_task_prompt(before))
+        self.assertEqual(after, fmtr.normalize_multi_task_prompt(before))
 
     def test_get_fqcn_module_from_prediction(self):
         self.assertEqual(
@@ -576,8 +576,8 @@ if __name__ == "__main__":
     tests.test_load_and_merge_vars_in_context()
     tests.test_insert_set_fact_task()
     tests.test_restore_original_task_names()
-    tests.test_strip_task_preamble_from_multi_task_prompt_no_preamble_unchanged_multi()
-    tests.test_strip_task_preamble_from_multi_task_prompt_no_preamble_unchanged_single()
-    tests.test_strip_task_preamble_from_multi_task_prompt_one_preamble_changed()
-    tests.test_strip_task_preamble_from_multi_task_prompt_two_preambles_changed()
+    tests.test_normalize_multi_task_prompt_no_preamble_unchanged_multi()
+    tests.test_normalize_multi_task_prompt_no_preamble_unchanged_single()
+    tests.test_normalize_multi_task_prompt_one_preamble_changed()
+    tests.test_normalize_multi_task_prompt_two_preambles_changed()
     tests.test_get_fqcn_module_from_prediction()


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-21078>

## Description

Rename `strip_task_preamble_from_multi_task_prompt()` to `normalize_multi_task_prompt()`.
Follow-up of https://github.com/ansible/ansible-wisdom-service/pull/920

## Testing

The change is covered by unit-tests.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
