### PR TITLE
rename the import for ansible_ai_connect

### DIFF
--- a/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
+++ b/ansible_wisdom/ai/api/aws/tests/test_wca_secret_manager.py
@@ -17,16 +17,16 @@ from unittest.mock import Mock
 from botocore.exceptions import ClientError
 from rest_framework.test import APITestCase
 
-from ansible_wisdom.ai.api.aws.exceptions import (
+from ansible_ai_connect.ai.api.aws.exceptions import (
     WcaSecretManagerError,
     WcaSecretManagerMissingCredentialsError,
 )
-from ansible_wisdom.ai.api.aws.wca_secret_manager import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import (
     SECRET_KEY_PREFIX,
     AWSSecretManager,
     Suffixes,
 )
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 
 ORG_ID = "org_123"
 SECRET_VALUE = "secret"

--- a/ansible_wisdom/ai/api/data/data_model.py
+++ b/ansible_wisdom/ai/api/data/data_model.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from pydantic import BaseModel, validator
 from typing_extensions import TypedDict
 
-from ansible_wisdom.ai.api.serializers import DataSource
+from ansible_ai_connect.ai.api.serializers import DataSource
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/exceptions.py
+++ b/ansible_wisdom/ai/api/exceptions.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from prometheus_client import Counter
 from rest_framework.exceptions import APIException
 
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     ModelTimeoutError,
     WcaException,
 )

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 
 import grpc
 
-from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
+from ansible_ai_connect.ai.api.formatter import get_task_names_from_prompt
 
 from .base import ModelMeshClient
 from .exceptions import ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import requests
 
-from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
+from ansible_ai_connect.ai.api.formatter import get_task_names_from_prompt
 
 from .base import ModelMeshClient
 from .exceptions import ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/llamacpp_client.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import requests
 
-from ansible_wisdom.ai.api.formatter import get_task_names_from_prompt
+from ansible_ai_connect.ai.api.formatter import get_task_names_from_prompt
 
 from .base import ModelMeshClient
 from .exceptions import ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
@@ -20,7 +20,7 @@ from django.test import TestCase, override_settings
 from langchain_core.messages.base import BaseMessage
 from responses import matchers
 
-from ansible_wisdom.ai.api.model_client.bam_client import BAMClient, unwrap_answer
+from ansible_ai_connect.ai.api.model_client.bam_client import BAMClient, unwrap_answer
 
 
 class TestUnwrapAnswer(TestCase):

--- a/ansible_wisdom/ai/api/model_client/tests/test_llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_llamacpp_client.py
@@ -20,8 +20,8 @@ from django.test import TestCase, override_settings
 from requests.exceptions import ReadTimeout
 from responses import matchers
 
-from ansible_wisdom.ai.api.model_client.exceptions import ModelTimeoutError
-from ansible_wisdom.ai.api.model_client.llamacpp_client import LlamaCPPClient
+from ansible_ai_connect.ai.api.model_client.exceptions import ModelTimeoutError
+from ansible_ai_connect.ai.api.model_client.llamacpp_client import LlamaCPPClient
 
 
 class TestLlamaCPPClient(TestCase):

--- a/ansible_wisdom/ai/api/model_client/tests/test_model_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_model_client.py
@@ -16,7 +16,7 @@ from unittest import TestCase
 
 from django.test import override_settings
 
-from ansible_wisdom.ai.api.model_client.base import ModelMeshClient
+from ansible_ai_connect.ai.api.model_client.base import ModelMeshClient
 
 timeout = 271828
 

--- a/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.model_client.ollama_client import OllamaClient
+from ansible_ai_connect.ai.api.model_client.ollama_client import OllamaClient
 
 
 class TestOllama(TestCase):
@@ -39,7 +39,7 @@ class TestOllama(TestCase):
             "model_id": "test",
         }
 
-    @patch("ansible_wisdom.ai.api.model_client.ollama_client.Ollama")
+    @patch("ansible_ai_connect.ai.api.model_client.ollama_client.Ollama")
     def test_infer(self, m_ollama):
         def final(_):
             return f"- name: Vache volante!\n{indent(self.expected_task_body, '  ')}"

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -25,13 +25,13 @@ from django.test import TestCase, override_settings
 from prometheus_client import Counter, Histogram
 from requests.exceptions import HTTPError, ReadTimeout
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import (
     DummySecretEntry,
     DummySecretManager,
     Suffixes,
     WcaSecretManagerError,
 )
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     ModelTimeoutError,
     WcaBadRequest,
     WcaCodeMatchFailure,
@@ -43,7 +43,7 @@ from ansible_wisdom.ai.api.model_client.exceptions import (
     WcaSuggestionIdCorrelationFailure,
     WcaTokenFailure,
 )
