### PR TITLE
Remove ansible content feedback

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -255,45 +255,6 @@ class FeedbackRequestSerializerTest(TestCase):
         except Exception:
             self.fail("serializer is_valid should not have raised exception")
 
-    def test_commercial_user_raises_exception_on_ansibleContent(self):
-        user = Mock(rh_user_has_seat=True)
-        request = Mock(user=user)
-
-        serializer = FeedbackRequestSerializer(
-            context={'request': request},
-            data={
-                "ansibleContent": {
-                    "content": "---\n- hosts: all\n  tasks:\n  - name: Install ssh\n",
-                    "documentUri": "file:///home/user/ansible/test.yaml",
-                    "trigger": "0",
-                }
-            },
-        )
-
-        # ansibleContent feedback raises exception when seat
-        with self.assertRaises(serializers.ValidationError):
-            serializer.is_valid(raise_exception=True)
-
-    def test_commercial_user_not_opted_out_raises_exception_on_ansibleContent(self):
-        org = Mock(telemetry_opt_out=False)
-        user = Mock(rh_user_has_seat=True, organization=org)
-        request = Mock(user=user)
-
-        serializer = FeedbackRequestSerializer(
-            context={'request': request},
-            data={
-                "ansibleContent": {
-                    "content": "---\n- hosts: all\n  tasks:\n  - name: Install ssh\n",
-                    "documentUri": "file:///home/user/ansible/test.yaml",
-                    "trigger": "0",
-                }
-            },
-        )
-
-        # ansibleContent feedback raises exception when seat
-        with self.assertRaises(serializers.ValidationError):
-            serializer.is_valid(raise_exception=True)
-
     def test_commercial_user_allows_sentimentFeedback(self):
         user = Mock(rh_user_has_seat=True)
         request = Mock(user=user)

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -84,7 +84,6 @@ from .permissions import (
     IsAAPLicensed,
 )
 from .serializers import (
-    AnsibleContentFeedback,
     AttributionRequestSerializer,
     AttributionResponseSerializer,
     CompletionRequestSerializer,
@@ -234,7 +233,6 @@ class Feedback(APIView):
         request_data=None,
     ) -> None:
         inline_suggestion_data: InlineSuggestionFeedback = validated_data.get("inlineSuggestion")
-        ansible_content_data: AnsibleContentFeedback = validated_data.get("ansibleContent")
         suggestion_quality_data: SuggestionQualityFeedback = validated_data.get(
             "suggestionQualityFeedback"
         )
@@ -278,16 +276,6 @@ class Feedback(APIView):
                 user,
                 ansible_extension_version,
             )
-        if ansible_content_data:
-            event = {
-                "content": ansible_content_data.get('content'),
-                "documentUri": ansible_content_data.get('documentUri'),
-                "trigger": ansible_content_data.get('trigger'),
-                "modelName": model_name,
-                "activityId": str(ansible_content_data.get('activityId', '')),
-                "exception": exception is not None,
-            }
-            send_segment_event(event, "ansibleContentFeedback", user)
         if suggestion_quality_data:
             event = {
                 "prompt": suggestion_quality_data.get('prompt'),
@@ -328,7 +316,6 @@ class Feedback(APIView):
 
         feedback_events = [
             inline_suggestion_data,
-            ansible_content_data,
             suggestion_quality_data,
             sentiment_feedback_data,
             issue_feedback_data,
@@ -346,7 +333,7 @@ class Feedback(APIView):
             elif "issueFeedback" in request_data:
                 event_type = "issueFeedback"
             else:
-                event_type = "ansibleContentFeedback"
+                event_type = "unknown"
 
             event = {
                 "data": ano_request_data,

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -23,7 +23,7 @@ if DEBUG:
     SPECTACULAR_SETTINGS = {
         'TITLE': f'{ANSIBLE_AI_PROJECT_NAME}.',  # noqa: F405
         'DESCRIPTION': 'Equip the automation developer at Lightspeed.',
-        'VERSION': '0.0.8',
+        'VERSION': '0.0.9',
         'SERVE_INCLUDE_SCHEMA': False,
         # OTHER SETTINGS
         'TAGS': [

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Ansible AI Connect.
-  version: 0.0.8
+  version: 0.0.9
   description: Equip the automation developer at Lightspeed.
 paths:
   /api/v0/ai/attributions/:
@@ -214,20 +214,6 @@ paths:
                 description: A valid inline suggestion feedback sample request to
                   get details about the suggestion like latency time, user decision
                   time, user action and suggestion id.
-              ValidAnsibleContentFeedbackExample:
-                value:
-                  ansibleContent:
-                    content: |
-                      ---
-                      - hosts: all
-                        become: yes
-
-                        tasks:
-                        - name: Install ssh
-                    documentUri: file:///home/user/ansible/test.yaml
-                    trigger: '0'
-                summary: Feedback Request sample for Ansible content upload
-                description: A valid sample request to get ansible content as feedback.
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/FeedbackRequest'
@@ -641,27 +627,6 @@ components:
       - '1'
       - '2'
       type: string
-    AnsibleContentFeedback:
-      type: object
-      properties:
-        content:
-          type: string
-          title: Ansible Content
-          description: Ansible file content.
-        documentUri:
-          type: string
-        trigger:
-          $ref: '#/components/schemas/TriggerEnum'
-        activityId:
-          type: string
-          format: uuid
-          title: Activity ID
-          description: A UUID that identifies a user activity session to the document
-            uploaded.
-      required:
-      - content
-      - documentUri
-      - trigger
     Attribution:
       type: object
       properties:
@@ -866,8 +831,6 @@ components:
     FeedbackRequest:
       type: object
       properties:
-        ansibleContent:
-          $ref: '#/components/schemas/AnsibleContentFeedback'
         inlineSuggestion:
           $ref: '#/components/schemas/InlineSuggestionFeedback'
         issueFeedback:
@@ -1079,12 +1042,6 @@ components:
             collection.
       required:
       - optOut
-    TriggerEnum:
-      enum:
-      - '0'
-      - '1'
-      - '2'
-      type: string
     TypeEnum:
       enum:
       - bug-report


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [AAP-22260](https://issues.redhat.com/browse/AAP-22260)  The changes on VS Code extension are found in [vscode-ansible PR#1254](https://github.com/ansible/vscode-ansible/pull/1254)

<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
(From [AAP-22260](https://issues.redhat.com/browse/AAP-22260)): With tech preview over, we have no use case for flowing ansibleContent feedback. We don't collect this data for commercial users. This can be removed from the vscode extension, and wisdom service. 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
Set up Lightspeed with VS Code extension and run completion and verify it works w/o issues.
This PR does not add new features.

### Steps to test
n/a

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Just regular Lightspeed operations.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
