### PR TITLE
containerfile: install nginx from nginx:1.22 module

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -12,7 +12,7 @@ ENV PROMETHEUS_MULTIPROC_DIR=/var/run/django_metrics
 ENV BUILD_PATH=/var/www/wisdom/public/static/console
 
 # Install dependencies
-RUN dnf module enable nodejs:18 -y && \
+RUN dnf module enable nodejs:18 nginx:1.22 -y && \
     dnf install -y \
     git \
     python3.11-devel \
@@ -23,9 +23,8 @@ RUN dnf module enable nodejs:18 -y && \
     python3.11-pip \
     postgresql \
     less \
-    npm
-
-RUN dnf module install -y nginx/common
+    npm \
+    nginx
 
 # Copy the ansible_wisdom package files
 COPY requirements-x86_64.txt /var/www/ansible-wisdom-service/


### PR DESCRIPTION
This change addresses the following problem during the build of the image:

```
Argument 'nginx/common' matches 2 streams ('1.22', '1.24') of module 'nginx', but none of the streams are enabled or default
```

There is now two module streams for nginx, 1.22 and 1.24 and we need to specify which one we want