### PR TITLE
code_coverage: use the ansible_ai_connect package

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -21,7 +21,7 @@ jobs:
       ANSIBLE_AI_DATABASE_PASSWORD: wisdom
       ANSIBLE_AI_DATABASE_USER: wisdom
       ARI_KB_PATH: /etc/ari/kb/
-      DJANGO_SETTINGS_MODULE: ansible_wisdom.main.settings.development
+      DJANGO_SETTINGS_MODULE: ansible_ai_connect.main.settings.development
       ENABLE_ARI_POSTPROCESS: False
       ENABLE_ANSIBLE_LINT_POSTPROCESS: True
       PYTHONUNBUFFERED: 1
@@ -73,7 +73,7 @@ jobs:
 
     - name: Running Unit Tests (Python)
       run: |
-        coverage run --rcfile=setup.cfg -m ansible_wisdom.manage test ansible_wisdom
+        coverage run --rcfile=setup.cfg -m ansible_ai_connect.manage test ansible_ai_connect
         coverage xml
         coverage report --rcfile=setup.cfg --format=markdown > code-coverage-results.md
 


### PR DESCRIPTION
Use the `ansible_ai_connect` package instead of `ansible_wisdom`, which
is deprecated.
