### PR TITLE
AAP-24828: VS Code plugin gets Parse Error on 204

### DIFF
--- a/ansible_wisdom/main/middleware.py
+++ b/ansible_wisdom/main/middleware.py
@@ -177,6 +177,9 @@ class SegmentMiddleware:
         if response.status_code == 204:
             response.data = None
             response["Content-Length"] = 0
+            # Set content to empty string so that underlying streaming TCP connections
+            # do not read incorrect content when processing HTTP responses after 204s
+            response.content = ""
         return response
 
 

--- a/ansible_wisdom/main/tests/test_middleware.py
+++ b/ansible_wisdom/main/tests/test_middleware.py
@@ -241,6 +241,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
                     self.assertEqual(r.status_code, HTTPStatus.NO_CONTENT)
                     self.assertIsNone(r.data)
                     self.assertEqual(r["Content-Length"], "0")
+                    self.assertEqual(r.content, b"")
                     self.assertSegmentTimestamp(log)
         finally:
             # Restore defaults and set the 'send' flag to False during test execution


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24828

## Description
`content` was still being included in the HTTP response which, in conjunction with Axios's uses of `keepalive` for `TCP` connections caused the intermittent errors reported in the JIRA. Presumably, but hard to confirm categorically, Axios was parsing the HTTP stream for a 204 up to the expected end of the payload keeping the connection alive. On subsequent reads the `content` was first read (lingering on the open stream from the first response) which, since an invalid HTTP wire protocol header raised the exception...  Nice.  

## Testing
Run the `wisdom-service` from this PR with VSCode.

Perform some completions that can return a 204 (hard to find, so using `ANSIBLE_AI_MODEL_MESH_API_TYPE=wca-dummy` and mis-configuring/not configuring ARI for post processing works well to guarantee all responses are a 204!)

### Steps to test
1. Pull down the PR
2. `make start-backend`
3. `make create-application`
4. Set `ANSIBLE_AI_MODEL_MESH_API_TYPE` to `wca-dummy`
5. Set `ARI_KB_PATH` to something incorrect.
6. Run `wisdom-service` on local host as you would normally.
7. Configure VSCode to use your local instance

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
