### PR TITLE
models: break up the dependency between the user and the payload

### DIFF
--- a/ansible_wisdom/ai/api/data/data_model.py
+++ b/ansible_wisdom/ai/api/data/data_model.py
@@ -37,9 +37,6 @@ class APIPayload(BaseModel):
 class ModelMeshData(TypedDict):
     prompt: str
     context: str
-    userId: Optional[str]
-    rh_user_has_seat: bool
-    organization_id: Optional[int] = None
     suggestionId: Optional[str] = None
 
 

--- a/ansible_wisdom/ai/api/model_client/base.py
+++ b/ansible_wisdom/ai/api/model_client/base.py
@@ -31,7 +31,7 @@ class ModelMeshClient:
         self._timeout = int(i) if i is not None else None
 
     @abstractmethod
-    def infer(self, model_input, model_id: str = "", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id: str = "", suggestion_id=None) -> Dict[str, Any]:
         pass
 
     def codematch(self, model_input, model_id):

--- a/ansible_wisdom/ai/api/model_client/dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/dummy_client.py
@@ -74,7 +74,7 @@ class DummyClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
         if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:

--- a/ansible_wisdom/ai/api/model_client/grpc_client.py
+++ b/ansible_wisdom/ai/api/model_client/grpc_client.py
@@ -52,7 +52,7 @@ class GrpcClient(ModelMeshClient):
         super().set_inference_url(inference_url=inference_url)
         self._inference_stub = self.get_inference_stub()
 
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
         model_id = self.get_model_id(None, model_id)
         logger.debug(f"Input prompt: {model_input}")
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")

--- a/ansible_wisdom/ai/api/model_client/http_client.py
+++ b/ansible_wisdom/ai/api/model_client/http_client.py
@@ -41,7 +41,7 @@ class HttpClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
         model_id = self.get_model_id(None, model_id)
         self._prediction_url = f"{self._inference_url}/predictions/{model_id}"
 

--- a/ansible_wisdom/ai/api/model_client/langchain.py
+++ b/ansible_wisdom/ai/api/model_client/langchain.py
@@ -90,7 +90,7 @@ class LangChainClient(ModelMeshClient):
     def get_chat_model(self, model_id):
         raise NotImplementedError
 
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
         model_id = self.get_model_id(None, model_id)
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")

--- a/ansible_wisdom/ai/api/model_client/llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/llamacpp_client.py
@@ -32,7 +32,7 @@ class LlamaCPPClient(ModelMeshClient):
         self.session = requests.Session()
         self.headers = {"Content-Type": "application/json"}
 
-    def infer(self, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
         model_id = self.get_model_id(None, model_id)
         self._prediction_url = f"{self._inference_url}/completion"
 

--- a/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_bam_client.py
@@ -87,5 +87,5 @@ class TestBam(TestCase):
             },
         )
 
-        response = model_client.infer(self.model_input, model_id=model)
+        response = model_client.infer(None, self.model_input, model_id=model)
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_dummy_client.py
@@ -43,7 +43,7 @@ class TestDummyClient(SimpleTestCase):
     def test_infer_with_jitter(self, loads, randbelow, sleep):
         client = DummyClient(inference_url="https://example.com")
         randbelow.return_value = random_value
-        client.infer(model_input="input")
+        client.infer(None, model_input="input")
         sleep.assert_called_once_with(latency / 1000)
         loads.assert_called_once_with(body)
 
@@ -52,7 +52,7 @@ class TestDummyClient(SimpleTestCase):
     @mock.patch("json.loads")
     def test_infer_without_jitter(self, loads, sleep):
         client = DummyClient(inference_url="https://ibm.com")
-        client.infer(model_input="input")
+        client.infer(None, model_input="input")
         sleep.assert_called_once_with(latency / 1000)
         loads.assert_called_once_with(body)
 

--- a/ansible_wisdom/ai/api/model_client/tests/test_llamacpp_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_llamacpp_client.py
@@ -66,7 +66,7 @@ class TestLlamaCPPClient(TestCase):
             },
         )
 
-        response = model_client.infer(self.model_input)
+        response = model_client.infer(None, self.model_input)
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))
 
     @responses.activate
@@ -93,7 +93,7 @@ class TestLlamaCPPClient(TestCase):
             },
         )
 
-        response = model_client.infer(self.model_input, model_id=model)
+        response = model_client.infer(None, self.model_input, model_id=model)
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))
 
     @override_settings(ANSIBLE_AI_MODEL_NAME="test")
