### PR TITLE
AAP-24977: [DAST] Lightspeed Downstream: Server Leaks Version Information via 'Server' HTTP Response Header Field

### DIFF
--- a/tools/configs/nginx.conf
+++ b/tools/configs/nginx.conf
@@ -45,4 +45,6 @@ http {
     # See http://nginx.org/en/docs/ngx_core_module.html#include
     # for more information.
     include /etc/nginx/conf.d/*.conf;
+
+    server_tokens off;
 }


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24977

## Description
Suppress Server version information in HTTP Response headers.

Using a test "On prem" deployment:-

**Before**
```
server: nginx/1.22.1
```
**After**
```
server: nginx
```

CloudFront, for "SaaS" already strips the version:-
```
server: CloudFront
```


## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
