### PR TITLE
Revert "verify signature of rhsso access token (#767)"

### DIFF
--- a/ansible_wisdom/users/auth.py
+++ b/ansible_wisdom/users/auth.py
@@ -16,7 +16,6 @@ import logging
 
 import jwt
 from django.conf import settings
-from jose import jwk
 from rest_framework import authentication
 from social_core.backends.oauth import BaseOAuth2
 from social_django.models import UserSocialAuth
@@ -78,12 +77,12 @@ class RHSSOAuthentication(authentication.BaseAuthentication):
         strategy = load_strategy()
         backend = load_backend(strategy, 'oidc', redirect_uri=None)
         key = backend.find_valid_key(access_token)
-        rsakey = jwk.construct(key)
+        rsakey = jwt.PyJWK(key)
 
         # Decode and verify access token using extracted public key
         decoded_token = jwt.decode(
             access_token,
-            rsakey.to_pem().decode("utf-8"),
+            rsakey.key,
             algorithms=['RS256'],
             issuer=backend.id_token_issuer(),
             audience=RHSSO_LIGHTSPEED_SCOPE,

--- a/ansible_wisdom/users/tests/test_auth.py
+++ b/ansible_wisdom/users/tests/test_auth.py
@@ -17,11 +17,9 @@ from uuid import uuid4
 
 import jwt
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from jose import constants, jwk
 from rest_framework.test import APIRequestFactory
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_django.models import UserSocialAuth
@@ -39,17 +37,7 @@ class DummyRHBackend(OpenIdConnectAuth):
         self.rsa_private_key = rsa.generate_private_key(
             public_exponent=65537, key_size=2048, backend=default_backend()
         )
-        public_bytes = self.rsa_private_key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        self.public_key = jwk.RSAKey(
-            algorithm=constants.Algorithms.RS256, key=public_bytes.decode('utf-8')
-        ).to_dict()
         self.issuer = "https://myauth.com/auth/realms/my-realm"
-
-    def find_valid_key(self, id_token):
-        return self.public_key
 
     def id_token_issuer(self):
         return self.issuer

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -17,22 +17,16 @@
 from uuid import uuid4
 
 import jwt
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from jose import constants, jwk
 from social_django.models import UserSocialAuth
 
 from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.constants import RHSSO_LIGHTSPEED_SCOPE
 from ansible_wisdom.users.pipeline import load_extra_data, redhat_organization
 
 
-def build_access_token(private_key, payload):
-    payload["aud"] = [RHSSO_LIGHTSPEED_SCOPE]
-    return jwt.encode(payload, key=private_key, algorithm='RS256')
+def build_access_token(payload):
+    return jwt.encode(payload, key='secret', algorithm='HS256')
 
 
 class DummyGithubBackend:
@@ -49,12 +43,6 @@ class DummyGithubBackend:
 
 class DummyRHBackend:
     name = "oidc"
-
-    def __init__(self, public_key):
-        self.public_key = public_key
-
-    def find_valid_key(self, id_token):
-        return self.public_key
 
     def extra_data(*args, **kwargs):
         return {
@@ -86,18 +74,6 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
         self.github_usa = UserSocialAuth.objects.create(
             user=self.rh_user, provider="github", uid=str(uuid4())
         )
-        self.rsa_private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=2048, backend=default_backend()
-        )
-
-        public_bytes = self.rsa_private_key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-
-        self.jwks_public_key = jwk.RSAKey(
-            algorithm=constants.Algorithms.RS256, key=public_bytes.decode('utf-8')
-        ).to_dict()
 
     def tearDown(self):
         self.rh_user.delete()
@@ -106,7 +82,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
 
     def test_load_extra_data(self):
         load_extra_data(
-            backend=DummyRHBackend(public_key=self.jwks_public_key),
+            backend=DummyRHBackend(),
             details=None,
             response=None,
             uid=None,
@@ -118,20 +94,15 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_rh_admin_user(self):
         response = {
             "access_token": build_access_token(
-                self.rsa_private_key,
                 {
                     "realm_access": {"roles": ["admin:org:all"]},
                     "preferred_username": "jean-michel",
                     "organization": {"id": "345"},
-                },
+                }
             )
         }
 
-        answer = redhat_organization(
-            backend=DummyRHBackend(public_key=self.jwks_public_key),
-            user=self.rh_user,
-            response=response,
-        )
+        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -144,20 +115,15 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_rh_user(self):
         response = {
             "access_token": build_access_token(
-                self.rsa_private_key,
                 {
                     "realm_access": {"roles": ["another_other_role"]},
                     "preferred_username": "yves",
                     "organization": {"id": "345"},
-                },
+                }
             )
         }
 
