### PR TITLE
AAP-24196: Logout should use POST

### DIFF
--- a/ansible_wisdom/users/templates/users/home.html
+++ b/ansible_wisdom/users/templates/users/home.html
@@ -120,7 +120,10 @@
               {% endif %}
             </div>
 
-            <a class="pf-c-button pf-m-secondary" type="button" href="{% url 'logout' %}">Log out</a>
+            <form id="logout-form" method="post" action="{% url 'logout' %}">
+              {% csrf_token %}
+              <button class="pf-c-button pf-m-secondary" type="submit">Log out</button>
+            </form>
 
           {% else %}
             <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24196

## Description
This PR changes our logout mechanism to use HTTP `POST`.

The use of `GET` has been [deprecated](https://docs.djangoproject.com/en/4.1/releases/4.1/#log-out-via-get) in Django.

Furthermore AAP 2.5 [imposes](https://github.com/ansible/aap-gateway/blob/devel/aap_gateway_api/views/api/v1/local_login.py#L54) use of `POST`. Therefore AAIC deployments by our Operator against AAP 2.5 need this change.

## Testing
Run `wisdom-service` and logout. Check the network logs for a `POST`.

Verified deploying `wisdom-service:pr-1026.202405201114` on `stage2-west`.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Run the service and login.
5. Logout.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
