### PR TITLE
AAP-23914: Lightspeed Telemetry :: Populate FQCN information, even if post-processing is disabled

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -396,6 +396,8 @@ def parse_module_from_prediction(re, prediction):
 
 
 def get_fqcn_or_module_from_prediction(prediction):
+    if prediction is None:
+        return None
     fqcn = get_fqcn_from_prediction(prediction)
     if fqcn is None:
         fqcn = get_module_from_prediction(prediction)

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -364,24 +364,26 @@ def completion_post_process(context: CompletionContext):
             task["prediction"] = post_processed_predictions["predictions"][0]
 
         fqcn_module = None
-
         if ari_results is not None:
             ari_result = ari_results[i]
             fqcn_module = ari_result["fqcn_module"]
-
-        if fqcn_module is None or fqcn_module == "":
-            # In case the module is not part of the collections, ARI does not handle it.
-            # This way, parsing the module from the prediction instead.
-            fqcn_module = fmtr.get_fqcn_or_module_from_prediction(task["prediction"])
-
-        if fqcn_module is not None:
-            task["module"] = fqcn_module
-            index = fqcn_module.rfind(".")
-            if index != -1:
-                task["collection"] = fqcn_module[:index]
+        post_process_task(fqcn_module, task)
 
     context.task_results = tasks
     context.post_processed_predictions = post_processed_predictions
+
+
+def post_process_task(fqcn_module, task):
+    if fqcn_module is None or fqcn_module == "":
+        # In case the module is not part of the collections, ARI does not handle it.
+        # This way, parsing the module from the prediction instead.
+        fqcn_module = fmtr.get_fqcn_or_module_from_prediction(task["prediction"])
+
+    if fqcn_module is not None:
+        task["module"] = fqcn_module
+        index = fqcn_module.rfind(".")
+        if index != -1:
+            task["collection"] = fqcn_module[:index]
 
 
 class PostProcessStage(PipelineElement):

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -362,18 +362,23 @@ def completion_post_process(context: CompletionContext):
             )
         else:
             task["prediction"] = post_processed_predictions["predictions"][0]
+
+        fqcn_module = None
+
         if ari_results is not None:
             ari_result = ari_results[i]
             fqcn_module = ari_result["fqcn_module"]
-            if fqcn_module is None or fqcn_module == "":
-                # In case the module is not part of the collections, ARI does not handle it.
-                # This way, parsing the module from the prediction instead.
-                fqcn_module = fmtr.get_fqcn_or_module_from_prediction(task["prediction"])
-            if fqcn_module is not None:
-                task["module"] = fqcn_module
-                index = fqcn_module.rfind(".")
-                if index != -1:
-                    task["collection"] = fqcn_module[:index]
+
+        if fqcn_module is None or fqcn_module == "":
+            # In case the module is not part of the collections, ARI does not handle it.
+            # This way, parsing the module from the prediction instead.
+            fqcn_module = fmtr.get_fqcn_or_module_from_prediction(task["prediction"])
+
+        if fqcn_module is not None:
+            task["module"] = fqcn_module
+            index = fqcn_module.rfind(".")
+            if index != -1:
+                task["collection"] = fqcn_module[:index]
 
     context.task_results = tasks
     context.post_processed_predictions = post_processed_predictions

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/post_process.py
@@ -367,13 +367,13 @@ def completion_post_process(context: CompletionContext):
         if ari_results is not None:
             ari_result = ari_results[i]
             fqcn_module = ari_result["fqcn_module"]
-        post_process_task(fqcn_module, task)
+        populate_module_and_collection(fqcn_module, task)
 
     context.task_results = tasks
     context.post_processed_predictions = post_processed_predictions
 
 
-def post_process_task(fqcn_module, task):
+def populate_module_and_collection(fqcn_module, task):
     if fqcn_module is None or fqcn_module == "":
         # In case the module is not part of the collections, ARI does not handle it.
         # This way, parsing the module from the prediction instead.

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
@@ -42,27 +42,36 @@ class TrimWhitespaceLinesTest(TestCase):
 
 
 class PostProcessTaskTest(TestCase):
-    def test_post_process_task(self):
+    def test_post_process_ari_task(self):
         task = dict()
