### PR TITLE
playbook gen with outline

### DIFF
--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -46,3 +46,11 @@ class ModelMeshClient:
 
     def get_chat_model(self, model_id):
         raise NotImplementedError
+
+    def generate_playbook(
+        self, text: str = "", create_outline: bool = False, outline: str = ""
+    ) -> tuple[str, str]:
+        raise NotImplementedError
+
+    def explain_playbook(self, content) -> str:
+        raise NotImplementedError

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -16,33 +16,17 @@ import json
 import logging
 import secrets
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import requests
 from django.conf import settings
-from langchain_core.prompt_values import ChatPromptValue
-from langchain_core.runnables import Runnable, RunnableConfig
 
 from .base import ModelMeshClient
 
 logger = logging.getLogger(__name__)
 
-
-class DummyLLM(Runnable):
-    def __init__(self):
-        self.response_dict = {
-            "explanations": '''# Information
-This playbook installs the Nginx web server on all hosts
-that are running Red Hat Enterprise Linux (RHEL) 9.
-''',
-            "summaries": '''1. First, ensure that your RHEL 9 system is up-to-date.
-2. Next, you install the Nginx package using the package manager.
-3. After installation, start the ginx service.
-4. Ensure that Nginx starts automatically.
-5. Check if Nginx is running successfully.
-6. Visit your system's IP address followed by the default Nginx port number (80 or 443).
-''',
-            "generations": '''```yaml
+PLAYBOOK = """
+```yaml
 ---
 - hosts: rhel9
   become: yes
@@ -66,31 +50,22 @@ that are running Red Hat Enterprise Linux (RHEL) 9.
         name: nginx
         state: started
         enabled: yes
-```''',
-        }
+```
+"""
 
-    def invoke(self, input: object, config: Optional[RunnableConfig] = None) -> object:
+OUTLINE = """
+1. First, ensure that your RHEL 9 system is up-to-date.
+2. Next, you install the Nginx package using the package manager.
+3. After installation, start the ginx service.
+4. Ensure that Nginx starts automatically.
+5. Check if Nginx is running successfully.
+6. Visit your system's IP address followed by the default Nginx port number (80 or 443).
+"""
 
-        if isinstance(input, ChatPromptValue):
-            content = input.messages[0].content
-            if "Write one paragraph per Ansible task." in content:
-                api = "explanations"
-            elif "Use a numbered list." in content:
-                api = "summaries"
-            elif "generate the playbook" in content:
-                api = "generations"
-            else:
-                raise Exception(f"Unknown system message template: {content}")
-        else:
-            raise Exception(f"Unknown input type: {type(input)}")
-
-        if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:
-            jitter: float = secrets.randbelow(1000) * 0.001
-        else:
-            jitter: float = 0.001
-        time.sleep(settings.DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC * jitter)
-
-        return self.response_dict[api]
+EXPLANATION = """# Information
+This playbook installs the Nginx web server on all hosts
+that are running Red Hat Enterprise Linux (RHEL) 9.
+"""
 
 
 class DummyClient(ModelMeshClient):
@@ -111,7 +86,12 @@ class DummyClient(ModelMeshClient):
         response_body['model_id'] = '_'
         return response_body
 
-    def get_chat_model(self, model_id):
-        logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
-        logger.debug("!!!! Mocking Chat Model !!!!")
-        return DummyLLM()
+    def generate_playbook(
+        self, text: str = "", create_outline: bool = False, outline: str = ""
+    ) -> tuple[str, str]:
+        if create_outline:
+            return PLAYBOOK, OUTLINE
+        return PLAYBOOK, ""
+
+    def explain_playbook(self, content) -> str:
+        return EXPLANATION

--- a/ansible_wisdom/ai/api/model_client/langchain.py
+++ b/ansible_wisdom/ai/api/model_client/langchain.py
@@ -37,7 +37,33 @@ SYSTEM_MESSAGE_TEMPLATE = (
 HUMAN_MESSAGE_TEMPLATE = "{prompt}"
 
 
-def unwrap_answer(message: str | BaseMessage) -> str:
+def unwrap_playbook_answer(message: str | BaseMessage) -> tuple[str, str]:
+    task: str = ""
+    if isinstance(message, BaseMessage):
+        if (
+            isinstance(message.content, list)
+            and len(message.content)
+            and isinstance(message.content[0], str)
+        ):
+            task = message.content[0]
+        elif isinstance(message.content, str):
+            task = message.content
+    elif isinstance(message, str):
+        # Ollama currently answers with just a string
+        task = message
+    if not task:
+        raise ValueError
+
+    m = re.search(r".*?```(yaml|)\n+(.+)```(.*)", task, re.MULTILINE | re.DOTALL)
+    if m:
+        playbook = m.group(2).strip()
+        outline = m.group(3).lstrip().strip()
+        return playbook, outline
+    else:
+        return "", ""
+
+
+def unwrap_task_answer(message: str | BaseMessage) -> str:
     task: str = ""
     if isinstance(message, BaseMessage):
         if (
@@ -87,9 +113,103 @@ class LangChainClient(ModelMeshClient):
         try:
             chain = chat_template | llm
             message = chain.invoke({"prompt": full_prompt})
-            response = {"predictions": [unwrap_answer(message)], "model_id": model_id}
+            response = {"predictions": [unwrap_task_answer(message)], "model_id": model_id}
 
             return response
 
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
+
+    def generate_playbook(
+        self, text: str = "", create_outline: bool = False, outline: str = ""
+    ) -> tuple[str, str]:
+        SYSTEM_MESSAGE_TEMPLATE = """
+        You are an Ansible expert.
+        Your role is to help Ansible developers write playbooks.
+        You answer with an Ansible playbook.
+        """
+
+        SYSTEM_MESSAGE_TEMPLATE_WITH_OUTLINE = """
+        You are an Ansible expert.
+        Your role is to help Ansible developers write playbooks.
+        The first part of the answer is an Ansible playbook.
+        the second part is a step by step explanation of this.
+        Use a new line to explain each step.
+        """
+
+        HUMAN_MESSAGE_TEMPLATE = """
+        This is what the playbook should do: {text}
+        """
+
+        HUMAN_MESSAGE_TEMPLATE_WITH_OUTLINE = """
+        This is what the playbook should do: {text}
+        This is a break down of the expected Playbook: {outline}
+        """
+
+        system_template = (
+            SYSTEM_MESSAGE_TEMPLATE_WITH_OUTLINE if create_outline else SYSTEM_MESSAGE_TEMPLATE
+        )
+        human_template = HUMAN_MESSAGE_TEMPLATE_WITH_OUTLINE if outline else HUMAN_MESSAGE_TEMPLATE
+        from ansible_ai_connect.ai.api.model_client.langchain import (
+            unwrap_playbook_answer,
+        )
+
+        model_id = self.get_model_id(None, "")
+        llm = self.get_chat_model(model_id)
+
+        chat_template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(
+                    dedent(system_template),
+                    additional_kwargs={"role": "system"},
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    dedent(human_template), additional_kwargs={"role": "user"}
+                ),
+            ]
+        )
+
+        chain = chat_template | llm
+        output = chain.invoke({"text": text, "outline": outline})
+        playbook, outline = unwrap_playbook_answer(output)
+
+        if not create_outline:
+            outline = ""
+
+        return playbook, outline
+
+    def explain_playbook(self, content) -> str:
+        SYSTEM_MESSAGE_TEMPLATE = """
+        You're an Ansible expert.
+        You format your output with Markdown.
+        You only answer with text paragraphs.
+        Write one paragraph per Ansible task.
+        Markdown title starts with the '#' character.
+        Write a title before every paragraph.
+        Do not return any YAML or Ansible in the output.
+        Give a lot of details regarding the parameters of each Ansible plugin.
+        """
+
+        HUMAN_MESSAGE_TEMPLATE = """Please explain the following Ansible playbook:
+
+        {playbook}"
+        """
+
+        model_id = self.get_model_id(None, "")
+        llm = self.get_chat_model(model_id)
+
+        chat_template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(
+                    dedent(SYSTEM_MESSAGE_TEMPLATE),
+                    additional_kwargs={"role": "system"},
+                ),
+                HumanMessagePromptTemplate.from_template(
+                    dedent(HUMAN_MESSAGE_TEMPLATE), additional_kwargs={"role": "user"}
+                ),
+            ]
+        )
+
+        chain = chat_template | llm
+        explanation = chain.invoke({"playbook": content})
+        return explanation

--- a/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
@@ -55,3 +55,23 @@ class TestDummyClient(SimpleTestCase):
         client.infer(model_input="input")
         sleep.assert_called_once_with(latency / 1000)
         loads.assert_called_once_with(body)
+
+    def test_generate_playbook(self):
+        client = DummyClient(inference_url="https://ibm.com")
+        playbook, outline = client.generate_playbook(text="foo", create_outline=False)
+        self.assertTrue(isinstance(playbook, str))
+        self.assertTrue(isinstance(outline, str))
+        self.assertEqual(outline, "")
+
+    def test_generate_playbook_with_outline(self):
+        client = DummyClient(inference_url="https://ibm.com")
+        playbook, outline = client.generate_playbook(text="foo", create_outline=True)
+        self.assertTrue(isinstance(playbook, str))
+        self.assertTrue(isinstance(outline, str))
+        self.assertTrue(outline)
+
+    def test_explain_playbook(self):
+        client = DummyClient(inference_url="https://ibm.com")
+        explanation = client.explain_playbook("ëoo")
+        self.assertTrue(isinstance(explanation, str))
+        self.assertTrue(explanation)

--- a/ansible_wisdom/ai/api/model_client/tests/test_langchain.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_langchain.py
@@ -3,12 +3,17 @@
 from textwrap import dedent
 
 from django.test import TestCase
+from langchain_community.llms.fake import FakeListLLM
 from langchain_core.messages.base import BaseMessage
 
-from ansible_ai_connect.ai.api.model_client.langchain import unwrap_answer
+from ansible_ai_connect.ai.api.model_client.langchain import (
+    LangChainClient,
+    unwrap_playbook_answer,
+    unwrap_task_answer,
+)
 
 
-class TestUnwrapAnswer(TestCase):
+class TestUnwrapTaskAnswer(TestCase):
     def setUp(self):
         self.expectation = "ansible.builtin.debug:\n  msg: something went wrong"
 
@@ -27,7 +32,7 @@ class TestUnwrapAnswer(TestCase):
 
         Some more blabla
         """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+        self.assertEqual(unwrap_task_answer(dedent(answer)), self.expectation)
 
     def test_unwrap_markdown_with_backquotes(self):
         # e.g: llama3
@@ -38,7 +43,7 @@ class TestUnwrapAnswer(TestCase):
             msg: something went wrong
         ```
         """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+        self.assertEqual(unwrap_task_answer(dedent(answer)), self.expectation)
 
     def test_unwrap_just_task(self):
         answer = """
