### PR TITLE
AAP-23647: Turn org_telemetry_opt_out to True by default

### DIFF
--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -45,6 +45,7 @@ from ansible_ai_connect.test_utils import (
 )
 from ansible_ai_connect.users.constants import (
     FAUX_COMMERCIAL_USER_ORG_ID,
+    USER_SOCIAL_AUTH_PROVIDER_AAP,
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
@@ -619,7 +620,18 @@ class TestTelemetryOptInOut(APITransactionTestCase):
         self.client.force_authenticate(user=user)
         r = self.client.get(reverse('me'))
         self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertIsNone(r.data.get('org_telemetry_opt_out'))
+        self.assertTrue(r.data.get('org_telemetry_opt_out'))
+
+    def test_aap_user(self):
+        user = create_user(
+            provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
+            social_auth_extra_data={"login": "aap_username"},
+            external_username="aap_username",
+        )
+        self.client.force_authenticate(user=user)
+        r = self.client.get(reverse('me'))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertTrue(r.data.get('org_telemetry_opt_out'))
 
     def test_rhsso_user_with_telemetry_opted_in(self):
         user = create_user(

--- a/ansible_wisdom/users/views.py
+++ b/ansible_wisdom/users/views.py
@@ -101,8 +101,9 @@ class CurrentUserView(RetrieveAPIView):
 
         # Enrich with Organisational data, if necessary
         organization = self.request.user.organization
-        if organization:
-            user_data["org_telemetry_opt_out"] = organization.telemetry_opt_out
+        user_data["org_telemetry_opt_out"] = (
+            organization.telemetry_opt_out if organization else True
+        )
 
         return Response(user_data)
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23647

## Description
This PR sets `org_telemetry_opt_out: true` for Users without an `Organization`.

For example, GitHub and AAP Users.

## Testing
1. Deploy `quay.io/ansible/wisdom-service:pr-1008.202405131450`
2. Login with a User that does not belong to an Organization

### Steps to test
1. Deploy `ansible-ai-connect-service` version `quay.io/ansible/wisdom-service:pr-1008.202405131450`
2. Login with a User that does not have an Organization
3. This can more easily be achieved by deploying an instance of `AnsibleAIConnect` to a k8s environment:
```
image: quay.io/ansible/wisdom-service
image_version: pr-1008.202405131450
```

### Scenarios tested
Login with a User that does not belong to an Organization...
Check `/me` for `org_telemetry_opt_out: true`.
Confirmed response from an `AnsibleAIConnect` instance:
```
{
  "rh_org_has_subscription": true,
  "rh_user_has_seat": true,
  "rh_user_is_org_admin": false,
  "external_username": "<removed>",
  "username": "<removed>",
  "org_telemetry_opt_out": true
}
```

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