-        post_process.post_process_task("ansible.builtin.package", task)
+        post_process.populate_module_and_collection("ansible.builtin.package", task)
         self.assertEqual(task["module"], "ansible.builtin.package")
         self.assertEqual(task["collection"], "ansible.builtin")
         task = dict()
-        post_process.post_process_task("community.general.s3_facts", task)
+        post_process.populate_module_and_collection("community.general.s3_facts", task)
         self.assertEqual(task["module"], "community.general.s3_facts")
         self.assertEqual(task["collection"], "community.general")
         task = dict()
-        post_process.post_process_task("servicenow.itsm.change_info", task)
+        post_process.populate_module_and_collection("servicenow.itsm.change_info", task)
         self.assertEqual(task["module"], "servicenow.itsm.change_info")
         self.assertEqual(task["collection"], "servicenow.itsm")
         task = dict()
-        post_process.post_process_task("docker_image", task)
+        post_process.populate_module_and_collection("docker_image", task)
         self.assertEqual(task["module"], "docker_image")
         self.assertNotIn("collection", task.keys())
 
-    def test_post_process_none_task(self):
+    def test_post_process_none_ari_task(self):
+        task = dict()
+        task["prediction"] = (
+            "    ansible.builtin.package:\n      name: openssh-server\n      state: present"
+        )
+        post_process.populate_module_and_collection(None, task)
+        self.assertEqual(task["module"], "ansible.builtin.package")
+        self.assertEqual(task["collection"], "ansible.builtin")
+
+    def test_post_process_none_ari_task_none_prediction(self):
         task = dict()
         task["prediction"] = None
-        post_process.post_process_task(None, task)
+        post_process.populate_module_and_collection(None, task)
         self.assertNotIn("module", task.keys())
         self.assertNotIn("collection", task.keys())

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/tests/test_post_process.py
@@ -39,3 +39,30 @@ class TrimWhitespaceLinesTest(TestCase):
         self.assertEqual(
             post_process.trim_whitespace_lines("hello\ngoodbye\n   "), "hello\ngoodbye\n"
         )
+
+
+class PostProcessTaskTest(TestCase):
+    def test_post_process_task(self):
+        task = dict()
+        post_process.post_process_task("ansible.builtin.package", task)
+        self.assertEqual(task["module"], "ansible.builtin.package")
+        self.assertEqual(task["collection"], "ansible.builtin")
+        task = dict()
+        post_process.post_process_task("community.general.s3_facts", task)
+        self.assertEqual(task["module"], "community.general.s3_facts")
+        self.assertEqual(task["collection"], "community.general")
+        task = dict()
+        post_process.post_process_task("servicenow.itsm.change_info", task)
+        self.assertEqual(task["module"], "servicenow.itsm.change_info")
+        self.assertEqual(task["collection"], "servicenow.itsm")
+        task = dict()
+        post_process.post_process_task("docker_image", task)
+        self.assertEqual(task["module"], "docker_image")
+        self.assertNotIn("collection", task.keys())
+
+    def test_post_process_none_task(self):
+        task = dict()
+        task["prediction"] = None
+        post_process.post_process_task(None, task)
+        self.assertNotIn("module", task.keys())
+        self.assertNotIn("collection", task.keys())

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -579,6 +579,7 @@ var3: value3
                 "          az: us-east-1r\n"
             ),
         )
+        self.assertIsNone(fmtr.get_fqcn_or_module_from_prediction(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-23914>

## Description
Since the post-processing being disabled by [1], on staging clusters, some telemetry evens are lacking the following information:
- schema1: completion event => missing tasks
- schema2: Recommendation Generated event => collection and module fields are empty

[1] https://github.com/ansible/ansible-wisdom-ops/commit/ce89fb48544e300dc55c9db6969bd06a8b363ba4

### Steps to test
- Disable ARI post-processing => ENABLE_ARI_POSTPROCESS=False
- Run the wisdom-service
- Infer
- Look at either completion event, from schema1, and _Recommendation Generated event, from schema2, both are lacking information, as described above.

### Scenarios tested
Tested local against staging Segment account, when both post-processing enabled and disabled.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