@@ -50,7 +55,7 @@ class TestUnwrapAnswer(TestCase):
 
 
         """
-        self.assertEqual(unwrap_answer(dedent(answer)), self.expectation)
+        self.assertEqual(unwrap_task_answer(dedent(answer)), self.expectation)
 
     def test_unwrap_class_with_content_key(self):
         _content = """
@@ -64,4 +69,64 @@ class TestUnwrapAnswer(TestCase):
             pass
 
         message = MyMessage(content=_content, type="whatever")
-        self.assertEqual(unwrap_answer(message), self.expectation)
+        self.assertEqual(unwrap_task_answer(message), self.expectation)
+
+
+class TestUnwrapPlaybookAnswer(TestCase):
+    def test_unwrap_class_with_content_key(self):
+        _content = """
+        This is the playbook:
+
+        ```
+        - hosts: localhost
+          tasks:
+            - name: Lapin bleu à réaction!
+              ansible.builtin.debug:
+                msg: something went wrong
+        ```
+
+        This playbook will do:
+        - This
+        - and that
+        """
+
+        class MyMessage(BaseMessage):
+            pass
+
+        playbook, outline = unwrap_playbook_answer(_content)
+        self.assertTrue(playbook.startswith("- hosts"))
+        self.assertTrue(outline.startswith("This playbook"))
+
+
+class TestLangChainClientNotImplemented(TestCase):
+    def test_not_implemented(self):
+        my_client = LangChainClient("a")
+
+        with self.assertRaises(NotImplementedError):
+            my_client.get_chat_model("a")
+
+
+class TestLangChainClient(TestCase):
+    def setUp(self):
+        self.my_client = LangChainClient("a")
+
+        def fake_get_chat_mode(self, model_id=None):
+            return FakeListLLM(responses=["\n```\nmy_playbook```\nmy outline\n\n", "b"])
+
+        self.my_client.get_chat_model = fake_get_chat_mode
+
+    def test_generate_playbook(self):
+        playbook, outline = self.my_client.generate_playbook(
+            text="foo",
+        )
+        self.assertEqual(playbook, "my_playbook")
+        self.assertEqual(outline, "")
+
+    def test_generate_playbook_with_outline(self):
+        playbook, outline = self.my_client.generate_playbook(text="foo", create_outline=True)
+        self.assertEqual(playbook, "my_playbook")
+        self.assertEqual(outline, "my outline")
+
+    def test_explain_playbook(self):
+        explanation = self.my_client.explain_playbook(content="foo")
+        self.assertTrue(explanation)

