### PR TITLE
raise exception in case of generation or explanation issue

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -494,6 +494,7 @@ class WCAClient(BaseWCAClient):
             headers=headers,
             json=data,
         )
+        result.raise_for_status()
         response = json.loads(result.text)
 
         playbook = response["playbook"]
@@ -519,6 +520,7 @@ class WCAClient(BaseWCAClient):
             headers=headers,
             json=data,
         )
+        result.raise_for_status()
         response = json.loads(result.text)
         return response["explanation"]
 


### PR DESCRIPTION
Use `raise_for_status()` to trigger an exception when the WCA requests are not
successful.

See: https://3.python-requests.org/user/quickstart/#response-status-codes
