### PR TITLE
AAP-24695: Metrics endpoint is generating HTTP-406's

### DIFF
--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -131,6 +131,16 @@ class TestMetricsView(APITransactionTestCase):
         self.user.delete()
 
     @override_settings(ALLOW_METRICS_FOR_ANONYMOUS_USERS=True)
+    def test_content_type_text(self):
+        r = self.client.get(reverse('prometheus-metrics'), headers={'Accept': 'text/plain'})
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+
+    @override_settings(ALLOW_METRICS_FOR_ANONYMOUS_USERS=True)
+    def test_content_type_json(self):
+        r = self.client.get(reverse('prometheus-metrics'), headers={'Accept': 'application/json'})
+        self.assertEqual(r.status_code, HTTPStatus.NOT_ACCEPTABLE)
+
+    @override_settings(ALLOW_METRICS_FOR_ANONYMOUS_USERS=True)
     def test_anonymous_access(self):
         r = self.client.get(reverse('prometheus-metrics'))
         self.assertEqual(r.status_code, HTTPStatus.OK)

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -24,6 +24,7 @@ from django_prometheus.exports import ExportToDjangoView
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.renderers import BaseRenderer
 from rest_framework.views import APIView
 
 from ansible_ai_connect.ai.api.permissions import (
@@ -112,8 +113,20 @@ class ConsoleView(ProtectedTemplateView):
         return context
 
 
+class PlainTextRenderer(BaseRenderer):
+    media_type = 'text/plain'
+    format = 'txt'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        if not isinstance(data, str):
+            data = str(data)
+        return data.encode(self.charset)
+
+
 class MetricsView(APIView):
     schema = None
+
+    renderer_classes = [PlainTextRenderer]
 
     def initialize_request(self, request, *args, **kwargs):
         if settings.ALLOW_METRICS_FOR_ANONYMOUS_USERS:


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24695

## Description
Further to https://github.com/ansible/ansible-ai-connect-service/pull/1044

It has been observed that Dynatrace's `/metrics` scraping is returning HTTP406's.

This indicates our server is unable to find a response renderer capable of handling the request's `Accept` header.
 
This is caused by the [default](https://github.com/ansible/ansible-ai-connect-service/pull/1044) Django response renderer to support `application/json`

This PR adds a renderer for `text/plain`.

## Testing

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Start the service as you would normally.
5. Check `http://localhost:8000/metrics` from your browser.
6. Check `http://localhost:8000/metrics` from Postman (or similar) with an `Accept` header of `text/plan`.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