--- a/ansible_wisdom/ai/api/model_client/tests/test_model_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_model_client.py
@@ -35,3 +35,13 @@ class TestModelMeshClient(TestCase):
     def test_timeout(self):
         c = ModelMeshClient(inference_url="https://example.com")
         self.assertEqual(c.timeout(1), timeout)
+
+    def test_not_implemented(self):
+        c = ModelMeshClient(inference_url="https://example.com")
+
+        with self.assertRaises(NotImplementedError):
+            c.get_chat_model("a")
+        with self.assertRaises(NotImplementedError):
+            c.generate_playbook("a")
+        with self.assertRaises(NotImplementedError):
+            c.explain_playbook("a")

--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -424,40 +424,17 @@ class ExplanationResponseSerializer(serializers.Serializer):
     )
 
 
-class SummaryRequestSerializer(serializers.Serializer):
-    class Meta:
-        fields = ['content', 'summaryId', 'ansibleExtensionVersion']
-
-    content = serializers.CharField(
-        required=True,
-        label="Description content",
-        help_text=("The description that needs to be summarized."),
-    )
-    summaryId = serializers.UUIDField(
-        format='hex_verbose',
-        required=False,
-        label="Summary ID",
-        help_text=("A UUID that identifies the particular summary data is being requested for."),
-    )
-    metadata = Metadata(required=False)
-
-
-class SummaryResponseSerializer(serializers.Serializer):
-    content = serializers.CharField()
-    format = serializers.CharField()
-    summaryId = serializers.UUIDField(
-        format='hex_verbose',
-        required=False,
-        label="Explanation ID",
-        help_text=("A UUID that identifies the particular summary data is being requested for."),
-    )
-
-
 class GenerationRequestSerializer(serializers.Serializer):
     class Meta:
