### PR TITLE
pip-audit: clean up the ignore-vulns list and ignore the JWT bomb attack

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -7,11 +7,13 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/pip_audit.yml
       - ansible_wisdom/**
   pull_request:
     branches:
       - main
     paths:
+      - .github/workflows/pip_audit.yml
       - ansible_wisdom/**
 permissions:
   contents: read
@@ -36,11 +38,5 @@ jobs:
         with:
           virtual-environment: env/
           ignore-vulns: |
-            GHSA-282v-666c-3fvg
-            GHSA-jh3w-4vvf-mjgr
-            GHSA-ww3m-ffrm-qvqv
-            PYSEC-2023-100
-            PYSEC-2023-228
-            GHSA-mq26-g339-26xf
-            PYSEC-2022-43059
-            GHSA-wj6h-64fc-37mp
+            GHSA-cjwg-qfpm-7377
+            GHSA-6c5p-j8vq-pqhj


### PR DESCRIPTION
Ignore both GHSA-cjwg-qfpm-7377 and GHSA-6c5p-j8vq-pqhj since the severity is Moderate and there is no fixed version of `python-jose` released yet.