### PR TITLE
unit-tests: reduce the dependency with local configuration

### DIFF
--- a/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_wisdom/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -33,6 +33,7 @@ from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
 from ansible_ai_connect.organizations.models import Organization
 
 
+@override_settings(DEPLOYMENT_MODE='saas')
 class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
     @classmethod
     def setUpClass(cls):

--- a/ansible_wisdom/ai/tests/test_apps.py
+++ b/ansible_wisdom/ai/tests/test_apps.py
@@ -60,6 +60,7 @@ class TestAiApp(APITestCase):
 
     @override_settings(ANSIBLE_WCA_USERNAME='username')
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE='wca-onprem')
+    @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY=None)
     def test_wca_on_prem_client_missing_api_key(self):
         app_config = AppConfig.create('ansible_ai_connect.ai')
         with self.assertRaises(WcaKeyNotFound):


### PR DESCRIPTION
- telemetry tests will likely fail if the deployment mode is not `saas`.
- don't assume `ANSIBLE_AI_MODEL_MESH_API_KEY` is not set.