-        fields = ['content', 'generationId', 'ansibleExtensionVersion']
+        fields = [
+            'text',
+            'generationId',
+            'createOutline',
+            'ansibleExtensionVersion',
+            'outline',
+        ]
 
-    content = serializers.CharField(
+    text = serializers.CharField(
         required=True,
         label="Description content",
         help_text=("The description that needs to be converted to a playbook."),
@@ -465,14 +442,29 @@ class GenerationRequestSerializer(serializers.Serializer):
     generationId = serializers.UUIDField(
         format='hex_verbose',
         required=False,
-        label="Summary ID",
+        label="generation ID",
         help_text=("A UUID that identifies the particular generation data is being requested for."),
     )
+    createOutline = serializers.BooleanField(
+        required=False,
+        default=False,
+        label='generate outline',
+        help_text=(
+            'Indicates whether the answer should also include an outline '
+            'of the Ansible Playbook.'
+        ),
+    )
+    outline = serializers.CharField(
+        required=False,
+        label="outline",
+        help_text="A long step by step outline of the expected Ansible Playbook.",
+    )
+
     metadata = Metadata(required=False)
 
 
 class GenerationResponseSerializer(serializers.Serializer):
-    content = serializers.CharField()
+    playbook = serializers.CharField()
     format = serializers.CharField()
     generationId = serializers.UUIDField(
         format='hex_verbose',
@@ -480,6 +472,7 @@ class GenerationResponseSerializer(serializers.Serializer):
         label="Explanation ID",
         help_text=("A UUID that identifies the particular summary data is being requested for."),
     )
+    outline = serializers.CharField()
 
 
 class ContentMatchRequestSerializer(serializers.Serializer):

--- a/ansible_wisdom/ai/api/urls.py
+++ b/ansible_wisdom/ai/api/urls.py
@@ -21,7 +21,6 @@ from .views import (
     Explanation,
     Feedback,
     Generation,
-    Summary,
 )
 
 urlpatterns = [
@@ -29,7 +28,6 @@ urlpatterns = [
     path('completions/', Completions.as_view(), name='completions'),
     path('contentmatches/', ContentMatches.as_view(), name='contentmatches'),
     path('explanations/', Explanation.as_view(), name='explanations'),
-    path('summaries/', Summary.as_view(), name='summaries'),
     path('generations/', Generation.as_view(), name='generations'),
     path('feedback/', Feedback.as_view(), name='feedback'),
 ]

--- a/ansible_wisdom/healthcheck/tests/test_healthcheck.py
+++ b/ansible_wisdom/healthcheck/tests/test_healthcheck.py
@@ -534,6 +534,8 @@ class TestHealthCheckWCAClient(BaseTestHealthCheckWCAClient):
         self._do_test_health_check_wca_disabled()
 
 
+@override_settings(ANSIBLE_WCA_USERNAME="joe")
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY="some-string")
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca-onprem")
 class TestHealthCheckWCAOnPremClient(BaseTestHealthCheckWCAClient):
 

--- a/ansible_wisdom/test_utils.py
+++ b/ansible_wisdom/test_utils.py
@@ -97,6 +97,7 @@ class WisdomAppsBackendMocking(WisdomTestCase):
         }
         for key, mocker in self.backend_patchers.items():
             mocker.start()
+        apps.get_app_config('ai').ready()
 
     def tearDown(self):
         for patcher in self.backend_patchers.values():

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -273,47 +273,6 @@ paths:
           description: Request was throttled
         '503':
           description: Service Unavailable
-  /api/v0/ai/summaries/:
-    post:
-      operationId: ai_summaries_create
-      description: Returns a text that summarizes an input text.
-      summary: Elaborate input text
-      tags:
-      - ai
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SummaryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/SummaryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/SummaryRequest'
-        required: true
-      security:
-      - oauth2:
-        - read
-        - write
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SummaryResponse'
-          description: ''
-        '204':
-          description: Empty response
-        '400':
-          description: Bad Request
-        '401':
-          description: Unauthorized
-        '429':
-          description: Request was throttled
-        '503':
-          description: Service Unavailable
   /api/v0/me/:
     get:
       operationId: me_retrieve
@@ -850,24 +809,33 @@ components:
     GenerationRequest:
       type: object
       properties:
-        content:
+        text:
           type: string
           title: Description content
           description: The description that needs to be converted to a playbook.
         generationId:
           type: string
           format: uuid
-          title: Summary ID
+          title: generation ID
           description: A UUID that identifies the particular generation data is being
             requested for.
+        createOutline:
+          type: boolean
+          default: false
+          title: generate outline
+          description: Indicates whether the answer should also include an outline
+            of the Ansible Playbook.
+        outline:
+          type: string
+          description: A long step by step outline of the expected Ansible Playbook.
         metadata:
           $ref: '#/components/schemas/Metadata'
       required:
-      - content
+      - text
     GenerationResponse:
       type: object
       properties:
-        content:
+        playbook:
           type: string
         format:
           type: string
@@ -877,9 +845,12 @@ components:
           title: Explanation ID
           description: A UUID that identifies the particular summary data is being
             requested for.
+        outline:
+          type: string
       required:
-      - content
       - format
+      - outline
+      - playbook
     InlineSuggestionFeedback:
       type: object
       properties:
@@ -1000,39 +971,6 @@ components:
       - expectedSuggestion
       - prompt
       - providedSuggestion
-    SummaryRequest:
-      type: object
-      properties:
-        content:
-          type: string
-          title: Description content
-          description: The description that needs to be summarized.
-        summaryId:
-          type: string
-          format: uuid
-          title: Summary ID
-          description: A UUID that identifies the particular summary data is being
-            requested for.
-        metadata:
-          $ref: '#/components/schemas/Metadata'
-      required:
-      - content
-    SummaryResponse:
-      type: object
-      properties:
-        content:
-          type: string
-        format:
-          type: string
-        summaryId:
-          type: string
-          format: uuid
-          title: Explanation ID
-          description: A UUID that identifies the particular summary data is being
-            requested for.
-      required:
-      - content
-      - format
     TelemetrySettingsRequest:
       type: object
       properties:


### PR DESCRIPTION
- Drop the /summaries end-point
- Move all the langchain related operation in `model_client.langchain`
- Add two new methods in `model_client.base` dedicated to Playbook Exp/Gen