### PR TITLE
AAP-23899: 'Unexpected error code (404) returned by AMS backend (quota_cost)' in server log

### DIFF
--- a/ansible_wisdom/users/authz_checker.py
+++ b/ansible_wisdom/users/authz_checker.py
@@ -288,7 +288,7 @@ class AMSCheck(BaseCheck):
 
         if ams_org_id == AMSCheck.ERROR_AMS_ORG_UNDEFINED:
             # Organization has not yet been created in AMS, either the organization
-            # is too recent (sync is done every 1h), or the organization has not AMS related
+            # is too recent (sync is done every 1h), or the organization has no AMS related
             # services (e.g Ansible, OpenShift, cloud.r.c) and so is not synchronized.
             logger.warning(f"Organization not found in AMS, organization_id={organization_id}")
             return False
@@ -324,6 +324,13 @@ class AMSCheck(BaseCheck):
         except AMSCheck.AMSError:
             # See https://issues.redhat.com/browse/AAP-22758
             # If the AMS Organisation lookup fails assume the User is not an administrator
+            return False
+
+        if ams_org_id == AMSCheck.ERROR_AMS_ORG_UNDEFINED:
+            # Organization has not yet been created in AMS, either the organization
+            # is too recent (sync is done every 1h), or the organization has no AMS related
+            # services (e.g Ansible, OpenShift, cloud.r.c) and so is not synchronized.
+            logger.warning(f"Organization not found in AMS, organization_id={organization_id}")
             return False
 
         params = {"search": f"account.username = '{username}' AND organization.id='{ams_org_id}'"}
@@ -363,6 +370,13 @@ class AMSCheck(BaseCheck):
             # See https://issues.redhat.com/browse/AAP-22758
             # If the AMS Organisation lookup fails assume the User has a subscription
             return True
+
+        if ams_org_id == AMSCheck.ERROR_AMS_ORG_UNDEFINED:
+            # Organization has not yet been created in AMS, either the organization
+            # is too recent (sync is done every 1h), or the organization has no AMS related
+            # services (e.g Ansible, OpenShift, cloud.r.c) and so is not synchronized.
+            logger.warning(f"Organization not found in AMS, organization_id={organization_id}")
+            return False
 
         # Check cache
         cache_key = f"ams_rh_org_has_subscription_{organization_id}"


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23899

## Description
This PR ensures subsequent AMS calls to check whether an Organisation has a subscription or a User is an administrator are bypassed if the initial AMS call to convert (RH) Organisation ID to AMS Organisation ID is not successful.

## Testing
Login with a User that belongs to an Organisation that does not exist in AMS[*]

[*] This is really difficult to replicate outside of a unit test. I leave it with the reviewer to consider whether it is effective to do so.

### Steps to test
1. Pull down the PR
2. Other than review the unit tests this is difficult to set-up to replicate both successful test.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
