### PR TITLE
AAP-25320: Analytics Telemetry: Filter out playbook keywords from the prediction to guarantee parsing the right module/collection

### DIFF
--- a/ansible_wisdom/ai/api/tests/test_formatter.py
+++ b/ansible_wisdom/ai/api/tests/test_formatter.py
@@ -634,7 +634,78 @@ var3: value3
                 "          az: us-east-1r\n"
             ),
         )
+
+    def test_get_fqcn_module_from_prediction_none(self):
         self.assertIsNone(fmtr.get_fqcn_or_module_from_prediction(None))
+
+    def test_get_ansible_task_keywords(self):
+        keywords = fmtr.get_ansible_task_keywords()
+        self.assertTrue("loop" in keywords)
+        self.assertTrue("action" in keywords)
+        self.assertTrue("async" in keywords)
+        self.assertTrue("become_method" in keywords)
+        self.assertTrue("collections" in keywords)
+        self.assertTrue("connection" in keywords)
+        self.assertTrue("delay" in keywords)
+        self.assertTrue("no_log" in keywords)
+        self.assertTrue("when" in keywords)
+        self.assertTrue("tags" in keywords)
+        self.assertTrue("timeout" in keywords)
+
+    def test_get_fqcn_module_from_prediction_with_task_keywords(self):
+        self.assertEqual(
+            "community.windows.win_iis_website",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      loop:\n"
+                "        - 8080\n"
+                "        - 8081\n"
+                "      community.windows.win_iis_website:\n"
+                "        name: \"name1\"\n"
+                "        state: started\n"
+            ),
+        )
+        self.assertEqual(
+            "community.windows.win_iis_website",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      community.windows.win_iis_website:\n"
+                "        name: \"name1\"\n"
+                "        state: started\n"
+                "      loop:\n"
+                "        - 8080\n"
+                "        - 8081\n"
+            ),
+        )
+        self.assertEqual(
+            "win_iis_website",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      loop:\n"
+                "        - 8080\n"
+                "        - 8081\n"
+                "      win_iis_website:\n"
+                "        name: \"name1\"\n"
+                "        state: started\n"
+            ),
+        )
+        self.assertEqual(
+            "win_iis_website",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      win_iis_website:\n"
+                "        name: \"name1\"\n"
+                "        state: started\n"
+                "      loop:\n"
+                "        - 8080\n"
+                "        - 8081\n"
+            ),
+        )
+        self.assertEqual(
+            "win_iis_website",
+            fmtr.get_fqcn_or_module_from_prediction(
+                "      timeout: 200\n"
+                "      win_iis_website:\n"
+                "        name: \"name1\"\n"
+                "        state: started\n"
+            ),
+        )
 
 
 if __name__ == "__main__":
@@ -666,3 +737,6 @@ if __name__ == "__main__":
     tests.test_strip_task_preamble_from_multi_task_prompt_one_preamble_changed()
     tests.test_strip_task_preamble_from_multi_task_prompt_two_preambles_changed()
     tests.test_get_fqcn_module_from_prediction()
+    tests.test_get_fqcn_module_from_prediction_none()
+    tests.test_get_ansible_task_keywords()
+    tests.test_get_fqcn_module_from_prediction_with_task_keywords()


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-25320>

## Description
Guarantee  we are filtering out Ansible `Playbook's Task` keywords from the module/collection parsing used for telemetry events payload.

## Considerations
- Tested this PR on top of https://github.com/ansible/ansible-ai-connect-service/pull/1108 , in order to ensure no dependency to `ansible` is declared (just the `ansible-core` one)

- Couldn't find a suitable (pre-computed) `List` object in `ansible-core` that provides all available `Task`'s class (and subclasses) fields available to use, so did a once (`global`) computation to get that list/set
-- Upsides: Dynamic Task fields available. No need for further maintaining once upgrading
-- Downsides: Memoized value (memory consumption). Computation costs once spinning up a pod, in order to memoize the value. Although honestly both values are not really considerable, I guess

- Another solution we can take is just to "hardcode" values somewhere in code, although will require for a few maintenance on doing `ansible-core` upgrades, but will not require for initial computation costs, just runtime predicate checks

- Another solution is do this same class introspection logic, but instead of at runtime, do it during some phase on the build time, so no initial computation costs, just runtime predicate checks again

### Scenarios tested
Tested by running actual unit tests, and increasing the coverage to support [those edge cases](https://github.com/ansible/ansible-ai-connect-service/pull/1119/files#diff-93b1364ecdbc7a29eb3a289b7f4d4c7673a3208c3bcbb401adae6ba583c01d07R655).

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
