### PR TITLE
Add WcaNoDefaultModelId exception

### DIFF
--- a/ansible_wisdom/ai/api/exceptions.py
+++ b/ansible_wisdom/ai/api/exceptions.py
@@ -111,9 +111,9 @@ class WcaModelIdNotFoundException(WisdomAccessDenied):
     default_detail = 'A WCA Model ID was expected but not found. Please contact your administrator.'
 
 
-class WcaOrganizationNotLinkedException(WisdomAccessDenied):
-    default_code = 'error__wca_organization_not_linked'
-    default_detail = 'User is not linked to an organization'
+class WcaNoDefaultModelIdException(WisdomAccessDenied):
+    default_code = 'error__no_default_model_id'
+    default_detail = 'No default WCA Model ID was found.'
 
 
 class WcaSuggestionIdCorrelationFailureException(BaseWisdomAPIException):

--- a/ansible_wisdom/ai/api/model_client/exceptions.py
+++ b/ansible_wisdom/ai/api/model_client/exceptions.py
@@ -58,8 +58,8 @@ class WcaModelIdNotFound(WcaException):
 
 
 @dataclass
-class WcaOrganizationNotLinked(WcaException):
-    """User is not linked to an organization"""
+class WcaNoDefaultModelId(WcaException):
+    """No default WCA Model ID was found."""
 
 
 @dataclass

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -40,7 +40,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
-    WcaOrganizationNotLinked,
+    WcaNoDefaultModelId,
     WcaSuggestionIdCorrelationFailure,
     WcaTokenFailure,
 )
@@ -183,7 +183,7 @@ class TestWCAClient(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
 
     def test_get_model_id_without_org_id(self):
         model_client = WCAClient(inference_url='http://example.com/')
-        with self.assertRaises(WcaOrganizationNotLinked):
+        with self.assertRaises(WcaNoDefaultModelId):
             model_client.get_model_id(None, None)
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='123:')

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -34,7 +34,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
-    WcaOrganizationNotLinkedException,
+    WcaNoDefaultModelIdException,
     WcaSuggestionIdCorrelationFailureException,
     WcaUserTrialExpiredException,
     process_error_count,
@@ -47,7 +47,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
-    WcaOrganizationNotLinked,
+    WcaNoDefaultModelId,
     WcaSuggestionIdCorrelationFailure,
     WcaUserTrialExpired,
 )
@@ -150,13 +150,10 @@ class InferenceStage(PipelineElement):
             logger.info(f"A WCA Api Key was expected but not found for suggestion {suggestion_id}")
             raise WcaKeyNotFoundException(cause=e)
 
-        except WcaOrganizationNotLinked as e:
+        except WcaNoDefaultModelId as e:
             exception = e
-            logger.info(
-                "User was expected to be linked to an org, "
-                f"but it was not for suggestion {suggestion_id}"
-            )
-            raise WcaOrganizationNotLinkedException(cause=e)
+            logger.info(f"No default WCA Model ID was found for suggestion {suggestion_id}")
+            raise WcaNoDefaultModelIdException(cause=e)
 
         except WcaModelIdNotFound as e:
             exception = e

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -51,7 +51,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
-    WcaOrganizationNotLinkedException,
+    WcaNoDefaultModelIdException,
     WcaSuggestionIdCorrelationFailureException,
     WcaUserTrialExpiredException,
     process_error_count,
@@ -63,7 +63,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
-    WcaOrganizationNotLinked,
+    WcaNoDefaultModelId,
     WcaSuggestionIdCorrelationFailure,
     WcaUserTrialExpired,
 )
@@ -252,7 +252,7 @@ class Feedback(APIView):
             model_name = model_mesh_client.get_model_id(
                 org_id, str(validated_data.get('model', ''))
             )
-        except (WcaOrganizationNotLinked, WcaModelIdNotFound, WcaSecretManagerError):
+        except (WcaNoDefaultModelId, WcaModelIdNotFound, WcaSecretManagerError):
             logger.debug(
                 f"Failed to retrieve Model Name for Feedback.\n "
                 f"Org ID: {user.org_id}, "
@@ -591,14 +591,13 @@ class ContentMatches(GenericAPIView):
             )
             raise WcaModelIdNotFoundException(cause=e)
 
-        except WcaOrganizationNotLinked as e:
+        except WcaNoDefaultModelId as e:
             exception = e
             logger.exception(
-                "User was expected to be linked to an org, "
-                "but it was not for content matching "
-                f"suggestion {suggestion_id}"
+                "A default WCA Model ID was expected but not found for "
+                f"content matching suggestion {suggestion_id}"
             )
-            raise WcaOrganizationNotLinkedException(cause=e)
+            raise WcaNoDefaultModelIdException(cause=e)
 
         except WcaSuggestionIdCorrelationFailure as e:
             exception = e


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [AAP-23031](https://issues.redhat.com/browse/AAP-23031)
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
This is the service side change corresponding to the [vscode-ansible PR#1309](https://github.com/ansible/vscode-ansible/pull/1309).  With this change, a new exception WcaOrganizationNotLinked  is added for the case that the user is not linked to an organization because the WcaModelIdNotFound was thrown for those cases as well. 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
A test case is included in the PR.

### Steps to test
1. Pull down the PR
2. Run unit tests following the regular procedure.
### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See the above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [X] This code change requires the following considerations before going to production:
  For the new WcaOrganizationNotLinkedException is correctly processed on VS Code extension, [vscode-ansible PR#1309](https://github.com/ansible/vscode-ansible/pull/1309) needs to be merged.
