### PR TITLE
AAP-24136: Terminology updates for Lightspeed operator

### DIFF
--- a/ansible_wisdom/main/templates/registration/login.html
+++ b/ansible_wisdom/main/templates/registration/login.html
@@ -19,7 +19,7 @@
                     <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>
 
                     {% if deployment_mode == 'onprem' %}
-                    <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'aap' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with AAP</a>
+                    <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'aap' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with Ansible Automation Platform</a>
                     {% else %}
                     <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'oidc' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with Red Hat</a>
                     {% endif %}

--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -88,7 +88,7 @@ class AlreadyAuth(TestCase):
         response.render()
         contents = response.content.decode()
         self.assertIn("You are currently not logged in.", contents)
-        self.assertIn("Log in with AAP", contents)
+        self.assertIn("Log in with Ansible Automation Platform", contents)
 
     @override_settings(DEPLOYMENT_MODE='upstream')
     def test_login_django(self):


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24136

## Description
Change "Log in with AAP" to "Log in with Ansible Automation Platform"

## Testing
Deploy the new `wisdom-service` image with an AAIC instance.

Check the "Login" screen. 

See JIRA for example.

### Steps to test
1. Deploy an AAIC instance with the `wisdom-service` image built by this PR.
2. Check the "Login" screen shows "Log in with Ansible Automation Platform"

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
