### PR TITLE
base: use importlib to resolv the static files

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -26,11 +26,11 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 import os
 import sys
+from importlib.resources import files
 from pathlib import Path
 from typing import Literal, cast
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR: Path = files("ansible_wisdom")
 ANSIBLE_AI_PROJECT_NAME = os.getenv("ANSIBLE_AI_PROJECT_NAME") or "Ansible AI Connect"
 
 # Quick-start development settings - unsuitable for production
@@ -357,11 +357,10 @@ LOGGING = {
         "level": os.getenv("DJANGO_LOG_LEVEL") or "WARNING",
     },
 }
-
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': list(BASE_DIR.glob("*/templates/")),
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -433,7 +432,7 @@ STATIC_ROOT = '/var/www/wisdom/public/static'
 
 # Paths to where static files that are not explicitly part of a
 # particular Django app should be collected from.
-STATICFILES_DIRS = [BASE_DIR / 'static']
+STATICFILES_DIRS = list(BASE_DIR.glob("*/static/"))
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-23784>
<!-- This PR does not need a corresponding Jira item. -->

## Description

Use `importlib` to identify the location of the static files. This way we don't need to know the run the service from the `ansible_wisdom` directory.

Use `setuptools_scm` to identify the files to include in the distribution. `setuptools_scm` relies on the `.gitignore` to identify unrelated files.
    
Note: Currently, `setuptools_scm` includes the `ansible_wisdom_console_react` directory, which is not necessarly something we want to do in the future.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
