### PR TITLE
[DRAFT] AAP-16888: I want to reduce time to resolve customer issues through better error messages

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
@@ -95,7 +95,7 @@ class PreProcessStage(PipelineElement):
             logger.error(
                 f'failed to preprocess:\n{payload.context}{payload.prompt}\nException:\n{exc}'
             )
-            raise PreprocessInvalidYamlException()
+            raise PreprocessInvalidYamlException(cause=exc)
 
         finally:
             duration = round((time.time() - start_time) * 1000, 2)

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -62,7 +62,9 @@ class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
             self.client.force_authenticate(user=self.user)
             r = self.client.post(reverse('completions'), self.payload)
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        self.assert_error_detail(r, AcceptedTermsPermission.code, AcceptedTermsPermission.message)
+        self.assert_permission_detail(
+            r, AcceptedTermsPermission.code, AcceptedTermsPermission.message
+        )
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_commercial_user_has_not_accepted(self):
@@ -94,7 +96,7 @@ class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('wca_api_key'))
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        self.assert_error_detail(
+        self.assert_permission_detail(
             r, IsOrganisationAdministrator.code, IsOrganisationAdministrator.message
         )
 
@@ -106,7 +108,7 @@ class TestIfOrgIsLightspeedSubscriber(WisdomServiceAPITestCaseBase):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse('wca_api_key'))
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-        self.assert_error_detail(
+        self.assert_permission_detail(
             r, IsOrganisationLightspeedSubscriber.code, IsOrganisationLightspeedSubscriber.message
         )
 

--- a/ansible_wisdom/ai/api/utils/tests/test_segment.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment.py
@@ -214,12 +214,19 @@ class TestSegment(TestCase):
             'rh_user_has_seat': False,
             'exception': 'SomeException',
             'details': 'Some details',
+            'response': {
+                'exception': 'SomeException',
+                'error_type': 'an_error_type',
+                'error_context_id': 'an_error_context_id',
+            },
         }
         send_segment_event(event, 'postprocess', user)
         argument = track_method.call_args[0][2]
 
         self.assertEqual(argument['details'], 'Some details')
         self.assertEqual(argument['exception'], 'SomeException')
+        self.assertEqual(argument.get('response').get('error_type'), 'an_error_type')
+        self.assertEqual(argument.get('response').get('error_context_id'), 'an_error_context_id')
 
     @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.track")
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
@@ -232,12 +239,18 @@ class TestSegment(TestCase):
             'rh_user_has_seat': True,
             'exception': 'SomeException',
             'details': 'Some details',
+            'response': {
+                'exception': 'SomeException',
+                'error_type': 'an_error_type',
+                'error_context_id': 'an_error_context_id',
+            },
         }
         send_segment_event(event, 'postprocess', user)
         argument = track_method.call_args[0][2]
 
         self.assertEqual(argument.get('details'), None)
         self.assertEqual(argument.get('exception'), 'SomeException')
+        self.assertFalse('response' in argument)
 
     def test_redact_contentmatches_response_data(self, *args):
         test_data = {

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -214,7 +214,7 @@ class Feedback(APIView):
         except Exception as exc:
             exception = exc
             logger.exception(f"An exception {exc.__class__} occurred in sending a feedback")
-            raise FeedbackInternalServerException()
+            raise FeedbackInternalServerException(cause=exc)
         finally:
             self.write_to_segment(request.user, validated_data, exception, request.data)
 
@@ -378,7 +378,7 @@ class Attributions(GenericAPIView):
             )
         except Exception as exc:
             logger.error(f"Failed to search for attributions\nException:\n{exc}")
-            raise AttributionException()
+            raise AttributionException(cause=exc)
 
         duration = round((time.time() - start_time) * 1000, 2)
         attribution_encoding_hist.observe(encode_duration / 1000)
@@ -526,7 +526,7 @@ class ContentMatches(GenericAPIView):
 
         except ModelTimeoutError as e:
             exception = e
-            logger.warn(
+            logger.warning(
                 f"model timed out after {settings.ANSIBLE_AI_MODEL_MESH_API_TIMEOUT} seconds"
                 f" for suggestion {suggestion_id}"
             )

--- a/ansible_wisdom/main/exception_handler.py
+++ b/ansible_wisdom/main/exception_handler.py
@@ -27,6 +27,8 @@ def exception_handler_with_error_type(exc, context):
         # of _new_ Segment events with _old_ Segment events.
         if hasattr(exc, 'default_code'):
             response.error_type = exc.default_code
+        if hasattr(exc, 'error_context_id'):
+            response.error_context_id = exc.error_context_id
 
         # Discard the default 'detail' property
         # We add the 'code', 'message' and 'model' to 'data' root

--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -136,6 +136,7 @@ class SegmentMiddleware:
                         # That extracts 'default_code' from Exceptions and stores it
                         # in the Response.
                         "error_type": getattr(response, 'error_type', None),
+                        "error_context_id": getattr(response, 'error_context_id', None),
                         "message": message,
                         "predictions": predictions,
                         "status_code": response.status_code,

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -104,6 +104,10 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                         )
                         self.assertEqual(1, properties['taskCount'])
                         self.assertEqual('SINGLETASK', properties['promptType'])
+                        self.assertTrue('response' in properties)
+                        self.assertTrue('error_type' in properties['response'])
+                        self.assertTrue('error_context_id' in properties['response'])
+
                     self.assertIsNotNone(event['timestamp'])
 
             with self.assertLogs(logger='root', level='DEBUG') as log:

--- a/ansible_wisdom/test_utils.py
+++ b/ansible_wisdom/test_utils.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import json
 from ast import literal_eval
 from http import HTTPStatus
 from typing import Union
@@ -51,10 +52,19 @@ class WisdomTestCase(TestCase):
             self.assertEqual(r['Content-Length'], "0")
             return
 
-        r_code = r.data.get('message').code
+        self.assert_permission_detail(r, code, message)
+        js = json.dumps(r.data)
+        j = json.loads(js)
+        self.assertTrue('error_context_id' in j)
+        self.assertIsNotNone(j['error_context_id'])
+
+    def assert_permission_detail(self, r, code: str, message: str = None):
+        js = json.dumps(r.data)
+        j = json.loads(js)
+        r_code = j.get('code')
         self.assertEqual(r_code, code)
         if message:
-            r_message = r.data.get('message')
+            r_message = j.get('message')
             self.assertEqual(r_message, message)
 
 


### PR DESCRIPTION
**=== DRAFT ===**

Jira Issue: https://issues.redhat.com/browse/AAP-16888

## Description
This PR adds an `error_context_id` attribute to the API response payload for exceptions.

The full stack trace and `error_context_id` are logged on the server.

The additional `error_context_id` field is sent to VSCode.... where we can either log it or show it.

The purpose is to support correlation of exceptions observed in VSCode with what happened on the server.

## Testing
### Steps to test
1. Pull down the PR
2. `make start-backend`
3. `make create-application`
4. Run `wisdom-service` however you would normally.

### Scenarios tested
Unit tests confirming the additional payload field.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:-
This PR requires changes to VSCode.. to be determined; if the approach in this PR is acceptable.
