### PR TITLE
better logging for unrecognized 404 inference

### DIFF
--- a/ansible_wisdom/ai/api/model_client/wca_client.py
+++ b/ansible_wisdom/ai/api/model_client/wca_client.py
@@ -237,7 +237,7 @@ class BaseWCAClient(ModelMeshClient):
             response.raise_for_status()
 
         except HTTPError as e:
-            logger.error(f"WCA inference failed due to {e}.")
+            logger.error(f"WCA inference failed for suggestion {suggestion_id} due to {e}.")
             raise WcaInferenceFailure(model_id=model_id)
 
         return response

--- a/ansible_wisdom/ai/api/tests/test_views.py
+++ b/ansible_wisdom/ai/api/tests/test_views.py
@@ -478,6 +478,7 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         response = MockResponse(
             json={"detail": "WML API call failed: Deployment id or name banana was not found."},
             status_code=HTTPStatus.NOT_FOUND,
+            headers={"Content-Type": "application/json"},
         )
         model_client.session.post = Mock(return_value=response)
         self.mock_model_client_with(model_client)
@@ -2200,6 +2201,7 @@ class TestContentMatchesWCAViewErrors(
         response = MockResponse(
             json={"detail": "WML API call failed: Deployment id or name banana was not found."},
             status_code=HTTPStatus.NOT_FOUND,
+            headers={"Content-Type": "application/json"},
         )
         self.model_client.session.post = Mock(return_value=response)
         self._assert_exception_in_log(WcaInvalidModelIdException)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-25477

## Description
There are WCA requests failing in production with a 404 that don't match ResponseStatusCode404WCABadRequestModelId and fall into generic handling, which does not log enough detail to troubleshoot. This PR adds an additional 404 check that logs the response body. It also adds an extra check in ResponseStatusCode404WCABadRequestModelId to be sure it's json before calling json(), which raises an error if the response is not json.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Adjust the prediction_url in BaseWCAClient.infer_from_parameters to something one character off
3. Make a completion request

Confirm the 404 response is nicely logged.

### Scenarios tested
Steps above plus unit tests.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
