### PR TITLE
make user uuid searchable in django admin

### DIFF
--- a/ansible_wisdom/users/admin.py
+++ b/ansible_wisdom/users/admin.py
@@ -49,6 +49,7 @@ class WisdomUserAdmin(ExportMixin, UserAdmin):
     fieldsets = UserAdmin.fieldsets + (
         (None, {'fields': ('community_terms_accepted', 'commercial_terms_accepted')}),
     )
+    search_fields = UserAdmin.search_fields + ('uuid',)
 
 
 @admin.register(Group)

--- a/ansible_wisdom/users/tests/test_admin.py
+++ b/ansible_wisdom/users/tests/test_admin.py
@@ -1,0 +1,25 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.contrib.auth.admin import UserAdmin
+from django.test import TestCase
+
+
+class TestWisdomUserAdmin(TestCase):
+    def test_search_fields_includes_uuid(self):
+        wisdom_admin = admin.site._registry[get_user_model()]
+        expected_search_fields = UserAdmin.search_fields + ('uuid',)
+        self.assertEqual(wisdom_admin.search_fields, expected_search_fields)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-25178
<!-- This PR does not need a corresponding Jira item. -->

## Description
Currently we can see a user's UUID in django admin, but don't have a good way to find a user by UUID. This PR makes users searchable by UUID.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Start the service
3. Log in as a django admin
4. Search users by UUID

### Scenarios tested
Steps above, plus unit test

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
