### PR TITLE
remove newline in version_info.json in push workflow

### DIFF
--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -215,7 +215,7 @@ spec:
             image: busybox
             command: ["/bin/sh", "-c"]
             args:
-              - echo $(date "+%Y%m%d%H%M") > $(results.time-stamp.path)
+              - echo -n $(date "+%Y%m%d%H%M") > $(results.time-stamp.path)
         results:
           - name: time-stamp
     - name: build-container


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-24017

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

A followup to https://github.com/ansible/ansible-ai-connect-service/pull/1056 which missed the push workflow that this PR is changing.

### fixing timestamp for build input

- remove an extra newline that breaks the `json.load` of  `version_info.json` 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test

tested in PR build/deployments

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
