### PR TITLE
wca_client: reduce the unit-tests dep with the local config

### DIFF
--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -132,6 +132,8 @@ def assert_call_count_metrics(metric):
 
 
 @override_settings(WCA_SECRET_BACKEND_TYPE='dummy')
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY=None)
+@override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_NAME=None)
 class TestWCAClient(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     @override_settings(WCA_SECRET_DUMMY_SECRETS='11009103:my-key<sep>my-optimized-model')
     def test_mock_wca_get_api_key(self):
@@ -241,6 +243,10 @@ class TestWCAClient(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
 
 @override_settings(ANSIBLE_WCA_RETRY_COUNT=1)
 @override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
+@override_settings(ANSIBLE_WCA_IDP_URL="https://iam.cloud.ibm.com/identity")
+@override_settings(ANSIBLE_WCA_IDP_LOGIN=None)
+@override_settings(ANSIBLE_WCA_IDP_PASSWORD=None)
 class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     @assert_call_count_metrics(metric=ibm_cloud_identity_token_hist)
     def test_get_token(self):
@@ -551,6 +557,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         )
 
 
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
 class TestWCACodematch(WisdomServiceLogAwareTestCase):
     def setUp(self):
         super().setUp()
@@ -716,6 +723,7 @@ class TestWCACodematch(WisdomServiceLogAwareTestCase):
         self.assertEqual(e.exception.model_id, model_id)
 
 
+@override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_NAME=None)
 class TestDummySecretManager(TestCase):
     def setUp(self):
         super().setUp()
@@ -746,6 +754,9 @@ class TestDummySecretManager(TestCase):
         self.assertEqual(sm.get_secret(123, Suffixes.API_KEY)["SecretString"], "abcdef")
 
 
+@override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+@override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_NAME=None)
+@override_settings(WCA_SECRET_DUMMY_SECRETS="")
 class TestWCAClientOnPrem(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     @override_settings(ANSIBLE_WCA_USERNAME='username')
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY='12345')
@@ -790,6 +801,7 @@ class TestWCAClientOnPrem(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
 @override_settings(ANSIBLE_WCA_USERNAME='username')
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY='12345')
 @override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_NAME='model-name')
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
 class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
     def test_headers(self):
         suggestion_id = 'suggestion_id'
@@ -834,6 +846,7 @@ class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
 @override_settings(ANSIBLE_WCA_USERNAME='username')
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY='12345')
 @override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_NAME='model-name')
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
 class TestWCAOnPremCodematch(WisdomServiceLogAwareTestCase):
     def test_headers(self):
         suggestions = [


### PR DESCRIPTION
Ensure some specific local settings won't break the wca_client test-suite.
