### PR TITLE
playbook/gen: accept a new wizardId

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -429,6 +429,7 @@ class GenerationRequestSerializer(serializers.Serializer):
         fields = [
             'text',
             'generationId',
+            'wizardId',
             'createOutline',
             'ansibleExtensionVersion',
             'outline',
@@ -458,6 +459,12 @@ class GenerationRequestSerializer(serializers.Serializer):
         required=False,
         label="outline",
         help_text="A long step by step outline of the expected Ansible Playbook.",
+    )
+    wizardId = serializers.UUIDField(
+        format='hex_verbose',
+        required=False,
+        label="wizard ID",
+        help_text=("A UUID to track the succession of interaction from the user."),
     )
 
     metadata = Metadata(required=False)

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -828,6 +828,11 @@ components:
         outline:
           type: string
           description: A long step by step outline of the expected Ansible Playbook.
+        wizardId:
+          type: string
+          format: uuid
+          title: wizard ID
+          description: A UUID to track the succession of interaction from the user.
         metadata:
           $ref: '#/components/schemas/Metadata'
       required:


### PR DESCRIPTION
This new wizardId is used to track the series of interaction done by the
user in order to get the final playbook generated.
