### PR TITLE
AAP-23414: Lightspeed onprem to block the metrics endpoint from public access

### DIFF
--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -59,7 +59,6 @@ urlpatterns = [
     path('', HomeView.as_view(), name='home'),
     # add the GitHub OAuth redirect URL /complete/github-team/
     path('', include('social_django.urls', namespace='social')),
-    path('', include('django_prometheus.urls')),
     path('admin/', admin.site.urls),
     path(f'api/{WISDOM_API_VERSION}/ai/', include("ansible_ai_connect.ai.api.urls")),
     path(f'api/{WISDOM_API_VERSION}/me/', CurrentUserView.as_view(), name='me'),
@@ -79,6 +78,13 @@ urlpatterns = [
     ),
     path('logout/', LogoutView.as_view(), name='logout'),
 ]
+
+# https://issues.redhat.com/browse/AAP-23414
+# /metrics is not available for "onprem" deployments
+if settings.DEPLOYMENT_MODE != "onprem":
+    urlpatterns += [
+        path('', include('django_prometheus.urls')),
+    ]
 
 if settings.DEBUG or settings.DEPLOYMENT_MODE == "saas":
     urlpatterns += [


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23414

## Description
This PR removes the Prometheus URLs from the service if `DEPLOYMENT_MODE == "onprem"`.

## Testing
Set `DEPLOYMENT_MODE` to `"onprem"` and try to access the `/metrics` URL.

It will not be found.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Override `DEPLOYMENT_MODE` to `"onprem"` in your development `settings` file. 
5. Start the service in your usual manner.
6. Try to access the `/metrics` URL.

### Scenarios tested
As above.

Verified with an `AnsibleAIConnect` deployment locally.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
