### PR TITLE
common LangChainClient class for BAM and Ollama

### DIFF
--- a/ansible_wisdom/ai/api/model_client/bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/bam_client.py
@@ -14,32 +14,17 @@
 
 import json
 import logging
-import re
-from textwrap import dedent
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import requests
 from django.conf import settings
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import SimpleChatModel
 from langchain_core.messages import BaseMessage
-from langchain_core.prompts.chat import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    SystemMessagePromptTemplate,
-)
 
-from .base import ModelMeshClient
-from .exceptions import ModelTimeoutError
+from .langchain import LangChainClient
 
 logger = logging.getLogger(__name__)
-
-SYSTEM_MESSAGE_TEMPLATE = (
-    "You are an Ansible expert. Return a single task that best completes the "
-    "partial playbook. Return only the task as YAML. Do not return multiple tasks. "
-    "Do not explain your response. Do not include the prompt in your response."
-)
-HUMAN_MESSAGE_TEMPLATE = "{prompt}"
 
 
 class ChatBAM(SimpleChatModel):
@@ -98,68 +83,11 @@ class ChatBAM(SimpleChatModel):
         return response
 
 
-def unwrap_answer(message: Union[str, BaseMessage]) -> str:
-    task: str = ""
-    if isinstance(message, BaseMessage):
-        if (
-            isinstance(message.content, list)
-            and len(message.content)
-            and isinstance(message.content[0], str)
-        ):
-            task = message.content[0]
-        elif isinstance(message.content, str):
-            task = message.content
-    elif isinstance(message, str):
-        # Ollama currently answers with just a string
-        task = message
-    if not task:
-        raise ValueError
-
-    m = re.search(r"```(yaml|)\n+(.+)```", task, re.MULTILINE | re.DOTALL)
-    if m:
-        task = m.group(2)
-    return dedent(re.split(r'- name: .+\n', task)[-1]).rstrip()
-
-
-class BAMClient(ModelMeshClient):
-    def __init__(self, inference_url):
-        super().__init__(inference_url=inference_url)
-        self._prediction_url = f"{self._inference_url}/v2/text/chat?version=2024-01-10"
-
+class BAMClient(LangChainClient):
     def get_chat_model(self, model_id):
         return ChatBAM(
             api_key=settings.ANSIBLE_AI_MODEL_MESH_API_KEY,
             model_id=model_id,
-            prediction_url=self._prediction_url,
+            prediction_url=f"{self._inference_url}/v2/text/chat?version=2024-01-10",
             timeout=self.timeout,
         )
-
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
-        model_id = self.get_model_id(None, model_id)
-
-        prompt = model_input.get("instances", [{}])[0].get("prompt", "")
-        context = model_input.get("instances", [{}])[0].get("context", "")
-
-        full_prompt = f"{context}{prompt}\n"
-        llm = self.get_chat_model(model_id)
-
-        chat_template = ChatPromptTemplate.from_messages(
-            [
-                SystemMessagePromptTemplate.from_template(
-                    SYSTEM_MESSAGE_TEMPLATE, additional_kwargs={"role": "system"}
-                ),
-                HumanMessagePromptTemplate.from_template(
-                    HUMAN_MESSAGE_TEMPLATE, additional_kwargs={"role": "user"}
-                ),
-            ]
-        )
-
-        try:
-            chain = chat_template | llm
-            message = chain.invoke({"prompt": full_prompt})
-            response = {"predictions": [unwrap_answer(message)], "model_id": model_id}
-
-            return response
-
-        except requests.exceptions.Timeout:
-            raise ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/langchain.py
+++ b/ansible_wisdom/ai/api/model_client/langchain.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+from textwrap import dedent
+from typing import Any, Dict
+
+import requests
+from langchain_core.messages import BaseMessage
+from langchain_core.prompts.chat import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
+
+from .base import ModelMeshClient
+from .exceptions import ModelTimeoutError
+
+SYSTEM_MESSAGE_TEMPLATE = (
+    "You are an Ansible expert. Return a single task that best completes the "
+    "partial playbook. Return only the task as YAML. Do not return multiple tasks. "
+    "Do not explain your response. Do not include the prompt in your response."
+)
+HUMAN_MESSAGE_TEMPLATE = "{prompt}"
+
+
+def unwrap_answer(message: str | BaseMessage) -> str:
+    task: str = ""
+    if isinstance(message, BaseMessage):
+        if (
+            isinstance(message.content, list)
+            and len(message.content)
+            and isinstance(message.content[0], str)
+        ):
+            task = message.content[0]
+        elif isinstance(message.content, str):
+            task = message.content
+    elif isinstance(message, str):
+        # Ollama currently answers with just a string
+        task = message
+    if not task:
+        raise ValueError
+
+    m = re.search(r"```(yaml|)\n+(.+)```", task, re.MULTILINE | re.DOTALL)
+    if m:
+        task = m.group(2)
+    return dedent(re.split(r'- name: .+\n', task)[-1]).rstrip()
+
+
+class LangChainClient(ModelMeshClient):
+    def get_chat_model(self, model_id):
+        raise NotImplementedError
+
+    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+        model_id = self.get_model_id(None, model_id)
+
+        prompt = model_input.get("instances", [{}])[0].get("prompt", "")
+        context = model_input.get("instances", [{}])[0].get("context", "")
+
+        full_prompt = f"{context}{prompt}\n"
+        llm = self.get_chat_model(model_id)
+
+        chat_template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(
+                    SYSTEM_MESSAGE_TEMPLATE, additional_kwargs={"role": "system"}
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    HUMAN_MESSAGE_TEMPLATE, additional_kwargs={"role": "user"}
+                ),
+            ]
+        )
+
+        try:
+            chain = chat_template | llm
+            message = chain.invoke({"prompt": full_prompt})
+            response = {"predictions": [unwrap_answer(message)], "model_id": model_id}
+
+            return response
+
+        except requests.exceptions.Timeout:
+            raise ModelTimeoutError

