### PR TITLE
AAP-22398: Logging in with unsubscribed org-admin won't show correct message

### DIFF
--- a/ansible_wisdom/main/templates/registration/login.html
+++ b/ansible_wisdom/main/templates/registration/login.html
@@ -18,34 +18,36 @@
                     {% if not user.is_authenticated %}
                     <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>
 
-                    <div style="margin-top: 25px">
                     {% if deployment_mode == 'onprem' %}
                     <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'aap' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with AAP</a>
                     {% else %}
                     <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'oidc' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with Red Hat</a>
                     {% endif %}
-                    </div>
                     {% endif %}
 
+                <div class="pf-l-bullseye">
+                  <div class="pf-l-bullseye__item">
                     <div class="pf-l-level pf-m-gutter" style="margin-top: 60px">
-                        <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank"><span class="fas fa-solid fa-comments"></span> Chat</a>
-                        <a class="pf-l-level__item" href="https://docs.ai.ansible.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
-                        <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
-                        {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_org_has_subscription and user.rh_user_is_org_admin %}
-                        <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
-                        {% endif %}
-                        {% if not user.is_authenticated %}
-                        {% if use_tech_preview %}
-                        {% if use_github_team %}
-                        <a class="pf-l-level__item" href="{% url 'social:begin' 'github-team' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
-                        {% else %}
-                        <a class="pf-l-level__item" href="{% url 'social:begin' 'github' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
-                        {% endif %}
-                        {% endif %}
-                        {% endif %}
+                      <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank"><span class="fas fa-solid fa-comments"></span> Chat</a>
+                      <a class="pf-l-level__item" href="https://docs.ai.ansible.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
+                      <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
+                      {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_org_has_subscription and user.rh_user_is_org_admin %}
+                      <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
+                      {% endif %}
+                      {% if not user.is_authenticated %}
+                      {% if use_tech_preview %}
+                      {% if use_github_team %}
+                      <a class="pf-l-level__item" href="{% url 'social:begin' 'github-team' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
+                      {% else %}
+                      <a class="pf-l-level__item" href="{% url 'social:begin' 'github' %}{% if next %}?next={{ next|urlencode }}{% endif %}"><span class="fas fa-sign-in-alt"></span> Log in to Tech Preview</a>
+                      {% endif %}
+                      {% endif %}
+                      {% endif %}
                     </div>
-
+                  </div>
                 </div>
+
+              </div>
             </div>
             {% else %}
             <div class="pf-l-bullseye__item">

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -55,11 +55,26 @@
           </span>
 
           <h1 class="pf-c-title pf-m-lg">
-              <p>Your organization doesn't have access to {{ project_name }}.
+            <p>Your organization doesn't have access to {{ project_name }}.
           </h1>
