### PR TITLE
AAP-24584: Remove the banner about tech preview being over

### DIFF
--- a/ansible_wisdom/main/templates/base.html
+++ b/ansible_wisdom/main/templates/base.html
@@ -19,17 +19,6 @@
         </div>
         <br />
         {% endif %}
-        {% if not use_tech_preview %}
-        <div class="pf-c-alert pf-m-info" aria-label="Information alert">
-          <div class="pf-c-alert__icon">
-            <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
-          </div>
-          <p class="pf-c-alert__title">
-            The {{ project_name }} Technical Preview is no longer available. For continued access to the commercial service, please see <a class="pf-l-level__item" href="https://www.redhat.com/en/blog/getting-started-red-hat-ansible-lightspeed-ibm-watsonx-code-assistant" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span>Getting started with {{ project_name }}</a>.
-          </p>
-        </div>
-        <br />
-        {% endif %}
         {% endblock banner %}
         {% if messages %}
             <ul class="messages">

--- a/ansible_wisdom/users/tests/test_views.py
+++ b/ansible_wisdom/users/tests/test_views.py
@@ -48,7 +48,6 @@ class UserHomeTestAsAnonymous(WisdomAppsBackendMocking, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Please log in using the button below.", count=1)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
@@ -81,7 +80,7 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: administrator, licensed user")
-        self.assertContains(response, "pf-c-alert__title", count=2)
+        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertContains(response, "model settings have not been configured", count=1)
         self.assertContains(response, "Admin Portal", count=1)
 
@@ -108,14 +107,12 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
     def test_rh_admin_without_seat_and_with_no_secret_no_sub_without_tech_preview(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "pf-c-alert__title")
         self.assertContains(response, "Your organization doesn't have access to Project Name.")
         self.assertContains(
             response,
             "You do not have an Active subscription to Ansible Automation Platform "
             "which is required to use Project Name.",
         )
-        self.assertContains(response, "The Project Name Technical Preview is no longer available")
         self.assertContains(response, "Role: administrator")
         self.assertContains(response, "Admin Portal")
 
@@ -126,7 +123,6 @@ class UserHomeTestAsAdmin(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: administrator, licensed user")
-        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertContains(response, "Admin Portal")
 
 
@@ -189,11 +185,9 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Role:")
-        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertContains(response, "You do not have a licensed seat for Project Name")
         self.assertNotContains(response, "You will be limited to features of the Project Name")
         self.assertNotContains(response, "Admin Portal")
-        self.assertContains(response, "The Project Name Technical Preview is no longer available")
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS='')
     @patch.object(ansible_ai_connect.users.models.User, "rh_org_has_subscription", True)
@@ -214,7 +208,6 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Role: licensed user")
         self.assertContains(response, "Project Name</h1>")
-        self.assertContains(response, "pf-c-alert__title", count=1)
         self.assertNotContains(response, "Admin Portal")
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
@@ -241,7 +234,6 @@ class UserHomeTestAsUser(WisdomAppsBackendMocking, TestCase):
             response, "Contact your Red Hat Organization's administrator for more information."
         )
         self.assertContains(response, "fa-exclamation-circle")
-        self.assertContains(response, "The Project Name Technical Preview is no longer available")
 
 
 @override_settings(AUTHZ_BACKEND_TYPE='dummy')
@@ -286,7 +278,6 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         )
         self.client.login(username=self.user.username, password=self.password)
         r = self.client.get(reverse('home'))
-        self.assertContains(r, "pf-c-alert__title", count=1)
         self.assertContains(r, "Your organization doesn't have access to Project Name.")
         self.assertIn(settings.COMMERCIAL_DOCUMENTATION_URL, str(r.content))
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24584

## Description
This PR simply removes the requested banner.

It tickles at the iceberg of "Tech Preview" removal... I started following the rabbit down the rabbit hole.. but the changes started becoming monstrous and, since the banner must be removed for "on prem" which has a code freeze, took the simplest route.

## Testing
Run `ansible-ai-connect-service` with Tech Preview disabled.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Run the service using the manner to which you're most accustomed.
5. Check the Home Page.

### Scenarios tested
As above.

I also updated an AAIC instance to use the container image built by this PR and verified "on prem" lacks the banner too.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
