### PR TITLE
AAP-22758: Thousands of AMS-related errors in production logs. Improve empty response handling.

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -238,6 +238,10 @@ class AMSCheck(BaseCheck):
         data = r.json()
 
         try:
+            if len(data["items"]) == 0:
+                logger.info(f"An AMS Organization could not be found. " f"rh_org_id: {rh_org_id}.")
+                return AMSCheck.ERROR_AMS_ORG_UNDEFINED
+
             result = data["items"][0]["id"]
             cache.set(cache_key, result, settings.AMS_ORG_CACHE_TIMEOUT_SEC)
             return result
@@ -246,7 +250,7 @@ class AMSCheck(BaseCheck):
                 f"Unexpected answer from AMS backend (organizations). "
                 f"rh_org_id: {rh_org_id}, data={data}."
             )
-            return AMSCheck.ERROR_AMS_ORG_UNDEFINED
+            raise AMSCheck.AMSError
 
     def self_test(self):
         self.update_bearer_token()

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -250,14 +250,12 @@ class TestToken(WisdomServiceLogAwareTestCase):
         checker._session = Mock()
         checker._session.get.return_value = m_r
 
-        with self.assertLogs(logger='root', level='ERROR') as log:
+        with self.assertLogs(logger='root', level='INFO') as log:
             self.assertEqual(checker.get_ams_org(123), AMSCheck.ERROR_AMS_ORG_UNDEFINED)
             self.assertInLog(
-                "Unexpected answer from AMS backend (organizations). "
-                "rh_org_id: 123, data={'items': []}",
+                "An AMS Organization could not be found. " "rh_org_id: 123.",
                 log,
             )
-            self.assertInLog("IndexError: list index out of range", log)
 
     def test_ams_check(self):
         m_r = Mock()


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-22758

## Description
Further to @robinbobbitt [comment](https://github.com/ansible/ansible-wisdom-service/commit/1981ea5faf3cfe236d4b7c33ed1c414f844fdfe7#r141083684) on #944 this PR improves the handling of empty responses from AMS. 

## Testing
Login to the service with a User that has no corresponding AMS organisation.

They should not be granted a subscription.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Start the `wisdom-service` according to your preference
5. Login with a User that does not have a corresponding AMS organisation
6. They should not be granted a subscription

### Scenarios tested
Unit tests cover re-tries and cache hits.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: