### PR TITLE
AAP-23414: Lightspeed onprem to block the metrics endpoint from public access. Fix URL

### DIFF
--- a/ansible_wisdom/main/urls.py
+++ b/ansible_wisdom/main/urls.py
@@ -64,7 +64,9 @@ urlpatterns = [
     path('', HomeView.as_view(), name='home'),
     # add the GitHub OAuth redirect URL /complete/github-team/
     path('', include('social_django.urls', namespace='social')),
-    path('metrics/', MetricsView.as_view(), name='prometheus-metrics'),
+    # Do not add a trailing slash. django_prometheus uses plain /metrics
+    # Adding a trailing slash breaks our metric collection in all sorts of ways.
+    path('metrics', MetricsView.as_view(), name='prometheus-metrics'),
     path('admin/', admin.site.urls),
     path(f'api/{WISDOM_API_VERSION}/ai/', include("ansible_ai_connect.ai.api.urls")),
     path(f'api/{WISDOM_API_VERSION}/me/', CurrentUserView.as_view(), name='me'),


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23414

## Description
Further too https://github.com/ansible/ansible-ai-connect-service/pull/1044 various unexpected HTTP responses to the `/metrics` endpoint have been observed. These have been traced back to the use of `APPEND_SLASH = True`. Various metric collectors are scrapping `/metrics` and Django is redirecting this to `/metrics/` matching our defined URL.
 
## Testing
Deploy to staging and check metrics are available on `/metrics` (no trailing slash).

Check Grafana does not contain HTTP 301's (and hopefully no HTTP 406's however this may be a different reason).