### PR TITLE
get_model_client: call get_wca_client() only when wca is actually enabled

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -66,7 +66,7 @@ completions_hist = Histogram(
 
 
 def get_model_client(wisdom_app, user):
-    if settings.DEPLOYMENT_MODE != 'onprem' and user.rh_user_has_seat:
+    if settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == "wca" and user.rh_user_has_seat:
         return wisdom_app.get_wca_client(), None
 
     # either onprem or non-seated customers (e.g. upstream)


### PR DESCRIPTION
Ensure `get_model_client()` doesn't return a WCA client when the configuration
points on a different model.