-from ansible_wisdom.ai.api.model_client.wca_client import (
+from ansible_ai_connect.ai.api.model_client.wca_client import (
     WCA_REQUEST_ID_HEADER,
     WCAClient,
     WCAOnPremClient,
@@ -54,7 +54,7 @@ from ansible_wisdom.ai.api.model_client.wca_client import (
     wca_codematch_hist,
     wca_codematch_retry_counter,
 )
-from ansible_wisdom.test_utils import (
+from ansible_ai_connect.test_utils import (
     WisdomAppsBackendMocking,
     WisdomServiceLogAwareTestCase,
 )

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -26,11 +26,11 @@ from django_prometheus.conf import NAMESPACE
 from prometheus_client import Counter, Histogram
 from requests.exceptions import HTTPError
 
-from ansible_wisdom.ai.api.formatter import (
+from ansible_ai_connect.ai.api.formatter import (
     get_task_names_from_prompt,
     strip_task_preamble_from_multi_task_prompt,
 )
-from ansible_wisdom.ai.api.model_client.wca_utils import (
+from ansible_ai_connect.ai.api.model_client.wca_utils import (
     ContentMatchContext,
     ContentMatchResponseChecks,
     InferenceContext,

--- a/ansible_wisdom/ai/api/permissions.py
+++ b/ansible_wisdom/ai/api/permissions.py
@@ -16,7 +16,7 @@ from django.apps import apps
 from django.conf import settings
 from rest_framework import permissions
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class AcceptedTermsPermission(permissions.BasePermission):

--- a/ansible_wisdom/ai/api/pipelines/completion_context.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_context.py
@@ -18,7 +18,7 @@ from typing import Any, Union
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from ansible_wisdom.ai.api.data.data_model import APIPayload
+from ansible_ai_connect.ai.api.data.data_model import APIPayload
 
 
 @dataclass

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/deserialise.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/deserialise.py
@@ -14,15 +14,15 @@
 
 import logging
 
-from ansible_wisdom.ai.api import formatter as fmtr
-from ansible_wisdom.ai.api.data.data_model import APIPayload
-from ansible_wisdom.ai.api.exceptions import process_error_count
-from ansible_wisdom.ai.api.pipelines.common import PipelineElement
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
-from ansible_wisdom.ai.api.pipelines.completion_stages.response import (
+from ansible_ai_connect.ai.api import formatter as fmtr
+from ansible_ai_connect.ai.api.data.data_model import APIPayload
+from ansible_ai_connect.ai.api.exceptions import process_error_count
+from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.pipelines.completion_stages.response import (
     CompletionsPromptType,
 )
-from ansible_wisdom.ai.api.serializers import CompletionRequestSerializer
+from ansible_ai_connect.ai.api.serializers import CompletionRequestSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -23,8 +23,8 @@ from django.conf import settings
 from django_prometheus.conf import NAMESPACE
 from prometheus_client import Histogram
 
-from ansible_wisdom.ai.api.data.data_model import ModelMeshPayload
-from ansible_wisdom.ai.api.exceptions import (
+from ansible_ai_connect.ai.api.data.data_model import ModelMeshPayload
+from ansible_ai_connect.ai.api.exceptions import (
     BaseWisdomAPIException,
     ModelTimeoutException,
     ServiceUnavailable,
@@ -38,7 +38,7 @@ from ansible_wisdom.ai.api.exceptions import (
     WcaUserTrialExpiredException,
     process_error_count,
 )
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     ModelTimeoutError,
     WcaBadRequest,
     WcaCloudflareRejection,
@@ -49,10 +49,10 @@ from ansible_wisdom.ai.api.model_client.exceptions import (
     WcaSuggestionIdCorrelationFailure,
     WcaUserTrialExpired,
 )
-from ansible_wisdom.ai.api.pipelines.common import PipelineElement
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
-from ansible_wisdom.ai.feature_flags import FeatureFlags, WisdomFlags
+from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.ai.feature_flags import FeatureFlags, WisdomFlags
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -22,11 +22,14 @@ from django_prometheus.conf import NAMESPACE
 from prometheus_client import Histogram
 from yaml.error import MarkedYAMLError
 
-from ansible_wisdom.ai.api import formatter as fmtr
-from ansible_wisdom.ai.api.exceptions import PostprocessException, process_error_count
-from ansible_wisdom.ai.api.pipelines.common import PipelineElement
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.ai.api import formatter as fmtr
+from ansible_ai_connect.ai.api.exceptions import (
+    PostprocessException,
+    process_error_count,
+)
+from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/pre_process.py
@@ -19,13 +19,13 @@ from django.conf import settings
 from django_prometheus.conf import NAMESPACE
 from prometheus_client import Histogram
 
-from ansible_wisdom.ai.api import formatter as fmtr
-from ansible_wisdom.ai.api.exceptions import (
+from ansible_ai_connect.ai.api import formatter as fmtr
+from ansible_ai_connect.ai.api.exceptions import (
     PreprocessInvalidYamlException,
     process_error_count,
 )
-from ansible_wisdom.ai.api.pipelines.common import PipelineElement
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/response.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/response.py
@@ -17,14 +17,14 @@ from enum import Enum
 
 from rest_framework.response import Response
 
-from ansible_wisdom.ai.api.exceptions import (
+from ansible_ai_connect.ai.api.exceptions import (
     InternalServerError,
     completions_return_code,
     process_error_count,
 )
-from ansible_wisdom.ai.api.pipelines.common import PipelineElement
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
-from ansible_wisdom.ai.api.serializers import CompletionResponseSerializer
+from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.serializers import CompletionResponseSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
@@ -18,7 +18,7 @@ Test post_process
 
 from unittest.case import TestCase
 
-from ansible_wisdom.ai.api.pipelines.completion_stages import post_process
+from ansible_ai_connect.ai.api.pipelines.completion_stages import post_process
 
 
 class TrimWhitespaceLinesTest(TestCase):

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -18,12 +18,12 @@ from unittest.mock import Mock
 
 from django.test import TestCase, modify_settings, override_settings
 
-from ansible_wisdom.ai.api.data.data_model import APIPayload
-from ansible_wisdom.ai.api.pipelines.completion_context import CompletionContext
-from ansible_wisdom.ai.api.pipelines.completion_stages.pre_process import (
+from ansible_ai_connect.ai.api.data.data_model import APIPayload
+from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
+from ansible_ai_connect.ai.api.pipelines.completion_stages.pre_process import (
     completion_pre_process,
 )
-from ansible_wisdom.ai.api.serializers import CompletionRequestSerializer
+from ansible_ai_connect.ai.api.serializers import CompletionRequestSerializer
 
 
 def add_indents(vars, n):

--- a/ansible_wisdom/ai/api/pipelines/completions.py
+++ b/ansible_wisdom/ai/api/pipelines/completions.py
@@ -17,19 +17,21 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from ansible_wisdom.ai.api.exceptions import InternalServerError
-from ansible_wisdom.ai.api.pipelines.common import Pipeline
-from ansible_wisdom.ai.api.pipelines.completion_stages.deserialise import (
+from ansible_ai_connect.ai.api.exceptions import InternalServerError
+from ansible_ai_connect.ai.api.pipelines.common import Pipeline
+from ansible_ai_connect.ai.api.pipelines.completion_stages.deserialise import (
     DeserializeStage,
 )
-from ansible_wisdom.ai.api.pipelines.completion_stages.inference import InferenceStage
-from ansible_wisdom.ai.api.pipelines.completion_stages.post_process import (
+from ansible_ai_connect.ai.api.pipelines.completion_stages.inference import (
+    InferenceStage,
+)
+from ansible_ai_connect.ai.api.pipelines.completion_stages.post_process import (
     PostProcessStage,
 )
-from ansible_wisdom.ai.api.pipelines.completion_stages.pre_process import (
+from ansible_ai_connect.ai.api.pipelines.completion_stages.pre_process import (
     PreProcessStage,
 )
-from ansible_wisdom.ai.api.pipelines.completion_stages.response import ResponseStage
+from ansible_ai_connect.ai.api.pipelines.completion_stages.response import ResponseStage
 
 from .completion_context import CompletionContext
 

--- a/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/api_telemetry_settings_views.py
@@ -23,14 +23,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.serializers import TelemetrySettingsRequestSerializer
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
-from ansible_wisdom.ai.api.views import InternalServerError, ServiceUnavailable
-from ansible_wisdom.users.signals import user_set_telemetry_settings
+from ansible_ai_connect.ai.api.serializers import TelemetrySettingsRequestSerializer
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.ai.api.views import InternalServerError, ServiceUnavailable
+from ansible_ai_connect.users.signals import user_set_telemetry_settings
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
+++ b/ansible_wisdom/ai/api/telemetry/tests/test_api_telemetry_settings_views.py
@@ -21,13 +21,13 @@ from django.urls import resolve, reverse
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.permissions import (
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.organizations.models import Organization
 
 
 @patch.object(IsOrganisationAdministrator, 'has_permission', return_value=True)
@@ -123,7 +123,7 @@ class TestTelemetrySettingsView(WisdomServiceAPITestCaseBase):
         self.assertFalse(r.data['optOut'])
 
         # Set settings
-        with self.assertLogs(logger='ansible_wisdom.users.signals', level='DEBUG') as signals:
+        with self.assertLogs(logger='ansible_ai_connect.users.signals', level='DEBUG') as signals:
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(
                     reverse('telemetry_settings'),

--- a/ansible_wisdom/ai/api/tests/test_api_timeout.py
+++ b/ansible_wisdom/ai/api/tests/test_api_timeout.py
@@ -22,10 +22,10 @@ from django.test import override_settings
 from django.urls import reverse
 from requests.exceptions import ReadTimeout
 
-from ansible_wisdom.ai.api.exceptions import ModelTimeoutException
-from ansible_wisdom.ai.api.model_client.grpc_client import GrpcClient
-from ansible_wisdom.ai.api.model_client.http_client import HttpClient
-from ansible_wisdom.ai.api.model_client.wca_client import WCAClient
+from ansible_ai_connect.ai.api.exceptions import ModelTimeoutException
+from ansible_ai_connect.ai.api.model_client.grpc_client import GrpcClient
+from ansible_ai_connect.ai.api.model_client.http_client import HttpClient
+from ansible_ai_connect.ai.api.model_client.wca_client import WCAClient
 
 from .test_views import WisdomServiceAPITestCaseBase
 

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -14,8 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api import formatter as fmtr
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.ai.api import formatter as fmtr
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 
 
 class AnsibleDumperTestCase(WisdomServiceLogAwareTestCase):

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, patch
 from django.test import override_settings
 from django.urls import reverse
 
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     BlockUserWithoutSeat,
     BlockUserWithoutSeatAndWCAReadyOrg,
@@ -26,9 +26,9 @@ from ansible_wisdom.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.test_utils import WisdomAppsBackendMocking
-from ansible_wisdom.users.tests.test_users import create_user
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.test_utils import WisdomAppsBackendMocking
+from ansible_ai_connect.users.tests.test_users import create_user
 
 
 # Hack to workaround bug introduced by

--- a/ansible_wisdom/ai/api/tests/test_serializers.py
+++ b/ansible_wisdom/ai/api/tests/test_serializers.py
@@ -23,7 +23,7 @@ from uuid import UUID
 from django.test import override_settings
 from rest_framework import serializers
 
-from ansible_wisdom.ai.api.serializers import (
+from ansible_ai_connect.ai.api.serializers import (
     CompletionRequestSerializer,
     ContentMatchRequestSerializer,
     ContentMatchSerializer,

--- a/ansible_wisdom/ai/api/utils/segment.py
+++ b/ansible_wisdom/ai/api/utils/segment.py
@@ -21,8 +21,8 @@ from django.utils import timezone
 from segment import analytics
 from segment.analytics import Client
 
-from ansible_wisdom.healthcheck.version_info import VersionInfo
-from ansible_wisdom.users.models import User
+from ansible_ai_connect.healthcheck.version_info import VersionInfo
+from ansible_ai_connect.users.models import User
 
 from .seated_users_allow_list import ALLOW_LIST
 

--- a/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/segment_analytics_telemetry.py
@@ -19,12 +19,12 @@ from django.conf import settings
 from packaging.version import InvalidVersion, Version
 from segment.analytics import Client
 
-from ansible_wisdom.ai.api.utils.segment import (
+from ansible_ai_connect.ai.api.utils.segment import (
     base_send_segment_event,
     send_segment_event,
 )
-from ansible_wisdom.organizations.models import Organization
-from ansible_wisdom.users.models import User
+from ansible_ai_connect.organizations.models import Organization
+from ansible_ai_connect.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/utils/tests/test_segment.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment.py
@@ -18,15 +18,15 @@ from unittest.mock import MagicMock, Mock
 from django.test import override_settings
 from segment import analytics
 
-from ansible_wisdom.ai.api.utils import segment_analytics_telemetry
-from ansible_wisdom.ai.api.utils.seated_users_allow_list import ALLOW_LIST
-from ansible_wisdom.ai.api.utils.segment import (
+from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
+from ansible_ai_connect.ai.api.utils.seated_users_allow_list import ALLOW_LIST
+from ansible_ai_connect.ai.api.utils.segment import (
     base_send_segment_event,
     redact_seated_users_data,
     send_segment_event,
     send_segment_group,
 )
-from ansible_wisdom.ai.api.utils.segment_analytics_telemetry import (
+from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     get_segment_analytics_client,
 )
 
@@ -199,11 +199,11 @@ class TestSegment(TestCase):
             send_segment_event(event, 'inlineSuggestionFeedback', user)
             self.assertEqual(
                 log.output[0],
-                'ERROR:ansible_wisdom.ai.api.utils.segment:It is not allowed to track'
+                'ERROR:ansible_ai_connect.ai.api.utils.segment:It is not allowed to track'
                 + ' inlineSuggestionFeedback events for seated users',
             )
 
-    @mock.patch("ansible_wisdom.ai.api.utils.segment.analytics.track")
+    @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.track")
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_send_segment_event_community_user(self, track_method):
@@ -221,7 +221,7 @@ class TestSegment(TestCase):
         self.assertEqual(argument['details'], 'Some details')
         self.assertEqual(argument['exception'], 'SomeException')
 
-    @mock.patch("ansible_wisdom.ai.api.utils.segment.analytics.track")
+    @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.track")
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_send_segment_event_seated_user(self, track_method):
@@ -297,7 +297,7 @@ class TestSegment(TestCase):
             redact_seated_users_data(test_data, ALLOW_LIST['trialExpired']), expected_result
         )
 
-    @mock.patch("ansible_wisdom.ai.api.utils.segment.analytics.group")
+    @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.group")
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_send_segment_group(self, group_method):
         user = Mock()

--- a/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -17,20 +17,20 @@ from unittest.mock import Mock, patch
 from attr import asdict
 from django.test import override_settings
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.ai.api.utils import segment_analytics_telemetry
-from ansible_wisdom.ai.api.utils.analytics_telemetry_model import (
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
+from ansible_ai_connect.ai.api.utils.analytics_telemetry_model import (
     AnalyticsProductFeedback,
     AnalyticsTelemetryEvents,
 )
-from ansible_wisdom.ai.api.utils.segment_analytics_telemetry import (
+from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     get_segment_analytics_client,
     meets_min_ansible_extension_version,
     send_segment_analytics_error_event,
     send_segment_analytics_event,
 )
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.organizations.models import Organization
 
 
 class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
@@ -81,12 +81,12 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
         self.assertFalse(meets_min_ansible_extension_version(None))
         self.assertFalse(meets_min_ansible_extension_version(''))
 
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.send_segment_event")
     def test_send_segment_analytics_error_value(self, send_segment_event):
         error = ValueError()
         self._assert_segment_analytics_error_sent(error, send_segment_event)
 
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.send_segment_event")
     def test_send_segment_analytics_error_type(self, send_segment_event):
         error = TypeError()
         self._assert_segment_analytics_error_sent(error, send_segment_event)
@@ -105,7 +105,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event(self, base_send_segment_event, LDClient):
         LDClient.return_value.variation.return_value = True
         analytics_event_object = AnalyticsProductFeedback(3, 123)
@@ -125,7 +125,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_requires_min_ansible_ext_version(
         self, base_send_segment_event, LDClient
     ):
@@ -139,7 +139,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.send_segment_event")
     def test_send_segment_analytics_event_error_validation(self, send_segment_event, LDClient):
         LDClient.return_value.variation.return_value = True
         payload = Mock(side_effect=ValueError)
@@ -160,7 +160,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
 
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_not_write_key(
         self, base_send_segment_event, LDClient
     ):
@@ -170,7 +170,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_user_no_seat(
         self, base_send_segment_event, LDClient
     ):
@@ -181,7 +181,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_no_telemetry_enabled(
         self, base_send_segment_event, LDClient
     ):
@@ -191,7 +191,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_no_org(self, base_send_segment_event, LDClient):
         LDClient.return_value.variation.return_value = True
         self.user.organization = None
@@ -200,7 +200,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY='dummy_key')
     @patch.object(feature_flags, 'LDClient')
-    @patch("ansible_wisdom.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_no_org_telemetry_enabled(
         self, base_send_segment_event, LDClient
     ):

--- a/ansible_wisdom/ai/api/utils/tests/test_timing.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_timing.py
@@ -14,7 +14,7 @@
 
 from unittest import TestCase, mock
 
-import ansible_wisdom.ai.api.utils.timing as timing
+import ansible_ai_connect.ai.api.utils.timing as timing
 
 
 class TestTiming(TestCase):
@@ -27,8 +27,8 @@ class TestTiming(TestCase):
                 pass
             self.assertCountEqual(
                 [
-                    f"INFO:ansible_wisdom.ai.api.utils.timing:[Timing]" f" {activity} start.",
-                    f"INFO:ansible_wisdom.ai.api.utils.timing:[Timing]"
+                    f"INFO:ansible_ai_connect.ai.api.utils.timing:[Timing]" f" {activity} start.",
+                    f"INFO:ansible_ai_connect.ai.api.utils.timing:[Timing]"
                     f" {activity} finished (Took -1.00s)",
                 ],
                 log.output,

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -36,8 +36,8 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ansible_wisdom.ai.api.aws.exceptions import WcaSecretManagerError
-from ansible_wisdom.ai.api.exceptions import (
+from ansible_ai_connect.ai.api.aws.exceptions import WcaSecretManagerError
+from ansible_ai_connect.ai.api.exceptions import (
     AttributionException,
     BaseWisdomAPIException,
     FeedbackInternalServerException,
@@ -55,7 +55,7 @@ from ansible_wisdom.ai.api.exceptions import (
     WcaUserTrialExpiredException,
     process_error_count,
 )
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaBadRequest,
     WcaCloudflareRejection,
     WcaEmptyResponse,
@@ -65,8 +65,8 @@ from ansible_wisdom.ai.api.model_client.exceptions import (
     WcaSuggestionIdCorrelationFailure,
     WcaUserTrialExpired,
 )
-from ansible_wisdom.ai.api.pipelines.completions import CompletionsPipeline
-from ansible_wisdom.users.models import User
+from ansible_ai_connect.ai.api.pipelines.completions import CompletionsPipeline
+from ansible_ai_connect.users.models import User
 
 from .. import search as ai_search
 from ..feature_flags import FeatureFlags, WisdomFlags

--- a/ansible_wisdom/ai/api/wca/api_key_views.py
+++ b/ansible_wisdom/ai/api/wca/api_key_views.py
@@ -29,18 +29,18 @@ from rest_framework.status import (
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
-from ansible_wisdom.ai.api.aws.exceptions import WcaSecretManagerError
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.api.model_client.exceptions import WcaTokenFailureApiKeyError
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.aws.exceptions import WcaSecretManagerError
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.model_client.exceptions import WcaTokenFailureApiKeyError
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.serializers import WcaKeyRequestSerializer
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
-from ansible_wisdom.ai.api.views import ServiceUnavailable
-from ansible_wisdom.users.signals import user_set_wca_api_key
+from ansible_ai_connect.ai.api.serializers import WcaKeyRequestSerializer
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.ai.api.views import ServiceUnavailable
+from ansible_ai_connect.users.signals import user_set_wca_api_key
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/api/wca/model_id_views.py
+++ b/ansible_wisdom/ai/api/wca/model_id_views.py
@@ -29,28 +29,28 @@ from rest_framework.status import (
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
-from ansible_wisdom.ai.api.aws.exceptions import WcaSecretManagerError
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.api.exceptions import (
+from ansible_ai_connect.ai.api.aws.exceptions import WcaSecretManagerError
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.exceptions import (
     ServiceUnavailable,
     WcaKeyNotFoundException,
     WcaUserTrialExpiredException,
 )
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
     WcaTokenFailure,
     WcaUserTrialExpired,
 )
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.serializers import WcaModelIdRequestSerializer
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
-from ansible_wisdom.users.signals import user_set_wca_model_id
+from ansible_ai_connect.ai.api.serializers import WcaModelIdRequestSerializer
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.users.signals import user_set_wca_model_id
 
 UNKNOWN_MODEL_ID = "Unknown"
 

--- a/ansible_wisdom/ai/api/wca/tests/test_api_key_views.py
+++ b/ansible_wisdom/ai/api/wca/tests/test_api_key_views.py
@@ -22,22 +22,22 @@ from django.utils import timezone
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
 
-import ansible_wisdom.ai.apps
-from ansible_wisdom.ai.api.aws.exceptions import WcaSecretManagerError
-from ansible_wisdom.ai.api.aws.wca_secret_manager import AWSSecretManager, Suffixes
-from ansible_wisdom.ai.api.model_client.exceptions import (
+import ansible_ai_connect.ai.apps
+from ansible_ai_connect.ai.api.aws.exceptions import WcaSecretManagerError
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import AWSSecretManager, Suffixes
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaTokenFailure,
     WcaTokenFailureApiKeyError,
 )
-from ansible_wisdom.ai.api.model_client.wca_client import WCAClient
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.model_client.wca_client import WCAClient
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.organizations.models import Organization
-from ansible_wisdom.test_utils import WisdomAppsBackendMocking
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.organizations.models import Organization
+from ansible_ai_connect.test_utils import WisdomAppsBackendMocking
 
 
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca")
@@ -48,11 +48,13 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def setUp(self):
         super().setUp()
         self.secret_manager_patcher = patch.object(
-            ansible_wisdom.ai.apps, 'AWSSecretManager', spec=AWSSecretManager
+            ansible_ai_connect.ai.apps, 'AWSSecretManager', spec=AWSSecretManager
         )
         self.secret_manager_patcher.start()
 
-        self.wca_client_patcher = patch.object(ansible_wisdom.ai.apps, 'WCAClient', spec=WCAClient)
+        self.wca_client_patcher = patch.object(
+            ansible_ai_connect.ai.apps, 'WCAClient', spec=WCAClient
+        )
         self.wca_client_patcher.start()
         apps.get_app_config('ai').ready()
 
@@ -175,7 +177,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
 
         # Set Key
         mock_wca_client.get_token.return_value = "token"
-        with self.assertLogs(logger='ansible_wisdom.users.signals', level='DEBUG') as signals:
+        with self.assertLogs(logger='ansible_ai_connect.users.signals', level='DEBUG') as signals:
             with self.assertLogs(logger='root', level='DEBUG') as log:
                 r = self.client.post(
                     reverse('wca_api_key'),
@@ -291,11 +293,13 @@ class TestWCAApiKeyValidatorView(WisdomAppsBackendMocking, WisdomServiceAPITestC
     def setUp(self):
         super().setUp()
         self.secret_manager_patcher = patch.object(
-            ansible_wisdom.ai.apps, 'AWSSecretManager', spec=AWSSecretManager
+            ansible_ai_connect.ai.apps, 'AWSSecretManager', spec=AWSSecretManager
         )
         self.secret_manager_patcher.start()
 
-        self.wca_client_patcher = patch.object(ansible_wisdom.ai.apps, 'WCAClient', spec=WCAClient)
+        self.wca_client_patcher = patch.object(
+            ansible_ai_connect.ai.apps, 'WCAClient', spec=WCAClient
+        )
         self.wca_client_patcher.start()
         apps.get_app_config('ai').ready()
 

--- a/ansible_wisdom/ai/api/wca/urls.py
+++ b/ansible_wisdom/ai/api/wca/urls.py
@@ -14,11 +14,11 @@
 
 from django.urls import path
 
-from ansible_wisdom.ai.api.wca.api_key_views import (
+from ansible_ai_connect.ai.api.wca.api_key_views import (
     WCAApiKeyValidatorView,
     WCAApiKeyView,
 )
-from ansible_wisdom.ai.api.wca.model_id_views import (
+from ansible_ai_connect.ai.api.wca.model_id_views import (
     WCAModelIdValidatorView,
     WCAModelIdView,
 )

--- a/ansible_wisdom/ai/apps.py
+++ b/ansible_wisdom/ai/apps.py
@@ -19,9 +19,9 @@ from ansible_risk_insight.scanner import Config
 from django.apps import AppConfig
 from django.conf import settings
 
-from ansible_wisdom.ansible_lint import lintpostprocessing
-from ansible_wisdom.ari import postprocessing
-from ansible_wisdom.users.authz_checker import AMSCheck, CIAMCheck, DummyCheck
+from ansible_ai_connect.ansible_lint import lintpostprocessing
+from ansible_ai_connect.ari import postprocessing
+from ansible_ai_connect.users.authz_checker import AMSCheck, CIAMCheck, DummyCheck
 
 from .api.aws.wca_secret_manager import AWSSecretManager, DummySecretManager
 from .api.model_client.dummy_client import DummyClient
@@ -38,7 +38,7 @@ UNINITIALIZED = None
 
 class AiConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "ansible_wisdom.ai"
+    name = "ansible_ai_connect.ai"
     model_mesh_client = None
     _ari_caller = UNINITIALIZED
     _seat_checker = UNINITIALIZED

--- a/ansible_wisdom/ai/feature_flags.py
+++ b/ansible_wisdom/ai/feature_flags.py
@@ -23,7 +23,7 @@ from ldclient.client import LDClient
 from ldclient.config import Config
 from ldclient.integrations import Files
 
-from ansible_wisdom.users.models import User
+from ansible_ai_connect.users.models import User
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ai/management/commands/_base_wca_command.py
+++ b/ansible_wisdom/ai/management/commands/_base_wca_command.py
@@ -17,7 +17,7 @@ from abc import abstractmethod
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import (
     AWSSecretManager,
     Suffixes,
     WcaSecretManagerError,

--- a/ansible_wisdom/ai/management/commands/_base_wca_delete_command.py
+++ b/ansible_wisdom/ai/management/commands/_base_wca_delete_command.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 
-from ansible_wisdom.ai.management.commands._base_wca_command import BaseWCACommand
+from ansible_ai_connect.ai.management.commands._base_wca_command import BaseWCACommand
 
 
 class BaseWCADeleteCommand(BaseWCACommand):

--- a/ansible_wisdom/ai/management/commands/_base_wca_get_command.py
+++ b/ansible_wisdom/ai/management/commands/_base_wca_get_command.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 
-from ansible_wisdom.ai.management.commands._base_wca_command import BaseWCACommand
+from ansible_ai_connect.ai.management.commands._base_wca_command import BaseWCACommand
 
 
 class BaseWCAGetCommand(BaseWCACommand):

--- a/ansible_wisdom/ai/management/commands/_base_wca_post_command.py
+++ b/ansible_wisdom/ai/management/commands/_base_wca_post_command.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 
-from ansible_wisdom.ai.management.commands._base_wca_command import BaseWCACommand
+from ansible_ai_connect.ai.management.commands._base_wca_command import BaseWCACommand
 
 
 class BaseWCAPostCommand(BaseWCACommand):

--- a/ansible_wisdom/ai/management/commands/delete_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/delete_wca_key.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_delete_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_delete_command import (
     BaseWCADeleteCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/delete_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/delete_wca_model_id.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_delete_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_delete_command import (
     BaseWCADeleteCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/get_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/get_wca_key.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_get_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_get_command import (
     BaseWCAGetCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/get_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/get_wca_model_id.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_get_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_get_command import (
     BaseWCAGetCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/post_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/post_wca_key.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_post_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_post_command import (
     BaseWCAPostCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/post_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/post_wca_model_id.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.management.commands._base_wca_post_command import (
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.management.commands._base_wca_post_command import (
     BaseWCAPostCommand,
 )
 

--- a/ansible_wisdom/ai/management/commands/tests/test_delete_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_delete_wca_key.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class DeleteWcaKeyCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class DeleteWcaKeyCommandTestCase(TestCase):
         ):
             call_command('delete_wca_key')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_key_deleted(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
 

--- a/ansible_wisdom/ai/management/commands/tests/test_delete_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_delete_wca_model_id.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class DeleteWcaModelIdCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class DeleteWcaModelIdCommandTestCase(TestCase):
         ):
             call_command('delete_wca_model_id')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_model_id_deleted(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
 

--- a/ansible_wisdom/ai/management/commands/tests/test_get_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_get_wca_key.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class GetWcaKeyCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class GetWcaKeyCommandTestCase(TestCase):
         ):
             call_command('get_wca_key')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_key_found(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.get_secret.return_value = {"CreatedDate": "xxx"}
@@ -42,7 +42,7 @@ class GetWcaKeyCommandTestCase(TestCase):
                 "API Key for orgId 'mock_org_id' found. Last updated: xxx", captured_output
             )
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_key_not_found(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.get_secret.return_value = None

--- a/ansible_wisdom/ai/management/commands/tests/test_get_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_get_wca_model_id.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class GetWcaModelIdCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class GetWcaModelIdCommandTestCase(TestCase):
         ):
             call_command('get_wca_model_id')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_model_id_found(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.get_secret.return_value = {"model_id": "mock_model_id", "CreatedDate": "xxx"}
@@ -43,7 +43,7 @@ class GetWcaModelIdCommandTestCase(TestCase):
                 captured_output,
             )
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_model_id_not_found(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.get_secret.return_value = None

--- a/ansible_wisdom/ai/management/commands/tests/test_post_wca_key.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_post_wca_key.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class PostWcaKeyCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class PostWcaKeyCommandTestCase(TestCase):
         ):
             call_command('post_wca_key')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_key_saved(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.save_secret.return_value = "mock_key_name"

--- a/ansible_wisdom/ai/management/commands/tests/test_post_wca_model_id.py
+++ b/ansible_wisdom/ai/management/commands/tests/test_post_wca_model_id.py
@@ -19,7 +19,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
 
 
 class PostWcaModelIdCommandTestCase(TestCase):
@@ -29,7 +29,7 @@ class PostWcaModelIdCommandTestCase(TestCase):
         ):
             call_command('post_wca_model_id')
 
-    @patch("ansible_wisdom.ai.management.commands._base_wca_command.AWSSecretManager")
+    @patch("ansible_ai_connect.ai.management.commands._base_wca_command.AWSSecretManager")
     def test_model_id_saved(self, mock_secret_manager):
         instance = mock_secret_manager.return_value
         instance.save_secret.return_value = "mock_model_id_name"

--- a/ansible_wisdom/ai/tests/test_apps.py
+++ b/ansible_wisdom/ai/tests/test_apps.py
@@ -16,14 +16,14 @@ from django.apps.config import AppConfig
 from django.test import override_settings
 from rest_framework.test import APITestCase
 
-from ansible_wisdom.ai.api.model_client.dummy_client import DummyClient
-from ansible_wisdom.ai.api.model_client.exceptions import (
+from ansible_ai_connect.ai.api.model_client.dummy_client import DummyClient
+from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaKeyNotFound,
     WcaUsernameNotFound,
 )
-from ansible_wisdom.ai.api.model_client.grpc_client import GrpcClient
-from ansible_wisdom.ai.api.model_client.http_client import HttpClient
-from ansible_wisdom.ai.api.model_client.wca_client import (
+from ansible_ai_connect.ai.api.model_client.grpc_client import GrpcClient
+from ansible_ai_connect.ai.api.model_client.http_client import HttpClient
+from ansible_ai_connect.ai.api.model_client.wca_client import (
     DummyWCAClient,
     WCAClient,
     WCAOnPremClient,
@@ -33,13 +33,13 @@ from ansible_wisdom.ai.api.model_client.wca_client import (
 class TestAiApp(APITestCase):
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='grpc')
     def test_grpc_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, GrpcClient)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca')
     def test_wca_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, WCAClient)
 
@@ -47,62 +47,62 @@ class TestAiApp(APITestCase):
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY='12345')
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca-onprem')
     def test_wca_on_prem_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, WCAOnPremClient)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY='12345')
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca-onprem')
     def test_wca_on_prem_client_missing_username(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         with self.assertRaises(WcaUsernameNotFound):
             app_config.ready()
 
     @override_settings(ANSIBLE_WCA_USERNAME='username')
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca-onprem')
     def test_wca_on_prem_client_missing_api_key(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         with self.assertRaises(WcaKeyNotFound):
             app_config.ready()
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='http')
     def test_http_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, HttpClient)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca-dummy')
     def test_wca_dummy_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, DummyWCAClient)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='dummy')
     def test_mock_client(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsInstance(app_config.model_mesh_client, DummyClient)
 
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     def test_enable_ari(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsNotNone(app_config.get_ari_caller())
 
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_disable_ari(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsNone(app_config.get_ari_caller())
 
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     def test_enable_ansible_lint(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsNotNone(app_config.get_ansible_lint_caller())
 
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=False)
     def test_disable_ansible_lint(self):
-        app_config = AppConfig.create('ansible_wisdom.ai')
+        app_config = AppConfig.create('ansible_ai_connect.ai')
         app_config.ready()
         self.assertIsNone(app_config.get_ansible_lint_caller())

--- a/ansible_wisdom/ai/tests/test_feature_flags.py
+++ b/ansible_wisdom/ai/tests/test_feature_flags.py
@@ -19,8 +19,8 @@ from django.conf import settings
 from django.test import override_settings
 from ldclient.config import Config
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
 
 
 class TestFeatureFlags(WisdomServiceAPITestCaseBase):

--- a/ansible_wisdom/ai/tests/test_search.py
+++ b/ansible_wisdom/ai/tests/test_search.py
@@ -22,7 +22,7 @@ from opensearchpy import AWSV4SignerAuth, OpenSearch
 from rest_framework.test import APITestCase
 from sentence_transformers import SentenceTransformer
 
-import ansible_wisdom.ai.search as search
+import ansible_ai_connect.ai.search as search
 
 
 class TestSearch(APITestCase):
@@ -87,8 +87,8 @@ class TestSearch(APITestCase):
                 self.assertIsNotNone(client)
                 self.assertIsNotNone(model)
 
-        with patch('ansible_wisdom.ai.search.client', self.DummyClient()):
-            with patch('ansible_wisdom.ai.search.model', self.DummySentenceTransformer()):
+        with patch('ansible_ai_connect.ai.search.client', self.DummyClient()):
+            with patch('ansible_ai_connect.ai.search.model', self.DummySentenceTransformer()):
                 ret = search.search(np.array(1))
                 self.assertIsNotNone(ret)
 
@@ -101,13 +101,13 @@ class TestSearch(APITestCase):
                 self.assertIsNone(model)
 
     def test_search(self):
-        with patch('ansible_wisdom.ai.search.client', self.DummyClient()):
-            with patch('ansible_wisdom.ai.search.model', self.DummySentenceTransformer()):
+        with patch('ansible_ai_connect.ai.search.client', self.DummyClient()):
+            with patch('ansible_ai_connect.ai.search.model', self.DummySentenceTransformer()):
                 ret = search.search(np.array(1))
                 self.assertIsNotNone(ret)
 
     def test_search_with_none_client(self):
-        with patch('ansible_wisdom.ai.search.client', None):
+        with patch('ansible_ai_connect.ai.search.client', None):
             with self.assertRaises(Exception):
                 search.search(np.array(1))
 

--- a/ansible_wisdom/ansible_lint/tests/test_lintpostprocessing.py
+++ b/ansible_wisdom/ansible_lint/tests/test_lintpostprocessing.py
@@ -17,11 +17,11 @@ import shutil
 import tempfile
 from multiprocessing.pool import ThreadPool
 
-from ansible_wisdom.ansible_lint.lintpostprocessing import (
+from ansible_ai_connect.ansible_lint.lintpostprocessing import (
     TEMP_TASK_FOLDER,
     AnsibleLintCaller,
 )
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 
 normal_sample_yaml = """---
 - name: Hello World Sample

--- a/ansible_wisdom/ari/postprocessing.py
+++ b/ansible_wisdom/ari/postprocessing.py
@@ -21,7 +21,7 @@ import yaml
 from ansible_risk_insight.scanner import ARIScanner
 from django.conf import settings
 
-from ansible_wisdom.ai.api import formatter as fmtr
+from ansible_ai_connect.ai.api import formatter as fmtr
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/ari/tests/test_postprocessing.py
+++ b/ansible_wisdom/ari/tests/test_postprocessing.py
@@ -14,7 +14,7 @@
 
 from django.test import TestCase
 
-from ansible_wisdom.ari import postprocessing
+from ansible_ai_connect.ari import postprocessing
 
 
 class ARICallerTestCase(TestCase):

--- a/ansible_wisdom/healthcheck/apps.py
+++ b/ansible_wisdom/healthcheck/apps.py
@@ -17,7 +17,7 @@ from health_check.plugins import plugin_dir
 
 
 class HealthCheckAppConfig(AppConfig):
-    name = 'ansible_wisdom.healthcheck'
+    name = 'ansible_ai_connect.healthcheck'
 
     def ready(self):
         from .backends import (

--- a/ansible_wisdom/healthcheck/backends.py
+++ b/ansible_wisdom/healthcheck/backends.py
@@ -18,10 +18,10 @@ from django.conf import settings
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import ServiceUnavailable
 
-import ansible_wisdom.ai.search
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.ai.api.model_client.wca_client import WcaInferenceFailure
-from ansible_wisdom.users.constants import FAUX_COMMERCIAL_USER_ORG_ID
+import ansible_ai_connect.ai.search
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.ai.api.model_client.wca_client import WcaInferenceFailure
+from ansible_ai_connect.users.constants import FAUX_COMMERCIAL_USER_ORG_ID
 
 ERROR_MESSAGE = "An error occurred"
 
@@ -212,7 +212,7 @@ class AttributionCheck(BaseLightspeedHealthCheck):
             return
 
         try:
-            attributions = ansible_wisdom.ai.search.search("aaa")["attributions"]
+            attributions = ansible_ai_connect.ai.search.search("aaa")["attributions"]
             assert len(attributions) > 0, "No attribution found"
         except Exception as e:
             self.add_error(ServiceUnavailable(ERROR_MESSAGE), e)

--- a/ansible_wisdom/healthcheck/tests/test_healthcheck.py
+++ b/ansible_wisdom/healthcheck/tests/test_healthcheck.py
@@ -28,15 +28,15 @@ from requests import Response
 from requests.exceptions import HTTPError
 from rest_framework.test import APITestCase
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.aws.wca_secret_manager import WcaSecretManagerError
-from ansible_wisdom.ai.api.model_client.wca_client import (
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import WcaSecretManagerError
+from ansible_ai_connect.ai.api.model_client.wca_client import (
     WCAClient,
     WcaInferenceFailure,
     WCAOnPremClient,
     WcaTokenFailure,
 )
-from ansible_wisdom.test_utils import (
+from ansible_ai_connect.test_utils import (
     WisdomAppsBackendMocking,
     WisdomServiceLogAwareTestCase,
 )
@@ -63,11 +63,11 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
         self.mock_wca_client_with(Mock(spec=WCAClient))
         self.mock_wca_onprem_client_with(Mock(spec=WCAOnPremClient))
         self.mock_seat_checker_with(Mock())
-        self.model_server_patcher = patch('ansible_wisdom.healthcheck.backends.requests')
+        self.model_server_patcher = patch('ansible_ai_connect.healthcheck.backends.requests')
         self.mock_requests = self.model_server_patcher.start()
         self.mock_requests.get = TestHealthCheck.mocked_requests_succeed
 
-        self.attribution_search_patcher = patch('ansible_wisdom.ai.search.search')
+        self.attribution_search_patcher = patch('ansible_ai_connect.ai.search.search')
         self.mock_ai_search = self.attribution_search_patcher.start()
         self.mock_ai_search.return_value = {"attributions": ["an attribution"]}
 
@@ -310,7 +310,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
 
             self.assertHealthCheckErrorInLog(
                 log,
-                'ansible_wisdom.ai.api.aws.exceptions.WcaSecretManagerError',
+                'ansible_ai_connect.ai.api.aws.exceptions.WcaSecretManagerError',
                 'secret-manager',
                 'unavailable: An error occurred',
             )
@@ -350,7 +350,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
 
             self.assertHealthCheckErrorInLog(
                 log,
-                'ansible_wisdom.ai.api.model_client.exceptions.WcaTokenFailure',
+                'ansible_ai_connect.ai.api.model_client.exceptions.WcaTokenFailure',
                 'wca',
                 {
                     "tokens": "unavailable: An error occurred",
@@ -381,7 +381,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
 
             self.assertHealthCheckErrorInLog(
                 log,
-                'ansible_wisdom.ai.api.model_client.exceptions.WcaTokenFailure',
+                'ansible_ai_connect.ai.api.model_client.exceptions.WcaTokenFailure',
                 'wca-onprem',
                 {
                     "tokens": "unavailable: An error occurred",
@@ -412,7 +412,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
 
             self.assertHealthCheckErrorInLog(
                 log,
-                'ansible_wisdom.ai.api.model_client.exceptions.WcaInferenceFailure',
+                'ansible_ai_connect.ai.api.model_client.exceptions.WcaInferenceFailure',
                 'wca',
                 {"tokens": "ok", "models": "unavailable: An error occurred"},
             )
@@ -440,7 +440,7 @@ class TestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLogAwa
 
             self.assertHealthCheckErrorInLog(
                 log,
-                'ansible_wisdom.ai.api.model_client.exceptions.WcaInferenceFailure',
+                'ansible_ai_connect.ai.api.model_client.exceptions.WcaInferenceFailure',
                 'wca-onprem',
                 {"tokens": "ok", "models": "unavailable: An error occurred"},
             )

--- a/ansible_wisdom/healthcheck/views.py
+++ b/ansible_wisdom/healthcheck/views.py
@@ -30,8 +30,8 @@ from health_check.views import MainView
 from rest_framework import permissions
 from rest_framework.views import APIView
 
-from ansible_wisdom.ai.feature_flags import FeatureFlags
-from ansible_wisdom.healthcheck.backends import BaseLightspeedHealthCheck
+from ansible_ai_connect.ai.feature_flags import FeatureFlags
+from ansible_ai_connect.healthcheck.backends import BaseLightspeedHealthCheck
 
 from .version_info import VersionInfo
 

--- a/ansible_wisdom/main/asgi.py
+++ b/ansible_wisdom/main/asgi.py
@@ -25,6 +25,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_wisdom.main.settings.development")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_ai_connect.main.settings.development")
 
 application = get_asgi_application()

--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -25,17 +25,17 @@ from rest_framework.exceptions import ErrorDetail
 from segment import analytics
 from social_django.middleware import SocialAuthExceptionMiddleware
 
-from ansible_wisdom.ai.api.utils import segment_analytics_telemetry
-from ansible_wisdom.ai.api.utils.analytics_telemetry_model import (
+from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
+from ansible_ai_connect.ai.api.utils.analytics_telemetry_model import (
     AnalyticsRecommendationGenerated,
     AnalyticsRecommendationTask,
     AnalyticsTelemetryEvents,
 )
-from ansible_wisdom.ai.api.utils.segment import send_segment_event
-from ansible_wisdom.ai.api.utils.segment_analytics_telemetry import (
+from ansible_ai_connect.ai.api.utils.segment import send_segment_event
+from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     send_segment_analytics_event,
 )
-from ansible_wisdom.healthcheck.version_info import VersionInfo
+from ansible_ai_connect.healthcheck.version_info import VersionInfo
 
 logger = logging.getLogger(__name__)
 version_info = VersionInfo()

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -94,15 +94,15 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "social_django",
-    "ansible_wisdom.users",
-    "ansible_wisdom.organizations",
-    "ansible_wisdom.ai",
+    "ansible_ai_connect.users",
+    "ansible_ai_connect.organizations",
+    "ansible_ai_connect.ai",
     "django_prometheus",
     "drf_spectacular",
     "django_extensions",
     "health_check",
     "health_check.db",
-    "ansible_wisdom.healthcheck",
+    "ansible_ai_connect.healthcheck",
     "oauth2_provider",
     'import_export',
 ]
@@ -119,7 +119,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
-    "ansible_wisdom.main.middleware.SegmentMiddleware",
+    "ansible_ai_connect.main.middleware.SegmentMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
     "csp.middleware.CSPMiddleware",
 ]
@@ -200,7 +200,7 @@ AUTHENTICATION_BACKENDS = [
         else "social_core.backends.github.GithubOAuth2"
     ),
     "social_core.backends.open_id_connect.OpenIdConnectAuth",
-    "ansible_wisdom.users.auth.AAPOAuth2",
+    "ansible_ai_connect.users.auth.AAPOAuth2",
     "django.contrib.auth.backends.ModelBackend",
     "oauth2_provider.backends.OAuth2Backend",
 ]
@@ -209,20 +209,20 @@ SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = [
     'terms_accepted',
 ]
 SOCIAL_AUTH_PIPELINE = (
-    'ansible_wisdom.users.pipeline.block_auth_users',
+    'ansible_ai_connect.users.pipeline.block_auth_users',
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',
     'social_core.pipeline.social_auth.social_user',
-    'ansible_wisdom.main.pipeline.remove_pii',
+    'ansible_ai_connect.main.pipeline.remove_pii',
     'social_core.pipeline.social_auth.auth_allowed',
-    'ansible_wisdom.users.pipeline.github_get_username',
+    'ansible_ai_connect.users.pipeline.github_get_username',
     # 'social_core.pipeline.user.get_username',
     'social_core.pipeline.user.create_user',
-    'ansible_wisdom.users.pipeline.redhat_organization',
+    'ansible_ai_connect.users.pipeline.redhat_organization',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.user.user_details',
-    'ansible_wisdom.users.pipeline.load_extra_data',
-    'ansible_wisdom.users.pipeline.terms_of_service',
+    'ansible_ai_connect.users.pipeline.load_extra_data',
+    'ansible_ai_connect.users.pipeline.terms_of_service',
 )
 
 # Wisdom Eng Team:
@@ -262,7 +262,7 @@ OAUTH2_PROVIDER = {
 #   django.db.utils.ProgrammingError: relation "users_user" does not exist
 #
 if sys.argv[1:2] not in [['migrate'], ['test']]:
-    INSTALLED_APPS.append('ansible_wisdom.wildcard_oauth2')
+    INSTALLED_APPS.append('ansible_ai_connect.wildcard_oauth2')
     OAUTH2_PROVIDER_APPLICATION_MODEL = 'wildcard_oauth2.Application'
 
 # OAUTH: todo
@@ -284,7 +284,7 @@ MULTI_TASK_MAX_REQUESTS = os.environ.get('MULTI_TASK_MAX_REQUESTS', 10)
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'DEFAULT_THROTTLE_CLASSES': ['ansible_wisdom.users.throttling.GroupSpecificThrottle'],
+    'DEFAULT_THROTTLE_CLASSES': ['ansible_ai_connect.users.throttling.GroupSpecificThrottle'],
     'DEFAULT_THROTTLE_RATES': {
         'user': COMPLETION_USER_RATE_THROTTLE,
         'test': "100000/minute",
@@ -297,17 +297,18 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
-    'EXCEPTION_HANDLER': 'ansible_wisdom.main.exception_handler.exception_handler_with_error_type',
+    'EXCEPTION_HANDLER': 'ansible_ai_connect.main.exception_handler.'
+    'exception_handler_with_error_type',
     'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
 }
 
 # Current RHSSOAuthentication implementation is incompatible with tech preview terms partial
 if not ANSIBLE_AI_ENABLE_TECH_PREVIEW:
     REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].insert(
-        -1, 'ansible_wisdom.users.auth.RHSSOAuthentication'
+        -1, 'ansible_ai_connect.users.auth.RHSSOAuthentication'
     )
 
-ROOT_URLCONF = "ansible_wisdom.main.urls"
+ROOT_URLCONF = "ansible_ai_connect.main.urls"
 
 LOGGING = {
     "version": 1,
@@ -331,7 +332,7 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
-        "ansible_wisdom.users.signals": {
+        "ansible_ai_connect.users.signals": {
             "handlers": ["console"],
             "level": "INFO",
             "propagate": False,
@@ -374,7 +375,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = "ansible_wisdom.main.wsgi.application"
+WSGI_APPLICATION = "ansible_ai_connect.main.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases

--- a/ansible_wisdom/main/settings/development.py
+++ b/ansible_wisdom/main/settings/development.py
@@ -43,7 +43,7 @@ if DEBUG:
             "social_django.middleware.SocialAuthExceptionMiddleware"
         )
         MIDDLEWARE[index] = (
-            "ansible_wisdom.main.middleware.WisdomSocialAuthExceptionMiddleware"  # noqa: F405
+            "ansible_ai_connect.main.middleware.WisdomSocialAuthExceptionMiddleware"  # noqa: F405
         )
 
 CSP_REPORT_ONLY = True

--- a/ansible_wisdom/main/tests/test_cache_per_user.py
+++ b/ansible_wisdom/main/tests/test_cache_per_user.py
@@ -21,7 +21,7 @@ from django.views.generic.base import View
 from rest_framework.request import HttpRequest, Request
 from rest_framework.response import Response
 
-from ansible_wisdom.main.cache.cache_per_user import cache_per_user
+from ansible_ai_connect.main.cache.cache_per_user import cache_per_user
 
 
 class TestCachePerUser(TestCase):

--- a/ansible_wisdom/main/tests/test_console_views.py
+++ b/ansible_wisdom/main/tests/test_console_views.py
@@ -20,14 +20,14 @@ from django.urls import resolve, reverse
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.permissions import (
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.organizations.models import Organization
 
 
 class TestConsoleView(WisdomServiceAPITestCaseBase):

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -24,8 +24,8 @@ from django.test import override_settings
 from django.urls import reverse
 from segment import analytics
 
-from ansible_wisdom.ai.api.exceptions import PostprocessException
-from ansible_wisdom.ai.api.tests.test_views import (
+from ansible_ai_connect.ai.api.exceptions import PostprocessException
+from ansible_ai_connect.ai.api.tests.test_views import (
     MockedMeshClient,
     WisdomServiceAPITestCaseBase,
 )
@@ -137,7 +137,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
 
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @patch(
-        'ansible_wisdom.ai.api.pipelines.completion_stages.pre_process.fmtr.preprocess',
+        'ansible_ai_connect.ai.api.pipelines.completion_stages.pre_process.fmtr.preprocess',
         side_effect=Exception,
     )
     def test_preprocess_error(self, preprocess):
@@ -150,7 +150,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
         with self.assertLogs(logger='root', level='DEBUG') as log:
             self.client.post(reverse('completions'), payload, format='json')
             self.assertInLog(
-                "ERROR:ansible_wisdom.ai.api.pipelines.completion_stages.pre_process:failed"
+                "ERROR:ansible_ai_connect.ai.api.pipelines.completion_stages.pre_process:failed"
                 " to preprocess:",
                 log,
             )

--- a/ansible_wisdom/main/tests/test_pipeline.py
+++ b/ansible_wisdom/main/tests/test_pipeline.py
@@ -14,7 +14,7 @@
 
 from unittest import TestCase
 
-import ansible_wisdom.main.pipeline as pipeline
+import ansible_ai_connect.main.pipeline as pipeline
 
 
 class TestPipeline(TestCase):

--- a/ansible_wisdom/main/tests/test_settings.py
+++ b/ansible_wisdom/main/tests/test_settings.py
@@ -20,16 +20,18 @@ import django.conf
 from django.test import SimpleTestCase
 from oauth2_provider.settings import oauth2_settings
 
-import ansible_wisdom.main.settings.base
+import ansible_ai_connect.main.settings.base
 
 
 class TestSettings(SimpleTestCase):
     @classmethod
     def reload_settings(cls):
         module_name = os.getenv("DJANGO_SETTINGS_MODULE")
-        settings_module = importlib.import_module(module_name)
+        settings_module = importlib.import_module(
+            module_name.replace("ansible_wisdom.", "ansible_ai_connect.")
+        )
 
-        importlib.reload(ansible_wisdom.main.settings.base)
+        importlib.reload(ansible_ai_connect.main.settings.base)
         importlib.reload(settings_module)
         importlib.reload(django.conf)
         from django.conf import settings

--- a/ansible_wisdom/main/tests/test_urls.py
+++ b/ansible_wisdom/main/tests/test_urls.py
@@ -17,13 +17,13 @@ from re import compile
 
 from django.test import Client, TestCase, override_settings
 
-import ansible_wisdom.main.urls
+import ansible_ai_connect.main.urls
 
 
 class TestUrls(TestCase):
     @override_settings(DEBUG=True)
     def test_urlpatterns(self):
-        reload(ansible_wisdom.main.urls)
+        reload(ansible_ai_connect.main.urls)
         routes = [
             'api/schema/',
             'api/schema/swagger-ui/',
@@ -32,7 +32,8 @@ class TestUrls(TestCase):
         r = compile("api/schema/")
         patterns = list(
             filter(
-                r.match, [str(pattern.pattern) for pattern in ansible_wisdom.main.urls.urlpatterns]
+                r.match,
+                [str(pattern.pattern) for pattern in ansible_ai_connect.main.urls.urlpatterns],
             )
         )
         self.assertCountEqual(routes, patterns)
@@ -50,7 +51,8 @@ class TestUrls(TestCase):
         r = compile("api/v0/telemetry/")
         patterns = list(
             filter(
-                r.match, [str(pattern.pattern) for pattern in ansible_wisdom.main.urls.urlpatterns]
+                r.match,
+                [str(pattern.pattern) for pattern in ansible_ai_connect.main.urls.urlpatterns],
             )
         )
         self.assertEqual(1, len(patterns))

--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -19,14 +19,14 @@ from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
-from ansible_wisdom.main.settings.base import SOCIAL_AUTH_OIDC_KEY
-from ansible_wisdom.main.views import LoginView
-from ansible_wisdom.users.constants import (
+from ansible_ai_connect.main.settings.base import SOCIAL_AUTH_OIDC_KEY
+from ansible_ai_connect.main.views import LoginView
+from ansible_ai_connect.users.constants import (
     USER_SOCIAL_AUTH_PROVIDER_AAP,
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
-from ansible_wisdom.users.tests.test_users import create_user
+from ansible_ai_connect.users.tests.test_users import create_user
 
 
 def create_user_with_provider(user_provider):

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -38,15 +38,15 @@ from drf_spectacular.views import (
 )
 from oauth2_provider.urls import app_name, base_urlpatterns
 
-from ansible_wisdom.ai.api.telemetry.api_telemetry_settings_views import (
+from ansible_ai_connect.ai.api.telemetry.api_telemetry_settings_views import (
     TelemetrySettingsView,
 )
-from ansible_wisdom.healthcheck.views import (
+from ansible_ai_connect.healthcheck.views import (
     WisdomServiceHealthView,
     WisdomServiceLivenessProbeView,
 )
-from ansible_wisdom.main.views import ConsoleView, LoginView, LogoutView
-from ansible_wisdom.users.views import (
+from ansible_ai_connect.main.views import ConsoleView, LoginView, LogoutView
+from ansible_ai_connect.users.views import (
     CurrentUserView,
     HomeView,
     TermsOfService,
@@ -61,7 +61,7 @@ urlpatterns = [
     path('', include('social_django.urls', namespace='social')),
     path('', include('django_prometheus.urls')),
     path('admin/', admin.site.urls),
-    path(f'api/{WISDOM_API_VERSION}/ai/', include("ansible_wisdom.ai.api.urls")),
+    path(f'api/{WISDOM_API_VERSION}/ai/', include("ansible_ai_connect.ai.api.urls")),
     path(f'api/{WISDOM_API_VERSION}/me/', CurrentUserView.as_view(), name='me'),
     path('unauthorized/', UnauthorizedView.as_view(), name='unauthorized'),
     path('check/status/', WisdomServiceHealthView.as_view(), name='health_check'),
@@ -82,7 +82,7 @@ urlpatterns = [
 
 if settings.DEBUG or settings.DEPLOYMENT_MODE == "saas":
     urlpatterns += [
-        path(f'api/{WISDOM_API_VERSION}/wca/', include('ansible_wisdom.ai.api.wca.urls')),
+        path(f'api/{WISDOM_API_VERSION}/wca/', include('ansible_ai_connect.ai.api.wca.urls')),
         path('console/', ConsoleView.as_view(), name='console'),
         path('console/<slug:slug1>/', ConsoleView.as_view(), name='console'),
         path('console/<slug:slug1>/<slug:slug2>/', ConsoleView.as_view(), name='console'),

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -23,13 +23,13 @@ from django.http import HttpResponseRedirect
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
 
-from ansible_wisdom.ai.api.permissions import (
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.main.base_views import ProtectedTemplateView
-from ansible_wisdom.main.settings.base import SOCIAL_AUTH_OIDC_KEY
+from ansible_ai_connect.main.base_views import ProtectedTemplateView
+from ansible_ai_connect.main.settings.base import SOCIAL_AUTH_OIDC_KEY
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/main/wsgi.py
+++ b/ansible_wisdom/main/wsgi.py
@@ -37,6 +37,6 @@ try:
 except ImportError:
     pass  # not running in uwsgi
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_wisdom.main.settings.development")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_ai_connect.main.settings.development")
 
 application = get_wsgi_application()

--- a/ansible_wisdom/manage.py
+++ b/ansible_wisdom/manage.py
@@ -21,7 +21,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_wisdom.main.settings.development")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ansible_ai_connect.main.settings.development")
 
     try:
         from django.core.management import execute_from_command_line

--- a/ansible_wisdom/organizations/models.py
+++ b/ansible_wisdom/organizations/models.py
@@ -40,7 +40,7 @@ class Organization(models.Model):
     @cached_property
     def is_subscription_check_should_be_bypassed(self) -> bool:
         # Avoid circular dependency issue with lazy import
-        from ansible_wisdom.ai.feature_flags import WisdomFlags
+        from ansible_ai_connect.ai.feature_flags import WisdomFlags
 
         try:
             return self.__make_organization_request_to_launchdarkly(
@@ -55,7 +55,7 @@ class Organization(models.Model):
             return False
 
         # Avoid circular dependency issue with lazy import
-        from ansible_wisdom.ai.feature_flags import FeatureFlags
+        from ansible_ai_connect.ai.feature_flags import FeatureFlags
 
         feature_flags = FeatureFlags()
         return feature_flags.check_flag(

--- a/ansible_wisdom/organizations/tests/test_organizations.py
+++ b/ansible_wisdom/organizations/tests/test_organizations.py
@@ -16,8 +16,8 @@ from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.organizations.models import Organization
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.organizations.models import Organization
 
 
 class TestOrganization(TestCase):

--- a/ansible_wisdom/users/apps.py
+++ b/ansible_wisdom/users/apps.py
@@ -17,7 +17,7 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'ansible_wisdom.users'
+    name = 'ansible_ai_connect.users'
 
     def ready(self) -> None:
-        import ansible_wisdom.users.signals  # noqa: F401
+        import ansible_ai_connect.users.signals  # noqa: F401

--- a/ansible_wisdom/users/auth.py
+++ b/ansible_wisdom/users/auth.py
@@ -21,7 +21,7 @@ from social_core.backends.oauth import BaseOAuth2
 from social_django.models import UserSocialAuth
 from social_django.utils import load_backend, load_strategy
 
-from ansible_wisdom.users.constants import (
+from ansible_ai_connect.users.constants import (
     RHSSO_LIGHTSPEED_SCOPE,
     USER_SOCIAL_AUTH_PROVIDER_AAP,
 )

--- a/ansible_wisdom/users/management/commands/createtoken.py
+++ b/ansible_wisdom/users/management/commands/createtoken.py
@@ -23,7 +23,7 @@ from django.utils.timezone import now
 from oauth2_provider.models import AccessToken
 from oauthlib.common import generate_token
 
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.organizations.models import Organization
 
 
 class Command(BaseCommand):

--- a/ansible_wisdom/users/management/commands/test_createtoken.py
+++ b/ansible_wisdom/users/management/commands/test_createtoken.py
@@ -22,7 +22,7 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 from oauth2_provider.models import AccessToken
 
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.organizations.models import Organization
 
 
 class TestCreateToken(TestCase):

--- a/ansible_wisdom/users/migrations/0009_user_organization.py
+++ b/ansible_wisdom/users/migrations/0009_user_organization.py
@@ -3,7 +3,7 @@
 import django.db.models.deletion
 from django.db import migrations
 
-import ansible_wisdom.users.models
+import ansible_ai_connect.users.models
 
 
 class Migration(migrations.Migration):
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='user',
             name='organization',
-            field=ansible_wisdom.users.models.NonClashingForeignKey(
+            field=ansible_ai_connect.users.models.NonClashingForeignKey(
                 default=None,
                 null=True,
                 on_delete=django.db.models.deletion.CASCADE,

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -23,8 +23,8 @@ from django.utils.functional import cached_property
 from django_deprecate_fields import deprecate_field
 from django_prometheus.models import ExportModelOperationsMixin
 
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.organizations.models import Organization
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.organizations.models import Organization
 
 from .constants import (
     FAUX_COMMERCIAL_USER_ORG_ID,

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -24,9 +24,9 @@ from social_core.pipeline.partial import partial
 from social_core.pipeline.user import get_username
 from social_django.models import UserSocialAuth
 
-from ansible_wisdom.ai.api.utils.segment import send_segment_group
-from ansible_wisdom.organizations.models import Organization
-from ansible_wisdom.users.constants import RHSSO_LIGHTSPEED_SCOPE
+from ansible_ai_connect.ai.api.utils.segment import send_segment_group
+from ansible_ai_connect.organizations.models import Organization
+from ansible_ai_connect.users.constants import RHSSO_LIGHTSPEED_SCOPE
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_wisdom/users/tests/test_auth.py
+++ b/ansible_wisdom/users/tests/test_auth.py
@@ -26,9 +26,9 @@ from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_django.models import UserSocialAuth
 from social_django.utils import load_strategy
 
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.auth import AAPOAuth2, RHSSOAuthentication
-from ansible_wisdom.users.constants import RHSSO_LIGHTSPEED_SCOPE
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.users.auth import AAPOAuth2, RHSSOAuthentication
+from ansible_ai_connect.users.constants import RHSSO_LIGHTSPEED_SCOPE
 
 
 class DummyRHBackend(OpenIdConnectAuth):
@@ -97,7 +97,7 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
             user=self.rh_user, provider="oidc", uid=str(uuid4())
         )
 
-    @patch('ansible_wisdom.users.auth.load_backend')
+    @patch('ansible_ai_connect.users.auth.load_backend')
     def test_authenticate_returns_existing_user(self, mock_load_backend):
         backend = DummyRHBackend()
         mock_load_backend.return_value = backend
@@ -112,7 +112,7 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
 
         self.assertEqual(user.id, self.rh_user.id)
 
-    @patch('ansible_wisdom.users.auth.load_backend')
+    @patch('ansible_ai_connect.users.auth.load_backend')
     def test_authenticate_succeeds_with_extra_scopes(self, mock_load_backend):
         backend = DummyRHBackend()
         mock_load_backend.return_value = backend
@@ -128,7 +128,7 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
 
         self.assertEqual(user.id, self.rh_user.id)
 
-    @patch('ansible_wisdom.users.auth.load_backend')
+    @patch('ansible_ai_connect.users.auth.load_backend')
     def test_authenticate_returns_none_on_invalid_scope(self, mock_load_backend):
         backend = DummyRHBackend()
         mock_load_backend.return_value = backend
@@ -160,7 +160,7 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
         self.assertIsNone(self.authentication.authenticate(request))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
-    @patch('ansible_wisdom.users.auth.load_backend')
+    @patch('ansible_ai_connect.users.auth.load_backend')
     def test_authenticate_creates_new_user(self, mock_load_backend):
         backend = DummyRHBackend()
         backend.strategy = load_strategy()
@@ -181,7 +181,7 @@ class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
         self.assertEqual(user.external_username, 'joe-new-user')
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
-    @patch('ansible_wisdom.users.auth.load_backend')
+    @patch('ansible_ai_connect.users.auth.load_backend')
     def test_authenticate_outdated_payload(self, mock_load_backend):
         backend = DummyRHBackend()
         backend.strategy = load_strategy()

--- a/ansible_wisdom/users/tests/test_authz_checker.py
+++ b/ansible_wisdom/users/tests/test_authz_checker.py
@@ -24,8 +24,8 @@ from django.test import TestCase, override_settings
 from prometheus_client import Counter, Histogram
 from requests.exceptions import HTTPError
 
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.authz_checker import (
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.users.authz_checker import (
     AMSCheck,
     CIAMCheck,
     DummyCheck,

--- a/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
+++ b/ansible_wisdom/users/tests/test_command_fix_users_with_two_sso_providers.py
@@ -20,8 +20,8 @@ from uuid import uuid4
 from django.contrib.auth import get_user_model
 from social_django.models import UserSocialAuth
 
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.management.commands.fix_users_with_two_sso_providers import (
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.users.management.commands.fix_users_with_two_sso_providers import (
     Command,
 )
 

--- a/ansible_wisdom/users/tests/test_pipeline.py
+++ b/ansible_wisdom/users/tests/test_pipeline.py
@@ -23,9 +23,9 @@ from django.contrib.auth import get_user_model
 from django.test import override_settings
 from social_django.models import UserSocialAuth
 
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.constants import RHSSO_LIGHTSPEED_SCOPE
-from ansible_wisdom.users.pipeline import load_extra_data, redhat_organization
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.users.constants import RHSSO_LIGHTSPEED_SCOPE
+from ansible_ai_connect.users.pipeline import load_extra_data, redhat_organization
 
 
 def build_access_token(private_key, payload):
@@ -235,7 +235,7 @@ class TestExtraData(WisdomServiceLogAwareTestCase):
                 },
             )
         }
-        with self.assertLogs(logger='ansible_wisdom.users.pipeline', level='ERROR') as log:
+        with self.assertLogs(logger='ansible_ai_connect.users.pipeline', level='ERROR') as log:
             answer = redhat_organization(
                 backend=DummyRHBackend(public_key=self.jwk_public_key),
                 user=self.rh_user,

--- a/ansible_wisdom/users/tests/test_signals.py
+++ b/ansible_wisdom/users/tests/test_signals.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_wisdom.test_utils import WisdomServiceLogAwareTestCase
-from ansible_wisdom.users.signals import _obfuscate
+from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
+from ansible_ai_connect.users.signals import _obfuscate
 
 
 class TestSignals(WisdomServiceLogAwareTestCase):

--- a/ansible_wisdom/users/tests/test_throttling.py
+++ b/ansible_wisdom/users/tests/test_throttling.py
@@ -14,8 +14,8 @@
 
 from django.conf import settings
 
-from ansible_wisdom.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
-from ansible_wisdom.ai.api.views import Attributions, Completions, Feedback
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.views import Attributions, Completions, Feedback
 
 from ..throttling import GroupSpecificThrottle
 

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -31,25 +31,25 @@ from prometheus_client.parser import text_string_to_metric_families
 from social_core.exceptions import AuthCanceled
 from social_django.models import UserSocialAuth
 
-import ansible_wisdom.ai.feature_flags as feature_flags
-from ansible_wisdom.ai.api.permissions import (
+import ansible_ai_connect.ai.feature_flags as feature_flags
+from ansible_ai_connect.ai.api.permissions import (
     AcceptedTermsPermission,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_wisdom.ai.api.tests.test_views import APITransactionTestCase
-from ansible_wisdom.organizations.models import Organization
-from ansible_wisdom.test_utils import (
+from ansible_ai_connect.ai.api.tests.test_views import APITransactionTestCase
+from ansible_ai_connect.organizations.models import Organization
+from ansible_ai_connect.test_utils import (
     WisdomAppsBackendMocking,
     WisdomServiceLogAwareTestCase,
 )
-from ansible_wisdom.users.constants import (
+from ansible_ai_connect.users.constants import (
     FAUX_COMMERCIAL_USER_ORG_ID,
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
-from ansible_wisdom.users.pipeline import _terms_of_service
-from ansible_wisdom.users.views import TermsOfService
+from ansible_ai_connect.users.pipeline import _terms_of_service
+from ansible_ai_connect.users.views import TermsOfService
 
 
 def create_user(
@@ -114,7 +114,7 @@ class TestUsers(APITransactionTestCase, WisdomServiceLogAwareTestCase):
         self.assertIn('You are currently not logged in.', str(r.content))
 
     def test_users_audit_logging(self):
-        with self.assertLogs(logger='ansible_wisdom.users.signals', level='INFO') as log:
+        with self.assertLogs(logger='ansible_ai_connect.users.signals', level='INFO') as log:
             self.client.login(username=self.user.username, password=self.password)
             self.assertInLog('LOGIN successful', log)
 

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -22,14 +22,14 @@ from django.conf import settings
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
-import ansible_wisdom.users.models
-from ansible_wisdom.ai.api.tests.test_views import APITransactionTestCase
-from ansible_wisdom.test_utils import WisdomAppsBackendMocking
-from ansible_wisdom.users.constants import (
+import ansible_ai_connect.users.models
+from ansible_ai_connect.ai.api.tests.test_views import APITransactionTestCase
+from ansible_ai_connect.test_utils import WisdomAppsBackendMocking
+from ansible_ai_connect.users.constants import (
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
-from ansible_wisdom.users.tests.test_users import create_user
+from ansible_ai_connect.users.tests.test_users import create_user
 
 
 def bypass_init(*args, **kwargs):
@@ -75,8 +75,8 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         self.user.delete()
         super().tearDown()
 
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", True)
     def test_rh_admin_with_seat_and_no_secret(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -87,8 +87,8 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", False)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_admin_without_seat_and_with_no_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -103,8 +103,8 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", False)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_admin_without_seat_and_with_no_secret_no_sub_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -115,8 +115,8 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "The Project Name Technical Preview is no longer available")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", True)
     def test_rh_admin_with_a_seat_and_with_secret(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -142,8 +142,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_user_without_seat_and_no_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -160,8 +160,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
     @override_settings(WCA_SECRET_DUMMY_SECRETS='valid')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_user_without_seat_with_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -178,8 +178,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_user_without_seat_and_no_secret_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -191,8 +191,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "The Project Name Technical Preview is no longer available")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", True)
     def test_rh_user_with_a_seat_and_no_secret(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -202,8 +202,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", True)
     def test_rh_user_with_a_seat_and_with_secret(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -213,8 +213,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", True)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_rh_user_with_no_seat_and_with_secret(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -225,8 +225,8 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
-    @patch.object(ansible_wisdom.users.models.User, "rh_org_has_subscription", False)
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_user_without_seat_and_with_secret_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
@@ -242,7 +242,7 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         self.password = "somepassword"
 
     @override_settings(COMMERCIAL_DOCUMENTATION_URL="https://official_docs")
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", True)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", True)
     def test_docs_url_for_seated_user(self):
         self.user = create_user(
             password=self.password,
@@ -255,7 +255,7 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(DOCUMENTATION_URL="https://community_docs")
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_docs_url_for_unseated_user_with_tech_preview(self):
         self.user = create_user(
             password=self.password,
@@ -269,7 +269,7 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
-    @patch.object(ansible_wisdom.users.models.User, "rh_user_has_seat", False)
+    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
     def test_docs_url_for_unseated_user_without_tech_preview(self):
         self.user = create_user(
             password=self.password,

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -27,9 +27,11 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from social_django.utils import load_strategy
 
-from ansible_wisdom.ai.api.aws.exceptions import WcaSecretManagerMissingCredentialsError
-from ansible_wisdom.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_wisdom.main.cache.cache_per_user import cache_per_user
+from ansible_ai_connect.ai.api.aws.exceptions import (
+    WcaSecretManagerMissingCredentialsError,
+)
+from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
+from ansible_ai_connect.main.cache.cache_per_user import cache_per_user
 
 from .serializers import UserResponseSerializer
 

--- a/ansible_wisdom/wildcard_oauth2/apps.py
+++ b/ansible_wisdom/wildcard_oauth2/apps.py
@@ -24,5 +24,5 @@ class WildcardOauth2ApplicationConfig(AppConfig):
     Configures wildcard_oauth2 as a Django app plugin
     """
 
-    name = 'ansible_wisdom.wildcard_oauth2'
+    name = 'ansible_ai_connect.wildcard_oauth2'
     verbose_name = "Wildcard OAuth2 Application"

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -34,6 +34,7 @@ COPY setup.cfg /var/www/ansible-wisdom-service/setup.cfg
 COPY pyproject.toml /var/www/ansible-wisdom-service/pyproject.toml
 COPY README.md /var/www/ansible-wisdom-service/README.md
 COPY ansible_wisdom /var/www/ansible-wisdom-service/ansible_wisdom
+RUN  ln -s /var/www/ansible-wisdom-service/ansible_wisdom /var/www/ansible-wisdom-service/ansible_ai_connect
 
 # Compile Python/Django application
 RUN /usr/bin/python3.11 -m pip --no-cache-dir install supervisor


### PR DESCRIPTION
Continue the transition from `ansible_wisdom` to `ansible_ai_connect`.

Also add a missing symlink in the container to be able to continue to resolve the two package names.

Another PR are coming to:

- handle the situation where `DJANGO_SETTINGS_MODULE` is using the old package name
- rename the `ansible_wisdom` directory and remove it from the distribution
- change the way we trigger the unit-tests (`wisdom-manage test ansible_wisdom` -> `wisdom-manage test ansible_ai_connect`)