-             <div style="padding: 15px">
-              <p>Contact your Red Hat Organization's administrator for more information.
-            </div>
+          <div style="padding: 15px">
+            <p>Contact your Red Hat Organization's administrator for more information.
+          </div>
+
+{# https://issues.redhat.com/browse/AAP-22398 #}
+{% elif user.is_authenticated and not use_tech_preview and user.rh_user_is_org_admin and not user.rh_org_has_subscription %}
+          <span class="pf-c-icon pf-m-xl pf-m-inline">
+            <span class="pf-c-icon__content  pf-m-danger">
+              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            </span>
+          </span>
+
+          <h1 class="pf-c-title pf-m-lg">
+            <p>Your organization doesn't have access to {{ project_name }}.
+          </h1>
+          <div style="padding: 15px">
+            <p>You do not have an Active subscription to Ansible Automation Platform which is required to use {{ project_name }}.
+          </div>
 
 {% elif user.is_authenticated and not use_tech_preview and user.rh_org_has_subscription and not user.rh_user_has_seat %}
           <span class="pf-c-icon pf-m-xl pf-m-inline">
@@ -97,15 +112,11 @@
           <h1 class="pf-c-title pf-m-lg">{{ project_name }}</h1>
 {% endif %}
 
-
-
           {% if user.is_authenticated %}
             <div style="padding: 15px">
-              <p>{% firstof user.external_username user.username %}
-              {% if user.rh_org_has_subscription %}
+              <p>{% firstof user.external_username user.username %}</p>
               {% if user.rh_user_is_org_admin or user.rh_user_has_seat %}
-              <p>Role: {% if user.rh_user_is_org_admin %}administrator{% endif %}{% if user.rh_user_is_org_admin and user.rh_user_has_seat %}, {% endif %}{% if user.rh_user_has_seat %}licensed user{% endif %}
-              {% endif %}
+                <p>Role: {% if user.rh_user_is_org_admin %}administrator{% endif %}{% if user.rh_user_is_org_admin and user.rh_user_has_seat %}, {% endif %}{% if user.rh_user_has_seat %}licensed user{% endif %}</p>
               {% endif %}
             </div>
 
@@ -121,7 +132,7 @@
             <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
             <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
 
-            {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_org_has_subscription and user.rh_user_is_org_admin %}
+            {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
             <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
             {% endif %}
           </div>

--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -127,20 +127,24 @@
             <a class="pf-c-button pf-m-primary" type="button" href="{% url 'login' %}">Log in</a>
           {% endif %}
 
-          <div class="pf-l-level pf-m-gutter" style="margin-top: 60px">
-            <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank"><span class="fas fa-solid fa-comments"></span> Chat</a>
-            <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
-            <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
+            <div class="pf-l-bullseye">
+              <div class="pf-l-bullseye__item">
+                <div class="pf-l-level pf-m-gutter" style="margin-top: 60px">
+                  <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank"><span class="fas fa-solid fa-comments"></span> Chat</a>
+                  <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
+                  <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
 
-            {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
-            <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
-            {% endif %}
+                  {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
+                  <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+
           </div>
-
         </div>
       </div>
     </div>
-
   </div>
 </section>
 {% endblock content %}

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -92,14 +92,14 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
     def test_rh_admin_without_seat_and_with_no_secret_with_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Role:")
         self.assertContains(response, "pf-c-alert__title", count=1)
-        self.assertNotContains(response, "Admin Portal")
         self.assertNotContains(response, "Your organization doesn't have access to Project Name.")
         self.assertNotContains(response, "You will be limited to features of the Project Name")
         self.assertNotContains(
             response, "The Project Name Technical Preview is no longer available"
         )
+        self.assertContains(response, "Role: administrator")
+        self.assertContains(response, "Admin Portal")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
@@ -108,11 +108,16 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
     def test_rh_admin_without_seat_and_with_no_secret_no_sub_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Role:")
         self.assertContains(response, "pf-c-alert__title")
-        self.assertNotContains(response, "Admin Portal")
-        self.assertNotContains(response, "Your organization doesn't have access to Project Name.")
+        self.assertContains(response, "Your organization doesn't have access to Project Name.")
+        self.assertContains(
+            response,
+            "You do not have an Active subscription to Ansible Automation Platform "
+            "which is required to use Project Name.",
+        )
         self.assertContains(response, "The Project Name Technical Preview is no longer available")
+        self.assertContains(response, "Role: administrator")
+        self.assertContains(response, "Admin Portal")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
     @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
@@ -231,6 +236,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Your organization doesn't have access to Project Name.")
+        self.assertContains(
+            response, "Contact your Red Hat Organization's administrator for more information."
+        )
         self.assertContains(response, "fa-exclamation-circle")
         self.assertContains(response, "The Project Name Technical Preview is no longer available")
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-22398

## Description
For admins/authenticated/no-subscription users, this PR:-

- Shows new text on the homepage.
- Shows "Role: administrator" on the homepage.
- Shows the "Admin portal" link on the homepage.

As [requested](https://issues.redhat.com/browse/AAP-22398?focusedId=24544979&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24544979) in the JIRA.

## Testing
Login with an Admin User without a subscription.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Run the server however you would normally.

### Scenarios tested
As above, with credentials provided by @robinbobbitt 

Please see JIRA for screenshot of _new_ scenario.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

I need to be able to confirm it works vs just the unit tests passing.