### PR TITLE
Rewrite algorythm from regexp to simple linear one

### DIFF
--- a/ansible_wisdom/ai/api/formatter.py
+++ b/ansible_wisdom/ai/api/formatter.py
@@ -315,8 +315,11 @@ def strip_task_preamble_from_multi_task_prompt(prompt):
 
 def unify_prompt_ending(prompt):
     # WCA codegen endpoint requires prompt to end with \n and can't contain : at the end
-    prompt = re.sub(r'[:\s]*$', '', prompt)
-    return f"{prompt}\n"
+    # Rewritten from regexp to linear algorythm to avoid backtracking and denial of service
+    for i in range(len(prompt) - 1, 0, -1):
+        if not (prompt[i] == ':' or prompt[i].isspace()):
+            return f"{prompt[0:i + 1]}\n"
+    return '\n'
 
 
 def get_task_count_from_prompt(prompt):

--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -511,6 +511,21 @@ var3: value3
         after = "    # Install go & Install nginx & Install git\n"
         self.assertEqual(after, fmtr.unify_prompt_ending(before))
 
+    def test_unify_prompt_ending_with_fully_valid_string(self):
+        before = "  # Install go & Install nginx & Install git"
+        after = "  # Install go & Install nginx & Install git\n"
+        self.assertEqual(after, fmtr.unify_prompt_ending(before))
+
+    def test_unify_prompt_ending_empty_string(self):
+        before = ""
+        after = "\n"
+        self.assertEqual(after, fmtr.unify_prompt_ending(before))
+
+    def test_unify_prompt_ending_whitespaces_string(self):
+        before = "   \n \t:  \n \t:: "
+        after = "\n"
+        self.assertEqual(after, fmtr.unify_prompt_ending(before))
+
     def test_get_fqcn_module_from_prediction(self):
         self.assertEqual(
             "ansible.builtin.package",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: not needed
Sonar Cloud says replaced regexp can be a hotspot, hence replaced by linear algorithm. See quotation below:
```
Most of the regular expression engines use backtracking to try all possible execution paths of the regular expression when evaluating an input, in some cases it can cause performance issues, called catastrophic backtracking situations. In the worst case, the complexity of the regular expression is exponential in the size of the input, this means that a small carefully-crafted input (like 20 chars) can trigger catastrophic backtracking and cause a denial of service of the application. Super-linear regex complexity can lead to the same impact too with, in this case, a large carefully-crafted input (thousands chars).

This rule determines the runtime complexity of a regular expression and informs you of the complexity if it is not linear.
```

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. All existing and new tests are green.


### Scenarios tested
Tests executed.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
