### PR TITLE
AAP-23164: Update Model Id fails with 503 when WCA model check fails with 401

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -31,9 +31,8 @@ from ansible_ai_connect.ai.api.formatter import (
     strip_task_preamble_from_multi_task_prompt,
 )
 from ansible_ai_connect.ai.api.model_client.wca_utils import (
-    ContentMatchContext,
     ContentMatchResponseChecks,
-    InferenceContext,
+    Context,
     InferenceResponseChecks,
     TokenContext,
     TokenResponseChecks,
@@ -216,7 +215,7 @@ class BaseWCAClient(ModelMeshClient):
                         model_id=model_id, x_request_id=x_request_id
                     )
 
-            context = InferenceContext(model_id, response, task_count > 1)
+            context = Context(model_id, response, task_count > 1)
             InferenceResponseChecks().run_checks(context)
             response.raise_for_status()
 
@@ -268,7 +267,7 @@ class BaseWCAClient(ModelMeshClient):
                 )
 
             result = post_request()
-            context = ContentMatchContext(model_id, result, suggestion_count > 1)
+            context = Context(model_id, result, suggestion_count > 1)
             ContentMatchResponseChecks().run_checks(context)
             result.raise_for_status()
 

--- a/ansible_wisdom/ai/api/model_client/wca_utils.py
+++ b/ansible_wisdom/ai/api/model_client/wca_utils.py
@@ -74,146 +74,109 @@ class TokenResponseChecks(Checks[TokenContext]):
         )
 
 
-class InferenceContext:
+class Context:
     def __init__(self, model_id, result, is_multi_task_prompt):
         self.model_id = model_id
         self.result = result
         self.is_multi_task_prompt = is_multi_task_prompt
 
 
-class InferenceResponseChecks(Checks[InferenceContext]):
-    class ResponseStatusCode204(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            if context.result.status_code == 204:
-                raise WcaEmptyResponse(model_id=context.model_id)
-
-    class ResponseStatusCode400WCABadRequestModelId(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            if context.result.status_code == 400:
-                payload_json = context.result.json()
-                if isinstance(payload_json, dict):
-                    payload_error = payload_json.get("error")
-                    if (
-                        payload_error
-                        and "bad request" in payload_error.lower()
-                        and "('body', 'model_id')" in payload_error.lower()
-                    ):
-                        raise WcaInvalidModelId(model_id=context.model_id)
-                    payload_detail = payload_json.get("detail")
-                    if (
-                        payload_detail
-                        and "failed to parse space id and model id" in payload_detail.lower()
-                    ):
-                        raise WcaInvalidModelId(model_id=context.model_id)
-
-    class ResponseStatusCode400(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            if context.result.status_code == 400:
-                raise WcaBadRequest(model_id=context.model_id, json_response=context.result.json())
-
-    class ResponseStatusCode403(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            if context.result.status_code == 403:
-                raise WcaInvalidModelId(model_id=context.model_id)
-
-    class ResponseStatusCode403Cloudflare(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            if context.result.status_code == 403:
-                text = context.result.text
-                if text and "cloudflare" in text.lower():
-                    raise WcaCloudflareRejection(model_id=context.model_id)
-
-    class ResponseStatusCode403UserTrialExpired(Check[InferenceContext]):
-        def check(self, context: InferenceContext):
-            is_user_trial_expired(
-                context.model_id,
-                context.result.status_code,
-                context.result.json(),
-            )
-
-    def __init__(self):
-        super().__init__(
-            [
-                # The ordering of these checks is important!
-                InferenceResponseChecks.ResponseStatusCode204(),
-                InferenceResponseChecks.ResponseStatusCode400WCABadRequestModelId(),
-                InferenceResponseChecks.ResponseStatusCode400(),
-                InferenceResponseChecks.ResponseStatusCode403Cloudflare(),
-                InferenceResponseChecks.ResponseStatusCode403UserTrialExpired(),
-                InferenceResponseChecks.ResponseStatusCode403(),
-            ]
-        )
+class ResponseStatusCode204(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 204:
+            raise WcaEmptyResponse(model_id=context.model_id)
 
 
-class ContentMatchContext:
-    def __init__(self, model_id, result, is_multi_task_suggestion):
-        self.model_id = model_id
-        self.result = result
-        self.is_multi_task_suggestion = is_multi_task_suggestion
+class ResponseStatusCode400WCABadRequestModelId(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 400:
+            payload_json = context.result.json()
+            if isinstance(payload_json, dict):
+                payload_error = payload_json.get("error")
+                if (
+                    payload_error
+                    and "bad request" in payload_error.lower()
+                    and "('body', 'model_id')" in payload_error.lower()
+                ):
+                    raise WcaInvalidModelId(model_id=context.model_id)
+                payload_detail = payload_json.get("detail")
+                if (
+                    payload_detail
+                    and "failed to parse space id and model id" in payload_detail.lower()
+                ):
+                    raise WcaInvalidModelId(model_id=context.model_id)
 
 
-class ContentMatchResponseChecks(Checks[ContentMatchContext]):
-    class ResponseStatusCode204(Check[ContentMatchContext]):
-        def check(self, context: ContentMatchContext):
-            if context.result.status_code == 204:
-                raise WcaEmptyResponse(model_id=context.model_id)
+class ResponseStatusCode400(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 400:
+            raise WcaBadRequest(model_id=context.model_id, json_response=context.result.json())
 
-    class ResponseStatusCode400WCABadRequestModelId(Check[ContentMatchContext]):
-        def check(self, context: ContentMatchContext):
-            if context.result.status_code == 400:
-                payload_json = context.result.json()
-                if isinstance(payload_json, dict):
-                    payload_error = payload_json.get("error")
-                    if (
-                        payload_error
-                        and "bad request" in payload_error.lower()
-                        and "('body', 'model_id')" in payload_error.lower()
-                    ):
-                        raise WcaInvalidModelId(model_id=context.model_id)
 
-    class ResponseStatusCode400(Check[ContentMatchContext]):
-        def check(self, context: ContentMatchContext):
-            if context.result.status_code == 400:
-                raise WcaBadRequest(model_id=context.model_id, json_response=context.result.json())
+class ResponseStatusCode403(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 403:
+            raise WcaInvalidModelId(model_id=context.model_id)
 
-    class ResponseStatusCode403(Check[ContentMatchContext]):
-        def check(self, context: ContentMatchContext):
-            if context.result.status_code == 403:
-                raise WcaInvalidModelId(model_id=context.model_id)
 
-    class ResponseStatusCode403Cloudflare(Check[InferenceContext]):
-        def check(self, context: ContentMatchContext):
-            if context.result.status_code == 403:
-                text = context.result.text
-                if text and "cloudflare" in text.lower():
-                    raise WcaCloudflareRejection(model_id=context.model_id)
+class ResponseStatusCode403Cloudflare(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 403:
+            text = context.result.text
+            if text and "cloudflare" in text.lower():
+                raise WcaCloudflareRejection(model_id=context.model_id)
 
-    class ResponseStatusCode403UserTrialExpired(Check[InferenceContext]):
-        def check(self, context: ContentMatchContext):
-            is_user_trial_expired(
-                context.model_id,
-                context.result.status_code,
-                context.result.json(),
-            )
+
+class ResponseStatusCode403UserTrialExpired(Check[Context]):
+
+    def check(self, context: Context):
+        if context.result.status_code == 403:
+            payload_json = context.result.json()
+            if isinstance(payload_json, dict):
+                payload_message_id = payload_json.get("message_id")
+                if payload_message_id and "wca-0001-e" in payload_message_id.lower():
+                    raise WcaUserTrialExpired(model_id=context.model_id)
+
+
+class ResponseStatusCode404WCABadRequestModelId(Check[Context]):
+    def check(self, context: Context):
+        if context.result.status_code == 404:
+            payload_json = context.result.json()
+            if isinstance(payload_json, dict):
+                payload_detail = payload_json.get("detail")
+                if payload_detail and "wml api call failed" in payload_detail.lower():
+                    raise WcaInvalidModelId(model_id=context.model_id)
+
+
+class InferenceResponseChecks(Checks[Context]):
 
     def __init__(self):
         super().__init__(
             [
                 # The ordering of these checks is important!
-                ContentMatchResponseChecks.ResponseStatusCode204(),
-                ContentMatchResponseChecks.ResponseStatusCode400WCABadRequestModelId(),
-                ContentMatchResponseChecks.ResponseStatusCode400(),
-                ContentMatchResponseChecks.ResponseStatusCode403Cloudflare(),
-                ContentMatchResponseChecks.ResponseStatusCode403UserTrialExpired(),
-                ContentMatchResponseChecks.ResponseStatusCode403(),
+                ResponseStatusCode204(),
+                ResponseStatusCode400WCABadRequestModelId(),
+                ResponseStatusCode400(),
+                ResponseStatusCode403Cloudflare(),
+                ResponseStatusCode403UserTrialExpired(),
+                ResponseStatusCode403(),
+                ResponseStatusCode404WCABadRequestModelId(),
             ]
         )
 
 
-def is_user_trial_expired(model_id, result_code, content):
-    if (
-        result_code == 403
-        and isinstance(content, dict)
-        and "WCA-0001-E" == content.get("message_id")
-    ):
-        raise WcaUserTrialExpired(model_id=model_id)
+class ContentMatchResponseChecks(Checks[Context]):
+
+    def __init__(self):
+        super().__init__(
+            [
+                # The ordering of these checks is important!
+                ResponseStatusCode204(),
+                ResponseStatusCode400WCABadRequestModelId(),
+                ResponseStatusCode400(),
+                ResponseStatusCode403Cloudflare(),
+                ResponseStatusCode403UserTrialExpired(),
+                ResponseStatusCode403(),
+                ResponseStatusCode404WCABadRequestModelId(),
+            ]
+        )


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23164

## Description
This PR adds support for (what appears to be) a new response from WCA.

I catch the (new) WCA response and raise a `WcaInvalidModelId` exception. 

All existing handling of this exception type is consequentially triggered (in the service and VSCode).

If we'd prefer to present this scenario differently to Users please say; it just requires more change (and to VSCode).

This PR also refactors the area of code where the change was added to remove duplication.

## Testing
Run locally (or using the PR build, when available).

Login with a User that has permissions to access the Admin Portal and try updating the Model Id accordingly.

See JIRA for details.

### Steps to test
1. Pull down the PR
2. `make start-backend`
3. `make create-application`
4. Run `ansible-ai-connect-service` as you would normally.
5. Login with a User that has access to the Admin Portal
6. Update the Model Id accordingly.

### Scenarios tested
The above.

I also checked the current VSCode extension and trying to use a Model Id override that was formatted correctly, but did not exist (see JIRA for details) presented the User with a "IBM watsonx Code Assistant Model ID is invalid. Please contact your administrator." message. I think this is acceptable.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