--- a/ansible_wisdom/ai/api/model_client/ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/ollama_client.py
@@ -16,20 +16,16 @@ import logging
 
 from langchain_community.llms import Ollama
 
-from .bam_client import BAMClient
+from .langchain import LangChainClient
 
 logger = logging.getLogger(__name__)
 
 
 # NOTE Heavily inspired by bam_client.py and we should ultimately merge the
 # two drivers to create a generic one.
-class OllamaClient(BAMClient):
-    def __init__(self, inference_url):
-        super().__init__(inference_url=inference_url)
-        self._prediction_url = self._inference_url
-
+class OllamaClient(LangChainClient):
     def get_chat_model(self, model_id):
         return Ollama(
-            base_url=self._prediction_url,
+            base_url=self._inference_url,
             model=model_id,
         )

--- a/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
@@ -13,73 +13,12 @@
 #  limitations under the License.
 
 import json
-from textwrap import dedent
 
 import responses
 from django.test import TestCase, override_settings
-from langchain_core.messages.base import BaseMessage
 from responses import matchers
 
-from ansible_ai_connect.ai.api.model_client.bam_client import BAMClient, unwrap_answer
-
-
-class TestUnwrapAnswer(TestCase):
-    def setUp(self):
-        self.expectation = "ansible.builtin.debug:\n  msg: something went wrong"
-
-    def test_unwrap_markdown_answer(self):
-        answer = """
-        I'm a model and I'm saying stuff
-
-
-        ```yaml
-
-        - name: Lapin bleu à réaction!
-          ansible.builtin.debug:
-            msg: something went wrong
-
-        ```
-
-        Some more blabla
-        """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
-
-    def test_unwrap_markdown_with_backquotes(self):
-        # e.g: llama3
-        answer = """
-        ```
-        - name: Lapin bleu à réaction!
-          ansible.builtin.debug:
-            msg: something went wrong
-        ```
-        """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
-
-    def test_unwrap_just_task(self):
-        answer = """
-        ----
-        - name: Lapin bleu à réaction!
-          ansible.builtin.debug:
-            msg: something went wrong
-
-
-
-        """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
-
-    def test_unwrap_class_with_content_key(self):
-        _content = """
-        ----
-        - name: Lapin bleu à réaction!
-          ansible.builtin.debug:
-            msg: something went wrong
-        """
-
-        class MyMessage(BaseMessage):
-            pass
-
-        message = MyMessage(content=_content, type="whatever")
-        self.assertEqual(unwrap_answer(message), self.expectation)
+from ansible_ai_connect.ai.api.model_client.bam_client import BAMClient
 
 
 class TestBam(TestCase):

--- a/ansible_wisdom/ai/api/model_client/tests/test_langchain.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_langchain.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+from textwrap import dedent
+
+from django.test import TestCase
+from langchain_core.messages.base import BaseMessage
+
+from ansible_ai_connect.ai.api.model_client.langchain import unwrap_answer
+
+
+class TestUnwrapAnswer(TestCase):
+    def setUp(self):
+        self.expectation = "ansible.builtin.debug:\n  msg: something went wrong"
+
+    def test_unwrap_markdown_answer(self):
+        answer = """
+        I'm a model and I'm saying stuff
+
+
+        ```yaml
+
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+
+        ```
+
+        Some more blabla
+        """
+        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+
+    def test_unwrap_markdown_with_backquotes(self):
+        # e.g: llama3
+        answer = """
+        ```
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+        ```
+        """
+        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+
+    def test_unwrap_just_task(self):
+        answer = """
+        ----
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+
+
+
+        """
+        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+
+    def test_unwrap_class_with_content_key(self):
+        _content = """
+        ----
+        - name: Lapin bleu à réaction!
+          ansible.builtin.debug:
+            msg: something went wrong
+        """
+
+        class MyMessage(BaseMessage):
+            pass
+
+        message = MyMessage(content=_content, type="whatever")
+        self.assertEqual(unwrap_answer(message), self.expectation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,14 +82,15 @@ profile = "black"
 [tool.pyright]
 include = [
   "ansible_wisdom/ai/api/aws/wca_secret_manager.py",
-  "ansible_wisdom/users/authz_checker.py",
   "ansible_wisdom/ai/api/model_client/bam_client.py",
   "ansible_wisdom/ai/api/model_client/dummy_client.py",
   "ansible_wisdom/ai/api/model_client/grpc_client.py",
   "ansible_wisdom/ai/api/model_client/http_client.py",
+  "ansible_wisdom/ai/api/model_client/langchain.py",
   "ansible_wisdom/ai/api/model_client/llamacpp_client.py",
   "ansible_wisdom/ai/api/model_client/ollama_client.py",
-  "ansible_wisdom/ai/api/model_client/wca_client.py"
+  "ansible_wisdom/ai/api/model_client/wca_client.py",
+  "ansible_wisdom/users/authz_checker.py"
 ]
 exclude = ["**/test_*.py", "ansible_wisdom/*/migrations/*.py"]
 


### PR DESCRIPTION
Both BAMClient and OllamaClient now inherite from the new LangChainClient class.
This to avoid the confusing situation where OllamaClient was depending on bam.py.
