### PR TITLE
GHA/pip-audit: ensure the test is run on req changes

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -7,12 +7,18 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/pip_audit.yml
       - ansible_wisdom/**
+      - pyproject.toml
+      - requirements*.txt
   pull_request:
     branches:
       - main
     paths:
+      - .github/workflows/pip_audit.yml
       - ansible_wisdom/**
+      - pyproject.toml
+      - requirements*.txt
 permissions:
   contents: read
 
@@ -20,7 +26,7 @@ jobs:
   selftest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -32,16 +38,8 @@ jobs:
           python -m pip install . -rrequirements.txt
           # See: https://github.com/advisories/GHSA-r9hx-vwmv-q579
           pip install --upgrade setuptools
-      - uses: pypa/gh-action-pip-audit@v1.0.6
+      - uses: pypa/gh-action-pip-audit@v1.0.8
         with:
           virtual-environment: env/
           ignore-vulns: |
-            GHSA-282v-666c-3fvg
-            GHSA-jh3w-4vvf-mjgr
-            GHSA-ww3m-ffrm-qvqv
-            PYSEC-2023-100
-            PYSEC-2023-228
-            GHSA-mq26-g339-26xf
-            PYSEC-2022-43059
-            GHSA-wj6h-64fc-37mp
             GHSA-g7vv-2v7x-gj9p


### PR DESCRIPTION
- clean up some old ignore-vulns entries.
- and ensure the pip_audit job get triggered as soon as we've got a requirement
  update.
- bump to pypa/gh-action-pip-audit@v1.0.8
- bump to actions/checkout@v4
