### PR TITLE
snyk: ignore SNYK-PYTHON-CRYPTOGRAPHY-6913422

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,9 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
+# To format the date now and in 3 months:
+#   date -u +"%Y-%m-%dT%H:%M:%SZ"
+#   date -d 'now + 3 month' -u +"%Y-%m-%dT%H:%M:%SZ"
 ignore:
   SNYK-PYTHON-PYOPENSSL-6149520:
     - '*':
@@ -44,4 +47,11 @@ ignore:
           vulnerable component 'joblib.numpy_pickle::NumpyArrayWrapper'
         expires: 2024-05-24T15:02:32.468Z
         created: 2024-04-24T15:02:32.471Z
+  SNYK-PYTHON-CRYPTOGRAPHY-6913422:
+    - '*':
+        reason: |
+          No DSA key validation is done at our level and TLS is handle
+          by OpenShift
+        expires: 2024-08-21T12:19:22Z
+        created: 2024-05-21T12:19:22Z
 patch: {}


### PR DESCRIPTION
No DSA key validation is done at our level and TLS is handle
by OpenShift
