### PR TITLE
extend the dummy client to support the playbook generation

### DIFF
--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -16,14 +16,81 @@ import json
 import logging
 import secrets
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 from django.conf import settings
+from langchain_core.prompt_values import ChatPromptValue
+from langchain_core.runnables import Runnable, RunnableConfig
 
 from .base import ModelMeshClient
 
 logger = logging.getLogger(__name__)
+
+
+class DummyLLM(Runnable):
+    def __init__(self):
+        self.response_dict = {
+            "explanations": '''# Information
+This playbook installs the Nginx web server on all hosts
+that are running Red Hat Enterprise Linux (RHEL) 9.
+''',
+            "summaries": '''1. First, ensure that your RHEL 9 system is up-to-date.
+2. Next, you install the Nginx package using the package manager.
+3. After installation, start the ginx service.
+4. Ensure that Nginx starts automatically.
+5. Check if Nginx is running successfully.
+6. Visit your system's IP address followed by the default Nginx port number (80 or 443).
+''',
+            "generations": '''```yaml
+---
+- hosts: rhel9
+  become: yes
+  tasks:
+    - name: Install EPEL repository
+      ansible.builtin.dnf:
+        name: epel-release
+        state: present
+
+    - name: Update package list
+      ansible.builtin.dnf:
+        update_cache: yes
+
+    - name: Install nginx
+      ansible.builtin.dnf:
+        name: nginx
+        state: present
+
+    - name: Start and enable nginx service
+      ansible.builtin.systemd:
+        name: nginx
+        state: started
+        enabled: yes
+```''',
+        }
+
+    def invoke(self, input: object, config: Optional[RunnableConfig] = None) -> object:
+
+        if isinstance(input, ChatPromptValue):
+            content = input.messages[0].content
+            if "Write one paragraph per Ansible task." in content:
+                api = "explanations"
+            elif "Use a numbered list." in content:
+                api = "summaries"
+            elif "generate the playbook" in content:
+                api = "generations"
+            else:
+                raise Exception(f"Unknown system message template: {content}")
+        else:
+            raise Exception(f"Unknown input type: {type(input)}")
+
+        if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:
+            jitter: float = secrets.randbelow(1000) * 0.001
+        else:
+            jitter: float = 0.001
+        time.sleep(settings.DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter)
+
+        return self.response_dict[api]
 
 
 class DummyClient(ModelMeshClient):
@@ -43,3 +110,8 @@ class DummyClient(ModelMeshClient):
         response_body = json.loads(settings.DUMMY_MODEL_RESPONSE_BODY)
         response_body['model_id'] = '_'
         return response_body
+
+    def get_chat_model(self, model_id):
+        logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
+        logger.debug("!!!! Mocking Chat Model !!!!")
+        return DummyLLM()


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [AAP-22356](https://issues.redhat.com/browse/AAP-22356) and [AAP-22357](https://issues.redhat.com/browse/AAP-22357)
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
ansible-wisdom-service dummy model client should support the playbook explanation and generation.

A new environment variable `DUMMY_MODEL_LLM_RESPONSE_DICT` is provided to override the default
responses.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->

Test cases are included in the PR.

### Steps to test
Run test cases provided (TestExplanationView, TestSummaryView and TestGenerationView classes)

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
In addition to test cases included, I ran manual test using Swagger UI.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
