### PR TITLE
bump protobuf to 4.25.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   'langchain~=0.2.3',
   'launchdarkly-server-sdk~=8.3.0',
   'opensearch-py~=2.1.1',
-  'protobuf~=4.22.1',
+  'protobuf~=4.25.3',
   'psycopg[binary]~=3.1.8',
   'pydantic==2.*',
   'pytz',

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -279,7 +279,7 @@ prometheus-client==0.20.0
     # via django-prometheus
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.22.1
+protobuf==4.25.3
     # via -r requirements.in
 psycopg[binary]==3.1.8
     # via -r requirements.in

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -279,7 +279,7 @@ prometheus-client==0.20.0
     # via django-prometheus
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.22.1
+protobuf==4.25.3
     # via -r requirements.in
 psycopg[binary]==3.1.8
     # via -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ jinja2==3.1.4
 langchain==0.2.3
 launchdarkly-server-sdk==8.3.0
 opensearch-py==2.1.1
-protobuf==4.22.1
+protobuf==4.25.3
 psycopg[binary]==3.1.8
 pydantic==2.6.4
 pytz


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23758

## Description
This addresses CVE-2024-2410. 

## Testing
### Scenarios tested
No testing has been completed on this change. We do not currently have an active use case for the gRPC client. No regressions are anticipated due to this minor version change.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
