### PR TITLE
AAP-23647: Turn org_telemetry_opt_out to True by default

### DIFF
--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -45,6 +45,7 @@ from ansible_ai_connect.test_utils import (
 )
 from ansible_ai_connect.users.constants import (
     FAUX_COMMERCIAL_USER_ORG_ID,
+    USER_SOCIAL_AUTH_PROVIDER_AAP,
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
@@ -619,7 +620,18 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.client.force_authenticate(user=user)
         r = self.client.get(reverse('me'))
         self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertIsNone(r.data.get('org_telemetry_opt_out'))
+        self.assertTrue(r.data.get('org_telemetry_opt_out'))
+
+    def test_aap_user(self):
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
+            social_auth_extra_data={"login": "aap_username"},
+            external_username="aap_username",
+        )
+        self.client.force_authenticate(user=user)
+        r = self.client.get(reverse('me'))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertTrue(r.data.get('org_telemetry_opt_out'))
 
     def test_rhsso_user_with_telemetry_opted_in(self):
         user = create_user(

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -101,8 +101,9 @@ class CurrentUserView(RetrieveAPIView):
 
         # Enrich with Organisational data, if necessary
         organization = self.request.user.organization
-        if organization:
-            user_data["org_telemetry_opt_out"] = organization.telemetry_opt_out
+        user_data["org_telemetry_opt_out"] = (
+            organization.telemetry_opt_out if organization else True
+        )
 
         return Response(user_data)
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23647

## Description
This PR sets `org_telemetry_opt_out: true` for Users without an `Organization`.

For example, GitHub and AAP Users.

## Testing
The Unit Tests are the only way to confirm operation at the exact time of writing.

Once this PR has been created I'll generate an `ansible-ai-connect-service` image/environment for testing.

### Steps to test
1. We should be able to use the transient PR/image/environment. Details to follow.

### Scenarios tested
Login with a User that does not belong to an Organization...
Check `/me` for `org_telemetry_opt_out: true`.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
