### PR TITLE
pin sqlparse==0.5.0 because of GHSA-2m57-hf25-phgg

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -444,8 +444,10 @@ sqlalchemy==2.0.28
     # via
     #   langchain
     #   langchain-community
-sqlparse==0.4.4
-    # via django
+sqlparse==0.5.0
+    # via
+    #   -r requirements.in
+    #   django
 stack-data==0.6.3
     # via ipython
 subprocess-tee==0.4.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -444,8 +444,10 @@ sqlalchemy==2.0.28
     # via
     #   langchain
     #   langchain-community
-sqlparse==0.4.4
-    # via django
+sqlparse==0.5.0
+    # via
+    #   -r requirements.in
+    #   django
 stack-data==0.6.3
     # via ipython
 subprocess-tee==0.4.1

--- a/requirements.in
+++ b/requirements.in
@@ -51,6 +51,9 @@ PyYAML==6.0
 requests==2.31.0
 segment-analytics-python==2.2.2
 sentence-transformers==2.5.1
+# pin sqlparse on 0.5.0 to address GHSA-2m57-hf25-phgg
+# Remove once a Django>4.2.11 is released with an updated dep on sqlparse
+sqlparse==0.5.0
 social-auth-app-django==5.4.0
 social-auth-core[openidconnect]==4.4.2
 # Use torch/torchvision CPU version


### PR DESCRIPTION
0.5.0 changelog entry: https://sqlparse.readthedocs.io/en/latest/changes.html#release-0-5-0-apr-13-2024