-        answer = redhat_organization(
-            backend=DummyRHBackend(public_key=self.jwks_public_key),
-            user=self.rh_user,
-            response=response,
-        )
+        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': False,
@@ -168,7 +134,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
         assert self.rh_user.external_username == "yves"
 
     def test_redhat_organization_with_github_user(self):
-        response = {"access_token": build_access_token(self.rsa_private_key, {})}
+        response = {"access_token": build_access_token({})}
 
         answer = redhat_organization(
             backend=DummyGithubBackend(), user=self.github_user, response=response
@@ -181,20 +147,15 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_AUTHZ_DUMMY_parameter(self):
         response = {
             "access_token": build_access_token(
-                self.rsa_private_key,
                 {
                     "realm_access": {"roles": ["another_other_role"]},
                     "preferred_username": "yves",
                     "organization": {"id": "345"},
-                },
+                }
             )
         }
 
-        answer = redhat_organization(
-            backend=DummyRHBackend(public_key=self.jwks_public_key),
-            user=self.rh_user,
-            response=response,
-        )
+        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -208,20 +169,15 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_AUTHZ_DUMMY_wildcard(self):
         response = {
             "access_token": build_access_token(
-                self.rsa_private_key,
                 {
                     "realm_access": {"roles": ["another_other_role"]},
                     "preferred_username": "yves",
                     "organization": {"id": "345"},
-                },
+                }
             )
         }
 
-        answer = redhat_organization(
-            backend=DummyRHBackend(public_key=self.jwks_public_key),
-            user=self.rh_user,
-            response=response,
-        )
+        answer = redhat_organization(backend=DummyRHBackend(), user=self.rh_user, response=response)
         assert answer == {
             'organization_id': 345,
             'rh_user_is_org_admin': True,
@@ -235,19 +191,16 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
     def test_redhat_organization_with_invalid_AUTHZ_DUMMY_parameter(self):
         response = {
             "access_token": build_access_token(
-                self.rsa_private_key,
                 {
                     "realm_access": {"roles": ["another_other_role"]},
                     "preferred_username": "yves",
                     "organization": {"id": "345"},
-                },
+                }
             )
         }
         with self.assertLogs(logger='ansible_wisdom.users.pipeline', level='ERROR') as log:
             answer = redhat_organization(
-                backend=DummyRHBackend(public_key=self.jwks_public_key),
-                user=self.rh_user,
-                response=response,
+                backend=DummyRHBackend(), user=self.rh_user, response=response
             )
             self.assertInLog("AUTHZ_DUMMY_RH_ORG_ADMINS has an invalid format.", log)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   'segment-analytics-python~=2.2.2',
   'sentence-transformers==2.*',
   'social-auth-app-django~=5.4.1',
-  'social-auth-core[openidconnect]~=4.4.2',
+  'social-auth-core[openidconnect]>=4.4.2',
   'transformers~=4.39.1',
   'tqdm~=4.64.1',
   'urllib3~=1.26.18',


### PR DESCRIPTION
This reverts commit ef407500155b530e634a720be0572274280417f6.

This commit depends on python3-jose which is a dependency we want to break.
In addition, once the authentication step is passed ( [See: find_valid_key()](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/open_id_connect.py#L192-L201) ), we can safely access
the JWT payload since it has already been checked.

Also a minor adjustment of the social-auth-core dependency to avoid a confict cause by 01045b2e53eaf42cf3546e86310b2f40ed3b31db.
