### PR TITLE
faux commercial users use faux commercial org

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -172,7 +172,7 @@ class BaseWCAClient(ModelMeshClient):
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")
 
-        organization_id = request.user.organization.id if request.user.organization else None
+        organization_id = request.user.org_id
         # WCA codegen fails if a multitask prompt includes the task preamble
         # https://github.com/rh-ibm-synergy/wca-feedback/issues/34
         prompt = strip_task_preamble_from_multi_task_prompt(prompt)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-25100

## Description
This is a follow-up to the changes in https://github.com/ansible/ansible-ai-connect-service/commit/615dec7c38c5b2c4b3384ae0e27d0875b1c0cfe0
We have some test users that don't have an org. They are part of the "Commercial" django group and need to use this fake org to retrieve their WCA configuration. This PR leverages the org_id user property to account for faux commercial users.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run an API test with a faux commercial user
3. Inferences should work again as faux commercial user

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Verified with steps above plus unit test that fails without my code change.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
