### PR TITLE
Telemetry Schema 2 for Playbook Exp/Gen

### DIFF
--- a/ansible_wisdom/ai/api/serializers.py
+++ b/ansible_wisdom/ai/api/serializers.py
@@ -290,26 +290,20 @@ class IssueFeedback(serializers.Serializer):
     )
 
 
-class PlaybookOutlineFeedback(serializers.Serializer):
+class PlaybookGenerationFeedback(serializers.Serializer):
     USER_ACTION_CHOICES = (('0', 'ACCEPTED'), ('1', 'REJECTED'), ('2', 'IGNORED'))
 
-    class Meta:
-        fields = ['action', 'outlineId']
-
     action = serializers.ChoiceField(choices=USER_ACTION_CHOICES, required=True)
-    outlineId = serializers.UUIDField(
+    wizardId = serializers.UUIDField(
         format='hex_verbose',
         required=True,
         label="Outline ID",
-        help_text="A UUID that identifies the playbook outline.",
+        help_text="A UUID that identifies the UI session.",
     )
 
 
 class PlaybookExplanationFeedback(serializers.Serializer):
     USER_ACTION_CHOICES = (('0', 'ACCEPTED'), ('1', 'REJECTED'), ('2', 'IGNORED'))
-
-    class Meta:
-        fields = ['action', 'explanationId']
 
     action = serializers.ChoiceField(choices=USER_ACTION_CHOICES, required=True)
     explanationId = serializers.UUIDField(
@@ -359,7 +353,7 @@ class FeedbackRequestSerializer(serializers.Serializer):
     metadata = Metadata(required=False)
     model = serializers.CharField(required=False)
     playbookExplanationFeedback = PlaybookExplanationFeedback(required=False)
-    playbookOutlineFeedback = PlaybookOutlineFeedback(required=False)
+    playbookGenerationFeedback = PlaybookGenerationFeedback(required=False)
     sentimentFeedback = SentimentFeedback(required=False)
     suggestionQualityFeedback = SuggestionQualityFeedback(required=False)
 

--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -617,7 +617,7 @@ class ContentMatches(GenericAPIView):
                 event['modelName'] = model_id
                 send_segment_event(event, event_name, user)
             else:
-                self._write_to_segment(
+                self.write_to_segment(
                     request_data,
                     duration,
                     exception,
@@ -664,7 +664,7 @@ class ContentMatches(GenericAPIView):
             )
         finally:
             duration = round((time.time() - start_time) * 1000, 2)
-            self._write_to_segment(
+            self.write_to_segment(
                 request_data,
                 duration,
                 exception,
@@ -677,7 +677,7 @@ class ContentMatches(GenericAPIView):
 
         return response_serializer
 
-    def _write_to_segment(
+    def write_to_segment(
         self,
         request_data,
         duration,
@@ -739,7 +739,9 @@ class Explanation(APIView):
         playbook = request_serializer.validated_data.get("content")
 
         llm = apps.get_app_config("ai").model_mesh_client
+        start_time = time.time()
         explanation = llm.explain_playbook(request, playbook)
+        duration = round((time.time() - start_time) * 1000, 2)
 
         # Anonymize response
         # Anonymized in the View to be consistent with where Completions are anonymized
@@ -753,10 +755,25 @@ class Explanation(APIView):
             "explanationId": explanation_id,
         }
 
+        self.write_to_segment(
+            request.user,
+            explanation_id,
+            duration,
+            playbook_length=len(playbook),
+        )
+
         return Response(
             answer,
             status=rest_framework_status.HTTP_200_OK,
         )
+
+    def write_to_segment(self, user, suggestion_id, duration, playbook_length):
+        event = {
+            'suggestionId': suggestion_id,
+            'duration': duration,
+            'playbook_length': playbook_length,
+        }
+        send_segment_event(event, "explanation", user)
 
 
 class Generation(APIView):
@@ -798,9 +815,12 @@ class Generation(APIView):
         create_outline = request_serializer.validated_data["createOutline"]
         outline = str(request_serializer.validated_data.get("outline", ""))
         text = request_serializer.validated_data["text"]
+        wizard_id = str(request_serializer.validated_data.get("wizardId", ""))
 
         llm = apps.get_app_config("ai").model_mesh_client
+        start_time = time.time()
         playbook, outline = llm.generate_playbook(request, text, create_outline, outline)
+        duration = round((time.time() - start_time) * 1000, 2)
 
         # Anonymize responses
         # Anonymized in the View to be consistent with where Completions are anonymized
@@ -817,8 +837,28 @@ class Generation(APIView):
             "format": "plaintext",
             "generationId": generation_id,
         }
+        self.write_to_segment(
+            request.user,
+            generation_id,
+            wizard_id,
+            duration,
+            create_outline,
+            playbook_length=len(playbook),
+        )
 
         return Response(
             answer,
             status=rest_framework_status.HTTP_200_OK,
         )
+
+    def write_to_segment(
+        self, user, generation_id, wizard_id, duration, create_outline, playbook_length
+    ):
+        event = {
+            'generationId': generation_id,
+            'wizardId': wizard_id,
+            'duration': duration,
+            'create_outline': create_outline,
+            'playbook_length': playbook_length,
+        }
+        send_segment_event(event, "generation", user)

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -800,8 +800,8 @@ components:
           type: string
         playbookExplanationFeedback:
           $ref: '#/components/schemas/PlaybookExplanationFeedback'
-        playbookOutlineFeedback:
-          $ref: '#/components/schemas/PlaybookOutlineFeedback'
+        playbookGenerationFeedback:
+          $ref: '#/components/schemas/PlaybookGenerationFeedback'
         sentimentFeedback:
           $ref: '#/components/schemas/SentimentFeedback'
         suggestionQualityFeedback:
@@ -923,19 +923,19 @@ components:
       required:
       - action
       - explanationId
-    PlaybookOutlineFeedback:
+    PlaybookGenerationFeedback:
       type: object
       properties:
         action:
           $ref: '#/components/schemas/ActionEnum'
-        outlineId:
+        wizardId:
           type: string
           format: uuid
           title: Outline ID
-          description: A UUID that identifies the playbook outline.
+          description: A UUID that identifies the UI session.
       required:
       - action
-      - outlineId
+      - wizardId
     SentimentFeedback:
       type: object
       properties:


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-21502>

## Description

Push events when:

- we preare an explanation for a playbook
- or we generate a new one

Also: 

- rename `PlaybookOutlineFeedback` as `PlaybookGenerationFeedback` and
  accept the `wizardId` parameter.
- rename `ContentMatches._write_to_segment()` to
  `ContentMatches.write_to_segment()` to match the other class of the module.

## Testing

- unit-tests

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:


