### PR TITLE
wcaOnPrem: raise a 404 with feature_not_released_yet for playbook ExpGen

### DIFF
--- a/ansible_wisdom/ai/api/exceptions.py
+++ b/ansible_wisdom/ai/api/exceptions.py
@@ -143,6 +143,12 @@ class ServiceUnavailable(BaseWisdomAPIException):
     default_detail = 'An error occurred attempting to complete the request.'
 
 
+class FeatureNotAvailable(BaseWisdomAPIException):
+    status_code = 404
+    default_code = 'feature_not_available'
+    default_detail = 'The feature is not available.'
+
+
 class InternalServerError(BaseWisdomAPIException):
     status_code = 500
     default_code = 'internal_server'

--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -28,6 +28,7 @@ from prometheus_client import Counter, Histogram
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 
+from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.formatter import (
     get_task_names_from_prompt,
     strip_task_preamble_from_multi_task_prompt,
@@ -581,3 +582,11 @@ class WCAOnPremClient(BaseWCAClient):
             )
 
         return summary
+
+    def generate_playbook(
+        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+    ) -> tuple[str, str]:
+        raise FeatureNotAvailable
+
+    def explain_playbook(self, request, content: str) -> str:
+        raise FeatureNotAvailable

--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -33,12 +33,13 @@ from ansible_ai_connect.users.constants import (
 from ansible_ai_connect.users.tests.test_users import create_user
 
 
-def create_user_with_provider(user_provider):
+def create_user_with_provider(user_provider, **kwargs):
     return create_user(
         username='test_user_name',
         password='test_passwords',
         provider=user_provider,
         external_username='anexternalusername',
+        **kwargs,
     )
 
 


### PR DESCRIPTION
## Description

Raise an err 404 with `feature_not_available` code when the client tries to access the ExpGen endpoint of a OnPrem server.

## Testing

unit-tests

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: