### PR TITLE
get_model_client: call get_wca_client() only when wca is actually enabled

### DIFF
--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -66,7 +66,7 @@ completions_hist = Histogram(
 
 
 def get_model_client(wisdom_app, user):
-    if settings.DEPLOYMENT_MODE != 'onprem' and user.rh_user_has_seat:
+    if settings.ANSIBLE_AI_MODEL_MESH_API_TYPE in ["wca", "wca-onprem"] and user.rh_user_has_seat:
         return wisdom_app.get_wca_client(), None
 
     # either onprem or non-seated customers (e.g. upstream)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -228,7 +228,7 @@ class TestGetModelClient(WisdomServiceAPITestCaseBase):
         self.user.organization = Organization.objects.get_or_create(id=1)[0]
         self.client.force_authenticate(user=self.user)
         model_client, model_name = get_model_client(apps.get_app_config('ai'), self.user)
-        self.assertTrue(isinstance(model_client, WCAClient))
+        self.assertTrue(isinstance(model_client, LlamaCPPClient))
         self.assertIsNone(model_name)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='llamacpp')
@@ -256,6 +256,8 @@ class TestGetModelClient(WisdomServiceAPITestCaseBase):
         self.assertIsNone(model_name)
 
 
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca')
+@override_settings(WCA_SECRET_BACKEND_TYPE='dummy')
 class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def stub_wca_client(
         self,
@@ -727,6 +729,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
 
 
 @modify_settings()
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca")
 class TestCompletionView(WisdomServiceAPITestCaseBase):
     # An artificial model ID for model-ID related test cases.
     DUMMY_MODEL_ID = "01234567-1234-5678-9abc-0123456789ab<|sepofid|>wisdom_codegen"


### PR DESCRIPTION
Ensure `get_model_client()` doesn't return a WCA client when the configuration
points on a different model.
