### PR TITLE
AnonymousUser causes AttributeError at /logout

### DIFF
--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -66,6 +66,9 @@ class LogoutTest(TestCase):
         response = self.client.get(reverse('logout'))
         self.assertEqual(response.url, 'http://aap/api/logout/?next=http://testserver/')
 
+    def test_logout_without_login(self):
+        self.client.get(reverse('logout'))
+
 
 class AlreadyAuth(TestCase):
     def test_login(self):

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -18,6 +18,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import views as auth_views
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.permissions import IsAuthenticated
@@ -54,6 +55,9 @@ class LogoutView(auth_views.LogoutView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_next_page(self, request):
+        if isinstance(request.user, AnonymousUser):
+            return None
+
         next_url = request.build_absolute_uri("/")
         if request.user.is_oidc_user():
             return (


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: no Jira issue
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
When the /logout endpoint is called without login, an AttributeError is thrown and it is logged as
```
AttributeError: 'AnonymousUser' object has no attribute 'is_oidc_user'
```
In the production environment, such lines are logged 47 times in the last 30 days. If the request was issued by
an anonymous user, the /logout endpoint does not have to do anything and no need to check if the user
is an OIDC user or not.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
A test case is included in this PR.

### Steps to test
1. Pull down the PR
2. Start the service locally
3. Call /logout endpoint from web browser and verify if no exception recorded on the console.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See the Steps to test section above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
