### PR TITLE
Default ANSIBLE_AI_ENABLE_TECH_PREVIEW to False

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_api_timeout.py
+++ b/ansible_wisdom/ai/api/tests/test_api_timeout.py
@@ -82,6 +82,7 @@ class TestApiTimeout(WisdomServiceAPITestCaseBase):
         model_client = WCAClient(inference_url='http://example.com/')
         self.assertEqual(123 * 2, model_client.timeout(2))
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch("requests.Session.post", side_effect=ReadTimeout())
     def test_timeout_http_timeout(self, _):
         self.client.force_authenticate(user=self.user)
@@ -100,6 +101,7 @@ class TestApiTimeout(WisdomServiceAPITestCaseBase):
                 r, ModelTimeoutException.default_code, ModelTimeoutException.default_detail
             )
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch("grpc._channel._UnaryUnaryMultiCallable.__call__", side_effect=mock_timeout_error())
     def test_timeout_grpc_timeout(self, _):
         self.client.force_authenticate(user=self.user)

--- a/ansible_wisdom/ai/api/tests/test_permissions.py
+++ b/ansible_wisdom/ai/api/tests/test_permissions.py
@@ -37,6 +37,7 @@ from ansible_ai_connect.users.tests.test_users import create_user
 # that expects both Key and Model ID to be defined.
 @override_settings(DEPLOYMENT_MODE="onprem")
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca-dummy")
+@override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
 class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
     payload = {
         "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
@@ -63,6 +64,7 @@ class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
         self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
         self.assert_error_detail(r, AcceptedTermsPermission.code, AcceptedTermsPermission.message)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_commercial_user_has_not_accepted(self):
         self.user.rh_user_has_seat = True
         with self.not_accepted_terms():
@@ -70,6 +72,7 @@ class AcceptedTermsPermissionTest(WisdomServiceAPITestCaseBase):
             r = self.client.post(reverse('completions'), self.payload)
         self.assertNotEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_community_user_has_accepted(self):
         with self.accepted_terms():
             self.client.force_authenticate(user=self.user)

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -688,6 +688,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
     # An artificial model ID for model-ID related test cases.
     DUMMY_MODEL_ID = "01234567-1234-5678-9abc-0123456789ab<|sepofid|>wisdom_codegen"
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_full_payload(self):
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
@@ -789,6 +790,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                         self.assertEqual(properties['taskCount'], 2)
                         self.assertEqual(properties['promptType'], CompletionsPromptType.MULTITASK)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_rate_limit(self):
         payload = {
@@ -814,6 +816,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertEqual(r.status_code, HTTPStatus.TOO_MANY_REQUESTS)
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_missing_prompt(self):
         payload = {
             "suggestionId": str(uuid.uuid4()),
@@ -862,6 +865,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                     self.assertEqual(properties['response']['status_code'], 401)
                     self.assertIsNotNone(event['timestamp'])
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_completions_preprocessing_error(self):
         payload = {
             "prompt": "---\n- hosts: all\nbecome: yes\n\n  tasks:\n    - name: Install Apache\n",
@@ -887,6 +891,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 )
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_completions_preprocessing_error_without_name_prompt(self):
         payload = {
             "prompt": "---\n  - Name: [Setup]",
@@ -909,6 +914,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertTrue("prompt does not contain the name parameter" in str(r.content))
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_full_payload_without_ARI(self):
         payload = {
@@ -932,6 +938,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertInLog('skipped ari post processing because ari was not initialized', log)
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     def test_full_payload_with_recommendation_with_broken_last_line(self):
         payload = {
@@ -959,6 +966,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertSegmentTimestamp(log)
 
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_completions_postprocessing_error_for_invalid_yaml(self):
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
@@ -986,6 +994,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
 
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_completions_postprocessing_for_invalid_suggestion(self):
         # the suggested task is invalid because it does not have module name
         # in this case, ARI should throw an exception
@@ -1027,6 +1036,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                         )
                     self.assertIsNotNone(event['timestamp'])
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_payload_with_ansible_lint_without_commercial(self):
@@ -1049,6 +1059,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertEqual(r.status_code, HTTPStatus.OK)
                 self.assertIsNotNone(r.data['predictions'])
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=False)
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     def test_full_payload_without_ansible_lint_without_commercial(self):
@@ -1243,6 +1254,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             error.request = request
         return error
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_completions_pii_clean_up(self):
         payload = {
             "prompt": "- name: Create an account for foo@ansible.com \n",
@@ -1263,6 +1275,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
                 self.assertInLog('Create an account for james8@example.com', log)
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_full_completion_post_response(self):
         payload = {
             "prompt": "---\n- hosts: all\n  become: yes\n\n  tasks:\n    - name: Install Apache\n",
@@ -1579,6 +1592,7 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
 @patch('ansible_ai_connect.ai.search.search')
 @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
 class TestAttributionsView(WisdomServiceAPITestCaseBase):
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_segment_events(self, mock_search):
         mock_search.return_value = {
             'attributions': [
@@ -1622,6 +1636,7 @@ class TestAttributionsView(WisdomServiceAPITestCaseBase):
                 self.assertEqual(hostname, properties['hostname'])
                 self.assertIsNotNone(event['timestamp'])
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_segment_events_with_exception(self, mock_search):
         mock_search.side_effect = Exception('Search Exception')
         payload = {
@@ -1643,6 +1658,7 @@ class TestAttributionsView(WisdomServiceAPITestCaseBase):
 
 
 class TestContentMatchesWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch('ansible_ai_connect.ai.search.search')
     def test_wca_contentmatch_with_no_seated_user(self, mock_search):
         self.user.rh_user_has_seat = False
@@ -1689,6 +1705,7 @@ class TestContentMatchesWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCa
         self.assertEqual(content_match["license"], license)
         self.assertEqual(content_match["data_source_description"], "Ansible Galaxy roles")
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch('ansible_ai_connect.ai.search.search')
     def test_wca_contentmatch_with_unseated_user_verify_single_task(self, mock_search):
         self.user.rh_user_has_seat = False
@@ -2226,6 +2243,7 @@ class TestContentMatchesWCAViewSegmentEvents(
             },
         }
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @patch('ansible_ai_connect.ai.api.views.send_segment_event')
     @patch('ansible_ai_connect.ai.search.search')
@@ -2447,6 +2465,7 @@ class TestContentMatchesWCAViewSegmentEvents(
         self.assertTrue(event_request.items() <= actual_event.get("request").items())
 
 
+@override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="dummy")
 class TestExplanationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     response_data = """# Information
@@ -2502,6 +2521,7 @@ that are running Red Hat Enterprise Linux 9.
             r = self.client.post(reverse('explanations'), payload, format='json')
             self.assertEqual(r.status_code, HTTPStatus.UNAUTHORIZED)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_bad_request(self):
         explanation_id = str(uuid.uuid4())
         # No content specified
@@ -2518,6 +2538,7 @@ that are running Red Hat Enterprise Linux 9.
             r = self.client.post(reverse('explanations'), payload, format='json')
             self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_bad_request_with_wca_client(self):
         explanation_id = str(uuid.uuid4())
         # No content specified
@@ -2588,6 +2609,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         enabled: yes
 """
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_ok(self):
         generation_id = str(uuid.uuid4())
         payload = {
@@ -2618,6 +2640,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             r = self.client.post(reverse('generations'), payload, format='json')
             self.assertEqual(r.status_code, HTTPStatus.UNAUTHORIZED)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_bad_request(self):
         generation_id = str(uuid.uuid4())
         # No content specified
@@ -2631,6 +2654,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             r = self.client.post(reverse('generations'), payload, format='json')
             self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_bad_request_with_wca_client(self):
         generation_id = str(uuid.uuid4())
         # No content specified

--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -133,7 +133,7 @@ LOGOUT_REDIRECT_URL = 'home'
 LOGIN_ERROR_URL = 'login'
 
 ANSIBLE_AI_ENABLE_TECH_PREVIEW = (
-    os.getenv('ANSIBLE_AI_ENABLE_TECH_PREVIEW', 'True').lower() == 'true'
+    os.getenv('ANSIBLE_AI_ENABLE_TECH_PREVIEW', 'False').lower() == 'true'
 )
 
 SIGNUP_URL = os.environ.get('SIGNUP_URL', 'https://www.redhat.com/en/engage/project-wisdom')

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -32,6 +32,7 @@ from ansible_ai_connect.ai.api.tests.test_views import (
 
 
 class TestMiddleware(WisdomServiceAPITestCaseBase):
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
@@ -135,6 +136,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                 self.assertNotInLog("username", log)
                 self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     @patch(
         'ansible_ai_connect.ai.api.pipelines.completion_stages.pre_process.fmtr.preprocess',
@@ -156,6 +158,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
             )
             self.assertSegmentTimestamp(log)
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_segment_error(self):
         payload = {
@@ -202,6 +205,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
             analytics.max_retries = analytics.Client.DefaultConfig.max_retries
             analytics.send = False
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(SEGMENT_WRITE_KEY='DUMMY_KEY_VALUE')
     def test_204_empty_response(self):
         payload = {

--- a/ansible_wisdom/main/tests/test_settings.py
+++ b/ansible_wisdom/main/tests/test_settings.py
@@ -51,6 +51,7 @@ class TestSettings(SimpleTestCase):
     @patch.dict(
         os.environ,
         {
+            'ANSIBLE_AI_ENABLE_TECH_PREVIEW': 'true',
             'SOCIAL_AUTH_GITHUB_TEAM_KEY': 'teamkey',
             'SOCIAL_AUTH_GITHUB_TEAM_SECRET': 'teamsecret',
             'SOCIAL_AUTH_GITHUB_TEAM_ID': '5678',
@@ -69,6 +70,7 @@ class TestSettings(SimpleTestCase):
     @patch.dict(
         os.environ,
         {
+            'ANSIBLE_AI_ENABLE_TECH_PREVIEW': 'true',
             'SOCIAL_AUTH_GITHUB_TEAM_KEY': 'teamkey',
             'SOCIAL_AUTH_GITHUB_TEAM_SECRET': 'teamsecret',
             'SOCIAL_AUTH_GITHUB_TEAM_ID': '',
@@ -86,6 +88,7 @@ class TestSettings(SimpleTestCase):
     @patch.dict(
         os.environ,
         {
+            'ANSIBLE_AI_ENABLE_TECH_PREVIEW': 'true',
             'SOCIAL_AUTH_GITHUB_TEAM_KEY': '',
             'SOCIAL_AUTH_GITHUB_KEY': "key",
             'SOCIAL_AUTH_GITHUB_SECRET': 'secret',

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -217,6 +217,7 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
 
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @override_settings(WCA_SECRET_DUMMY_SECRETS='1234567:valid')
     @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
     @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)


### PR DESCRIPTION
Disable the Tech Preview by default until we finally remove the associate
logic.

The previous behaviour was to continue to enable the legacy TC mode by default which
was not consistent with the reality of our prod environment.

Note: unfortunately, a lot of tests are relying on `ANSIBLE_AI_ENABLE_TECH_PREVIEW=True`. Those will have to be remove or fixed later.