@@ -102,4 +102,4 @@ class TestLlamaCPPClient(TestCase):
         model_client = LlamaCPPClient(inference_url=self.inference_url)
         model_client.session.post = Mock(side_effect=ReadTimeout())
         with self.assertRaises(ModelTimeoutError):
-            model_client.infer(self.model_input)
+            model_client.infer(None, self.model_input)

--- a/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_ollama_client.py
@@ -46,5 +46,5 @@ class TestOllama(TestCase):
 
         m_ollama.return_value = final
         model_client = OllamaClient("http://localhost")
-        response = model_client.infer(self.model_input, model_id="test")
+        response = model_client.infer(None, self.model_input, model_id="test")
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/tests/test_wca_client.py
@@ -444,6 +444,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_client.get_api_key = Mock(return_value=api_key)
 
         result = model_client.infer(
+            request=Mock(),
             model_input=model_input,
             model_id=model_id,
             suggestion_id=suggestion_id,
@@ -485,7 +486,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_client.get_api_key = Mock(return_value=api_key)
         with self.assertRaises(ModelTimeoutError) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -517,7 +521,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_client.get_api_key = Mock(return_value=api_key)
         with self.assertRaises(WcaInferenceFailure) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -555,7 +562,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
 
         with self.assertRaises(WcaSuggestionIdCorrelationFailure) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -569,7 +579,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_id, model_client, model_input = stub
         with self.assertRaises(WcaInvalidModelId) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -579,7 +592,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_id, model_client, model_input = stub
         with self.assertRaises(WcaInvalidModelId) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -589,7 +605,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_id, model_client, model_input = stub
         with self.assertRaises(WcaEmptyResponse) as e:
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -608,7 +627,10 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_id, model_client, model_input = stub
         with self.assertRaises(WcaBadRequest):
             model_client.infer(
-                model_input=model_input, model_id=model_id, suggestion_id=DEFAULT_SUGGESTION_ID
+                request=Mock(),
+                model_input=model_input,
+                model_id=model_id,
+                suggestion_id=DEFAULT_SUGGESTION_ID,
             )
 
     @assert_call_count_metrics(metric=wca_codegen_hist)
@@ -894,6 +916,7 @@ class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
         model_client.session.post = Mock(return_value=MockResponse(json={}, status_code=200))
 
         model_client.infer(
+            request=Mock(),
             model_input=model_input,
             suggestion_id=suggestion_id,
         )

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/deserialise.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/deserialise.py
@@ -62,7 +62,6 @@ class DeserializeStage(PipelineElement):
             )
 
         payload = APIPayload(**request_serializer.validated_data)
-        payload.userId = request.user.uuid
         payload.original_prompt = request.data.get("prompt", "")
 
         context.payload = payload

--- a/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_wisdom/ai/api/pipelines/completion_stages/inference.py
@@ -85,9 +85,6 @@ class InferenceStage(PipelineElement):
                 {
                     "prompt": payload.prompt,
                     "context": payload.context,
-                    "userId": str(payload.userId) if payload.userId else None,
-                    "rh_user_has_seat": request._request.user.rh_user_has_seat,
-                    "organization_id": request._request.user.org_id,
                     "suggestionId": str(suggestion_id),
                 }
             ]
@@ -102,7 +99,7 @@ class InferenceStage(PipelineElement):
         start_time = time.time()
         try:
             predictions = model_mesh_client.infer(
-                data, model_id=model_id, suggestion_id=suggestion_id
+                request, data, model_id=model_id, suggestion_id=suggestion_id
             )
             model_id = predictions.get("model_id", model_id)
         except ModelTimeoutError as e:

--- a/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -45,7 +45,12 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
         self.user.rh_user_has_seat = True
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         self.user.organization.telemetry_opt_out = False
+        self.user.organization.save()
         feature_flags.FeatureFlags.instance = None
+
+    def tearDown(self):
+        Organization.objects.filter(id=123).delete()
+        super().tearDown()
 
     @staticmethod
     def on_segment_error(self, error, items):
@@ -195,6 +200,7 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_error_no_org(self, base_send_segment_event, LDClient):
         LDClient.return_value.variation.return_value = True
+        self.user.organization.delete()
         self.user.organization = None
         self._assert_event_not_sent(base_send_segment_event)
 


### PR DESCRIPTION
Pass the `request` object as the first `infer()` parameter and remove the
user related information from the payload.
