### PR TITLE
AAP-23414: Lightspeed onprem to block the metrics endpoint from public access

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -562,3 +562,9 @@ ENABLE_HEALTHCHECK_AUTHORIZATION = (
 ENABLE_HEALTHCHECK_ATTRIBUTION = (
     os.getenv('ENABLE_HEALTHCHECK_ATTRIBUTION', 'True').lower() == 'true'
 )
+
+# Follow AWX naming for this environment variable
+# It is used to protect Prometheus's /metrics endpoint
+ALLOW_METRICS_FOR_ANONYMOUS_USERS = (
+    os.getenv('ALLOW_METRICS_FOR_ANONYMOUS_USERS', 'True').lower() == 'true'
+)

--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -45,7 +45,12 @@ from ansible_ai_connect.healthcheck.views import (
     WisdomServiceHealthView,
     WisdomServiceLivenessProbeView,
 )
-from ansible_ai_connect.main.views import ConsoleView, LoginView, LogoutView
+from ansible_ai_connect.main.views import (
+    ConsoleView,
+    LoginView,
+    LogoutView,
+    MetricsView,
+)
 from ansible_ai_connect.users.views import (
     CurrentUserView,
     HomeView,
@@ -59,7 +64,7 @@ urlpatterns = [
     path('', HomeView.as_view(), name='home'),
     # add the GitHub OAuth redirect URL /complete/github-team/
     path('', include('social_django.urls', namespace='social')),
-    path('', include('django_prometheus.urls')),
+    path('metrics/', MetricsView.as_view(), name='prometheus-metrics'),
     path('admin/', admin.site.urls),
     path(f'api/{WISDOM_API_VERSION}/ai/', include("ansible_ai_connect.ai.api.urls")),
     path(f'api/{WISDOM_API_VERSION}/me/', CurrentUserView.as_view(), name='me'),

--- a/ansible_wisdom/users/auth.py
+++ b/ansible_wisdom/users/auth.py
@@ -60,6 +60,10 @@ class AAPOAuth2(BaseOAuth2):
         """Overrides super extra_data to add license check"""
         data = super().extra_data(user, uid, response, details=details, *args, **kwargs)
         data['aap_licensed'] = self.user_has_valid_license(response.get('access_token'))
+        data['aap_system_auditor'] = (
+            response['is_system_auditor'] if 'is_system_auditor' in response else False
+        )
+        data['aap_superuser'] = response['is_superuser'] if 'is_superuser' in response else False
         return data
 
     def user_has_valid_license(self, access_token):

--- a/ansible_wisdom/users/models.py
+++ b/ansible_wisdom/users/models.py
@@ -132,3 +132,13 @@ class User(ExportModelOperationsMixin('user'), AbstractUser):
     @cached_property
     def rh_aap_licensed(self) -> bool:
         return self.is_aap_user() and self.social_auth.values()[0]['extra_data']['aap_licensed']
+
+    @cached_property
+    def rh_aap_system_auditor(self) -> bool:
+        return (
+            self.is_aap_user() and self.social_auth.values()[0]['extra_data']['aap_system_auditor']
+        )
+
+    @cached_property
+    def rh_aap_superuser(self) -> bool:
+        return self.is_aap_user() and self.social_auth.values()[0]['extra_data']['aap_superuser']

--- a/ansible_wisdom/users/pipeline.py
+++ b/ansible_wisdom/users/pipeline.py
@@ -180,5 +180,13 @@ def load_extra_data(backend, details, response, uid, user, *args, **kwargs):
         extra_data = backend.extra_data(user, uid, response, details, *args, **kwargs)
         user.external_username = extra_data.get("login")
         user.save()
-        social.extra_data["aap_licensed"] = extra_data.get("aap_licensed")
+        social.extra_data["aap_licensed"] = (
+            extra_data.get("aap_licensed") if user.is_aap_user() else False
+        )
+        social.extra_data["aap_system_auditor"] = (
+            extra_data.get("aap_system_auditor") if user.is_aap_user() else False
+        )
+        social.extra_data["aap_superuser"] = (
+            extra_data.get("aap_superuser") if user.is_aap_user() else False
+        )
         social.save()

--- a/ansible_wisdom/users/tests/test_auth.py
+++ b/ansible_wisdom/users/tests/test_auth.py
@@ -62,26 +62,55 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
     @patch.multiple(
         'social_core.backends.oauth.BaseOAuth2',
         extra_data=MagicMock(return_value={"test": "data"}),
-        get_json=MagicMock(return_value={"license_info": {"date_expired": False}}),
+        get_json=MagicMock(
+            return_value={
+                "license_info": {"date_expired": False},
+            }
+        ),
     )
     def test_date_expired_checked_and_is_true_during_auth(self):
         self.authentication = AAPOAuth2()
-        request = Mock(headers={'Authorization': 'Bearer some_token'})
-        data = self.authentication.extra_data(request, "UUID", request)
+        user = MagicMock()
+        response = {"is_system_auditor": True, "is_superuser": True}
+        data = self.authentication.extra_data(user, "UUID", response)
 
         self.assertTrue(data['aap_licensed'])
+        self.assertTrue(data['aap_system_auditor'])
+        self.assertTrue(data['aap_superuser'])
 
     @patch.multiple(
         'social_core.backends.oauth.BaseOAuth2',
         extra_data=MagicMock(return_value={"test": "data"}),
-        get_json=MagicMock(return_value={"license_info": {"date_expired": True}}),
+        get_json=MagicMock(
+            return_value={
+                "license_info": {"date_expired": True},
+            }
+        ),
     )
     def test_date_expired_checked_and_is_false_during_auth(self):
         self.authentication = AAPOAuth2()
-        request = Mock(headers={'Authorization': 'Bearer some_token'})
-        data = self.authentication.extra_data(request, "UUID", request)
+        user = MagicMock()
+        response = {"is_system_auditor": False, "is_superuser": False}
+        data = self.authentication.extra_data(user, "UUID", response)
 
         self.assertFalse(data['aap_licensed'])
+        self.assertFalse(data['aap_system_auditor'])
+        self.assertFalse(data['aap_superuser'])
+
+    @patch.multiple(
+        'social_core.backends.oauth.BaseOAuth2',
+        extra_data=MagicMock(return_value={"test": "data"}),
+        get_json=MagicMock(return_value={}),
+    )
+    def test_missing_values(self):
+        self.authentication = AAPOAuth2()
+        user = MagicMock()
+        response = {}
+        data = self.authentication.extra_data(user, "UUID", response)
+
+        self.assertFalse(data['aap_licensed'])
+        self.assertFalse(data['aap_system_auditor'])
+        self.assertFalse(data['aap_superuser'])
 
 
 class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):

--- a/ansible_wisdom/users/tests/test_users.py
+++ b/ansible_wisdom/users/tests/test_users.py
@@ -28,6 +28,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from prometheus_client.parser import text_string_to_metric_families
+from rest_framework.test import APITransactionTestCase
 from social_core.exceptions import AuthCanceled
 from social_django.models import UserSocialAuth
 
@@ -37,7 +38,6 @@ from ansible_ai_connect.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_ai_connect.ai.api.tests.test_views import APITransactionTestCase
 from ansible_ai_connect.organizations.models import Organization
 from ansible_ai_connect.test_utils import (
     WisdomAppsBackendMocking,
@@ -582,7 +582,7 @@ class TestUserModelMetrics(APITransactionTestCase):
 
     def test_user_model_metrics(self):
         def get_user_count():
-            r = self.client.get(reverse('prometheus-django-metrics'))
+            r = self.client.get(reverse('prometheus-metrics'))
             for family in text_string_to_metric_families(r.content.decode()):
                 for sample in family.samples:
                     if sample[0] == 'django_model_inserts_total' and sample[1] == {'model': 'user'}:


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23414

## Description
This PR protects the `/metrics` endpoint, mainly for "on prem".

It follows the same approach adopted by AWX and uses the same environment variable name to support anonymous access.

Access for both "System Administrator" and "System Auditor" roles also follows AWX for consistency.

Naming of the additional `User` properties follows the existing `rh_aap_licensed` for consistency.

## Testing
Set an Environment Variable `ALLOW_METRICS_FOR_ANONYMOUS_USERS` to `False`

Run the `ansible-ai-connect-service` instance generated by this PR as an "on prem" instance.

Login with different Users that have the different AAP roles ("System Administrator", "System Auditor" or "Normal User").

Check the availability of the `/metrics` endpoint. It should only work for "System Administrator" and "System Auditor". 

### Steps to test
1. As above.

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

- PR for `ansible-ai-connect-operator` to set `ALLOW_METRICS_FOR_ANONYMOUS_USERS` to `False`