### PR TITLE
AAP-24913: Parameterise 'Login with Ansible Automation Platform' text

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -170,6 +170,7 @@ else:
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/unauthorized/'
 
 AAP_API_URL = os.environ.get("AAP_API_URL")
+AAP_API_PROVIDER_NAME = os.environ.get("AAP_API_PROVIDER_NAME", "Ansible Automation Platform")
 SOCIAL_AUTH_VERIFY_SSL = os.getenv("SOCIAL_AUTH_VERIFY_SSL", 'True').lower() in ('true', '1', 't')
 SOCIAL_AUTH_AAP_KEY = os.environ.get("SOCIAL_AUTH_AAP_KEY")
 SOCIAL_AUTH_AAP_SECRET = os.environ.get("SOCIAL_AUTH_AAP_SECRET")

--- a/ansible_wisdom/main/templates/registration/login.html
+++ b/ansible_wisdom/main/templates/registration/login.html
@@ -19,7 +19,7 @@
                     <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>
 
                     {% if deployment_mode == 'onprem' %}
-                    <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'aap' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with Ansible Automation Platform</a>
+                    <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'aap' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with {{ aap_api_provider_name }}</a>
                     {% else %}
                     <a class="pf-c-button pf-m-primary" href="{% url 'social:begin' 'oidc' %}{% if next %}?next={{ next|urlencode }}{% endif %}">Log in with Red Hat</a>
                     {% endif %}

--- a/ansible_wisdom/main/tests/test_views.py
+++ b/ansible_wisdom/main/tests/test_views.py
@@ -95,6 +95,17 @@ class AlreadyAuth(TestCase):
         self.assertIn("You are currently not logged in.", contents)
         self.assertIn("Log in with Ansible Automation Platform", contents)
 
+    @override_settings(DEPLOYMENT_MODE='onprem')
+    @override_settings(AAP_API_PROVIDER_NAME='Ansible Automation Controller')
+    def test_login_aap_override_provider_name(self):
+        request = RequestFactory().get("/login")
+        request.user = AnonymousUser()
+        response = LoginView.as_view()(request)
+        response.render()
+        contents = response.content.decode()
+        self.assertIn("You are currently not logged in.", contents)
+        self.assertIn("Log in with Ansible Automation Controller", contents)
+
     @override_settings(DEPLOYMENT_MODE='upstream')
     def test_login_django(self):
         request = RequestFactory().get("/login")

--- a/ansible_wisdom/main/views.py
+++ b/ansible_wisdom/main/views.py
@@ -45,6 +45,7 @@ class LoginView(auth_views.LoginView):
         context["use_tech_preview"] = settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW
         context["deployment_mode"] = settings.DEPLOYMENT_MODE
         context["project_name"] = settings.ANSIBLE_AI_PROJECT_NAME
+        context["aap_api_provider_name"] = settings.AAP_API_PROVIDER_NAME
         return context
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24913

## Description
Support overriding the name of the AAP authentication provider.

During the "on prem" testathon there was some discussion as to whether the name should be "Ansible Automation Platform" or "Ansible Automation Controller" and whether this would even be the same for AAP 2.4 and AAP 2.5. This PR allows any value to be used to cover all scenarios.

## Testing
Run as "on prem" and check wording of the "Login with ...." button.

### Steps to test
1. Pull down the PR
2. `make start-backends` 
3. `make create-application`
4. Set `DEPLOYMENT_MODE="onprem"`
5. Set `AAP_API_PROVIDER_NAME=whatever you like`
6. Start the service using your method of choice.
7. Click "Log in" button on the home page.
8. Check wording of "Log in with ....". It should match whatever you set `AAP_API_PROVIDER_NAME` to. 

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
