### PR TITLE
Unit Test failure fix

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -297,7 +297,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
             mock_model_id=Mock(side_effect=WcaNoDefaultModelId),
         )
         model_client, model_input = stub
-        self.mock_wca_client_with(model_client)
+        self.mock_model_client_with(model_client)
         with self.assertLogs(logger='root', level='DEBUG') as log:
             r = self.client.post(reverse('completions'), model_input)
             self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Fix [a unit test failure](https://github.com/ansible/ansible-ai-connect-service/actions/runs/9211871151/job/25342235081)
```
======================================================================
ERROR: test_wca_completion_user_not_linked_to_org (ansible_ai_connect.ai.api.tests.test_views.TestCompletionWCAView.test_wca_completion_user_not_linked_to_org)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/django/test/utils.py", line 461, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/django/test/utils.py", line 461, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ansible-ai-connect-service/ansible-ai-connect-service/ansible_ai_connect/ai/api/tests/test_views.py", line 300, in test_wca_completion_user_not_linked_to_org
    self.mock_wca_client_with(model_client)
    ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TestCompletionWCAView' object has no attribute 'mock_wca_client_with'

----------------------------------------------------------------------
```
## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Execute unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See the section above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
