### PR TITLE
snyk: extend the expiration date for SNYK-PYTHON-PYOPENSSL-6592766

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,7 +14,7 @@ ignore:
   SNYK-PYTHON-PYOPENSSL-6592766:
     - '*':
         reason: SSL_OP_NO_TICKET option isn't enabled
-        expires: 2024-05-24T15:02:32.468Z
+        expires: 2024-10-24T15:02:32.468Z
         created: 2024-04-24T15:02:32.471Z
   SNYK-PYTHON-PYOPENSSL-6157250:
     - '*':


### PR DESCRIPTION
The vulnerability severity is low and we don't expose any TLS service.
