### PR TITLE
reformatting to avoid an endless duel between Black and Flake8

### DIFF
--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -96,10 +96,11 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
         """
 
         if self.organization and self.organization.is_subscription_check_should_be_bypassed:
-            logger.info(
-                f"""Bypass organization check for organization ID {self.organization.id}
- and user UUID: {self.uuid}."""
+            message = (
+                "Bypass organization check for organization ID "
+                f"{self.organization.id} and user UUID: {self.uuid}."
             )
+            logger.info(message)
             return True
 
         if self.is_aap_user():

--- a/ansible_wisdom/users/signals.py
+++ b/ansible_wisdom/users/signals.py
@@ -55,10 +55,9 @@ def user_set_wca_model_id_log(sender, user, org_id, model_id, **kwargs):
 @receiver(user_set_telemetry_settings)
 def user_set_telemetry_settings_log(sender, user, org_id, settings, **kwargs):
     """User set Telemetry settings"""
-    logger.info(
-        f"User: '{user}' set Telemetry settings for Organisation "
-        f"'{org_id}' to '{json.dumps(settings, indent = 2) }'."
-    )
+    data = json.dumps(settings, indent=2)
+    message = f"User: '{user}' set Telemetry settings for Organisation " f"'{org_id}' to '{data}'."
+    logger.info(message)
 
 
 def _obfuscate(value: str) -> str:


### PR DESCRIPTION
Minor adjustment to be sure the code, as reformated by Black is Flake8 compliant.

```
ansible_wisdom/users/models.py:100:89: E272 multiple spaces before keyword
ansible_wisdom/users/signals.py:60:54: E251 unexpected spaces around keyword / parameter equals
ansible_wisdom/users/signals.py:60:56: E251 unexpected spaces around keyword / parameter equals
ansible_wisdom/users/signals.py:60:59: E202 whitespace before '}'
1     E202 whitespace before '}'
2     E251 unexpected spaces around keyword / parameter equals
1     E272 multiple spaces before keyword
4
```
