### PR TITLE
remove langchain from the base image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   'ipython~=8.10.0',
   'jwcrypto~=1.5.6',
   'jinja2~=3.1.3',
-  'langchain~=0.2.3',
   'launchdarkly-server-sdk~=8.3.0',
   'opensearch-py~=2.1.1',
   'protobuf~=4.25.3',
@@ -57,6 +56,8 @@ classifiers = [
     "Framework :: Django",
     "Programming Language :: Python :: 3",
 ]
+[project.optional-dependencies]
+langchain = ['langchain~=0.2.3', 'langchain-community~=0.2.4']
 
 [project.urls]
 Homepage = "https://github.com/ansible/ansible-wisdom-service"

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -4,12 +4,6 @@
 #
 #    pip-compile --output-file=requirements-aarch64.txt requirements.in
 #
-aiohttp==3.9.4
-    # via
-    #   langchain
-    #   langchain-community
-aiosignal==1.3.1
-    # via aiohttp
 annotated-types==0.6.0
     # via pydantic
 ansible==8.5.0
@@ -37,7 +31,6 @@ asttokens==2.4.1
     # via stack-data
 attrs==23.2.0
     # via
-    #   aiohttp
     #   jsonschema
     #   referencing
 backcall==0.2.0
@@ -76,8 +69,6 @@ cryptography==42.0.6
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
-dataclasses-json==0.6.7
-    # via langchain-community
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -137,16 +128,10 @@ filelock==3.13.4
     #   huggingface-hub
     #   torch
     #   transformers
-frozenlist==1.4.1
-    # via
-    #   aiohttp
-    #   aiosignal
 fsspec==2024.3.1
     # via huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.22.2
@@ -158,7 +143,6 @@ idna==3.7
     # via
     #   -r requirements.in
     #   requests
-    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 ipython==8.10.0
@@ -178,12 +162,8 @@ joblib==1.4.0
     # via
     #   ansible-risk-insight
     #   scikit-learn
-jsonpatch==1.33
-    # via langchain-core
 jsonpickle==3.0.4
     # via ansible-risk-insight
-jsonpointer==2.4
-    # via jsonpatch
 jsonschema==4.21.1
     # via
     #   ansible-compat
@@ -195,24 +175,6 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain==0.2.3
-    # via
-    #   -r requirements.in
-    #   langchain-community
-langchain-community==0.2.4
-    # via -r requirements.in
-langchain-core==0.2.2
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-text-splitters
-langchain-text-splitters==0.2.1
-    # via langchain
-langsmith==0.1.50
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
 levenshtein==0.25.1
@@ -221,8 +183,6 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.21.3
-    # via dataclasses-json
 matplotlib-inline==0.1.7
     # via ipython
 mdurl==0.1.2
@@ -231,20 +191,12 @@ monotonic==1.6
     # via segment-analytics-python
 mpmath==1.3.0
     # via sympy
-multidict==6.0.5
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   typing-inspect
+    # via black
 networkx==3.3
     # via torch
 numpy==1.26.4
     # via
-    #   langchain
-    #   langchain-community
     #   scikit-learn
     #   scipy
     #   sentence-transformers
@@ -261,8 +213,6 @@ openpyxl==3.1.2
     # via tablib
 opensearch-py==2.1.1
     # via -r requirements.in
-orjson==3.10.1
-    # via langsmith
 packaging==23.2
     # via
     #   ansible-compat
@@ -271,8 +221,6 @@ packaging==23.2
     #   black
     #   django-allow-cidr
     #   huggingface-hub
-    #   langchain-core
-    #   marshmallow
     #   transformers
 parso==0.8.4
     # via jedi
@@ -308,11 +256,7 @@ pure-eval==0.2.2
 pycparser==2.21
     # via cffi
 pydantic==2.6.4
-    # via
-    #   -r requirements.in
-    #   langchain
-    #   langchain-core
-    #   langsmith
+    # via -r requirements.in
 pydantic-core==2.16.3
     # via pydantic
 pygit2==1.14.1
@@ -349,9 +293,6 @@ pyyaml==6.0
     #   ansible-risk-insight
     #   drf-spectacular
     #   huggingface-hub
-    #   langchain
-    #   langchain-community
-    #   langchain-core
     #   tablib
     #   transformers
     #   yamllint
@@ -369,9 +310,6 @@ requests==2.32.0
     #   ansible-risk-insight
     #   django-oauth-toolkit
     #   huggingface-hub
-    #   langchain
-    #   langchain-community
-    #   langsmith
     #   opensearch-py
     #   requests-oauthlib
     #   segment-analytics-python
@@ -427,10 +365,6 @@ social-auth-core==4.5.4
     # via
     #   -r requirements.in
     #   social-auth-app-django
-sqlalchemy==2.0.29
-    # via
-    #   langchain
-    #   langchain-community
 sqlparse==0.5.0
     # via
     #   -r requirements.in
@@ -447,11 +381,6 @@ tablib[html,ods,xls,xlsx,yaml]==3.6.1
     # via django-import-export
 tabulate==0.9.0
     # via ansible-risk-insight
-tenacity==8.2.3
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-core
 threadpoolctl==3.4.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -485,11 +414,7 @@ typing-extensions==4.11.0
     #   psycopg
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy
     #   torch
-    #   typing-inspect
-typing-inspect==0.9.0
-    # via dataclasses-json
 uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.18
@@ -513,5 +438,3 @@ xlwt==1.3.0
     # via tablib
 yamllint==1.35.1
     # via ansible-lint
-yarl==1.9.4
-    # via aiohttp

--- a/requirements-dev-aarch64.txt
+++ b/requirements-dev-aarch64.txt
@@ -4,6 +4,16 @@
 #
 #    pip-compile --output-file=requirements-dev-aarch64.txt requirements-dev.in
 #
+aiohttp==3.9.5
+    # via
+    #   langchain
+    #   langchain-community
+aiosignal==1.3.1
+    # via aiohttp
+annotated-types==0.7.0
+    # via pydantic
+attrs==23.2.0
+    # via aiohttp
 black==24.3.0
     # via -r requirements-dev.in
 build==1.2.1
@@ -20,6 +30,8 @@ click==8.1.7
     #   pip-tools
 coverage==7.2.1
     # via -r requirements-dev.in
+dataclasses-json==0.6.7
+    # via langchain-community
 distlib==0.3.8
     # via virtualenv
 enum-compat==0.0.3
@@ -28,6 +40,12 @@ filelock==3.13.4
     # via virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
+frozenlist==1.4.1
+    # via
+    #   aiohttp
+    #   aiosignal
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.62.2
     # via grpcio-tools
 grpcio-tools==1.54.2
@@ -38,18 +56,57 @@ idna==3.7
     # via
     #   -r requirements-dev.in
     #   requests
+    #   yarl
 isort==5.10.1
     # via -r requirements-dev.in
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.0.0
+    # via jsonpatch
+langchain==0.2.3
+    # via
+    #   -r requirements-dev.in
+    #   langchain-community
+langchain-community==0.2.4
+    # via -r requirements-dev.in
+langchain-core==0.2.7
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.2.1
+    # via langchain
+langsmith==0.1.77
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
+marshmallow==3.21.3
+    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
+multidict==6.0.5
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   black
+    #   typing-inspect
 nodeenv==1.8.0
     # via pre-commit
+numpy==1.26.4
+    # via
+    #   langchain
+    #   langchain-community
+orjson==3.10.5
+    # via langsmith
 packaging==23.2
     # via
     #   black
     #   build
+    #   langchain-core
+    #   marshmallow
 pathspec==0.12.1
     # via
     #   black
@@ -66,6 +123,13 @@ protobuf==4.25.3
     # via grpcio-tools
 pycodestyle==2.10.0
     # via flake8
+pydantic==2.7.4
+    # via
+    #   langchain
+    #   langchain-core
+    #   langsmith
+pydantic-core==2.18.4
+    # via pydantic
 pyflakes==3.0.1
     # via flake8
 pyproject-hooks==1.0.0
@@ -74,15 +138,39 @@ pyproject-hooks==1.0.0
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
     #   pre-commit
     #   responses
     #   yamllint
 requests==2.31.0
-    # via responses
+    # via
+    #   langchain
+    #   langchain-community
+    #   langsmith
+    #   responses
 responses==0.24.1
     # via -r requirements-dev.in
+sqlalchemy==2.0.30
+    # via
+    #   langchain
+    #   langchain-community
+tenacity==8.4.1
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 torch-model-archiver==0.10.0
     # via -r requirements-dev.in
+typing-extensions==4.12.2
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   sqlalchemy
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 urllib3==2.2.1
     # via
     #   requests
@@ -93,6 +181,8 @@ wheel==0.43.0
     # via pip-tools
 yamllint==1.32.0
     # via -r requirements-dev.in
+yarl==1.9.4
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev-x86_64.txt
+++ b/requirements-dev-x86_64.txt
@@ -4,6 +4,16 @@
 #
 #    pip-compile --output-file=requirements-dev-x86_64.txt requirements-dev.in
 #
+aiohttp==3.9.5
+    # via
+    #   langchain
+    #   langchain-community
+aiosignal==1.3.1
+    # via aiohttp
+annotated-types==0.7.0
+    # via pydantic
+attrs==23.2.0
+    # via aiohttp
 black==24.3.0
     # via -r requirements-dev.in
 build==1.2.1
@@ -20,6 +30,8 @@ click==8.1.7
     #   pip-tools
 coverage==7.2.1
     # via -r requirements-dev.in
+dataclasses-json==0.6.7
+    # via langchain-community
 distlib==0.3.8
     # via virtualenv
 enum-compat==0.0.3
@@ -28,6 +40,12 @@ filelock==3.13.4
     # via virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
+frozenlist==1.4.1
+    # via
+    #   aiohttp
+    #   aiosignal
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.62.2
     # via grpcio-tools
 grpcio-tools==1.54.2
@@ -38,18 +56,57 @@ idna==3.7
     # via
     #   -r requirements-dev.in
     #   requests
+    #   yarl
 isort==5.10.1
     # via -r requirements-dev.in
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.0.0
+    # via jsonpatch
+langchain==0.2.3
+    # via
+    #   -r requirements-dev.in
+    #   langchain-community
+langchain-community==0.2.4
+    # via -r requirements-dev.in
+langchain-core==0.2.7
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.2.1
+    # via langchain
+langsmith==0.1.77
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
+marshmallow==3.21.3
+    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
+multidict==6.0.5
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   black
+    #   typing-inspect
 nodeenv==1.8.0
     # via pre-commit
+numpy==1.26.4
+    # via
+    #   langchain
+    #   langchain-community
+orjson==3.10.5
+    # via langsmith
 packaging==23.2
     # via
     #   black
     #   build
+    #   langchain-core
+    #   marshmallow
 pathspec==0.12.1
     # via
     #   black
@@ -66,6 +123,13 @@ protobuf==4.25.3
     # via grpcio-tools
 pycodestyle==2.10.0
     # via flake8
+pydantic==2.7.4
+    # via
+    #   langchain
+    #   langchain-core
+    #   langsmith
+pydantic-core==2.18.4
+    # via pydantic
 pyflakes==3.0.1
     # via flake8
 pyproject-hooks==1.0.0
@@ -74,15 +138,39 @@ pyproject-hooks==1.0.0
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
     #   pre-commit
     #   responses
     #   yamllint
 requests==2.31.0
-    # via responses
+    # via
+    #   langchain
+    #   langchain-community
+    #   langsmith
+    #   responses
 responses==0.24.1
     # via -r requirements-dev.in
+sqlalchemy==2.0.30
+    # via
+    #   langchain
+    #   langchain-community
+tenacity==8.4.1
+    # via
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 torch-model-archiver==0.10.0
     # via -r requirements-dev.in
+typing-extensions==4.12.2
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   sqlalchemy
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 urllib3==2.2.1
     # via
     #   requests
@@ -93,6 +181,8 @@ wheel==0.43.0
     # via pip-tools
 yamllint==1.32.0
     # via -r requirements-dev.in
+yarl==1.9.4
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,6 +4,8 @@ flake8==6.0.0
 grpcio-tools==1.54.2
 # pin idna until responses -> requests is updated
 idna==3.7
+langchain==0.2.3
+langchain-community==0.2.4
 isort==5.10.1
 pip-tools
 pre-commit

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -4,12 +4,6 @@
 #
 #    pip-compile --output-file=requirements-x86_64.txt requirements.in
 #
-aiohttp==3.9.4
-    # via
-    #   langchain
-    #   langchain-community
-aiosignal==1.3.1
-    # via aiohttp
 annotated-types==0.6.0
     # via pydantic
 ansible==8.5.0
@@ -37,7 +31,6 @@ asttokens==2.4.1
     # via stack-data
 attrs==23.2.0
     # via
-    #   aiohttp
     #   jsonschema
     #   referencing
 backcall==0.2.0
@@ -76,8 +69,6 @@ cryptography==42.0.6
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
-dataclasses-json==0.6.7
-    # via langchain-community
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -137,16 +128,10 @@ filelock==3.13.4
     #   huggingface-hub
     #   torch
     #   transformers
-frozenlist==1.4.1
-    # via
-    #   aiohttp
-    #   aiosignal
 fsspec==2024.3.1
     # via huggingface-hub
 gitdb==4.0.11
     # via ansible-risk-insight
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.60.1
     # via -r requirements.in
 huggingface-hub==0.22.2
@@ -158,7 +143,6 @@ idna==3.7
     # via
     #   -r requirements.in
     #   requests
-    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 ipython==8.10.0
@@ -178,12 +162,8 @@ joblib==1.4.0
     # via
     #   ansible-risk-insight
     #   scikit-learn
-jsonpatch==1.33
-    # via langchain-core
 jsonpickle==3.0.4
     # via ansible-risk-insight
-jsonpointer==2.4
-    # via jsonpatch
 jsonschema==4.21.1
     # via
     #   ansible-compat
@@ -195,24 +175,6 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain==0.2.3
-    # via
-    #   -r requirements.in
-    #   langchain-community
-langchain-community==0.2.4
-    # via -r requirements.in
-langchain-core==0.2.2
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-text-splitters
-langchain-text-splitters==0.2.1
-    # via langchain
-langsmith==0.1.50
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
 levenshtein==0.25.1
@@ -221,8 +183,6 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.21.3
-    # via dataclasses-json
 matplotlib-inline==0.1.7
     # via ipython
 mdurl==0.1.2
@@ -231,20 +191,12 @@ monotonic==1.6
     # via segment-analytics-python
 mpmath==1.3.0
     # via sympy
-multidict==6.0.5
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   typing-inspect
+    # via black
 networkx==3.3
     # via torch
 numpy==1.26.4
     # via
-    #   langchain
-    #   langchain-community
     #   scikit-learn
     #   scipy
     #   sentence-transformers
@@ -261,8 +213,6 @@ openpyxl==3.1.2
     # via tablib
 opensearch-py==2.1.1
     # via -r requirements.in
-orjson==3.10.1
-    # via langsmith
 packaging==23.2
     # via
     #   ansible-compat
@@ -271,8 +221,6 @@ packaging==23.2
     #   black
     #   django-allow-cidr
     #   huggingface-hub
-    #   langchain-core
-    #   marshmallow
     #   transformers
 parso==0.8.4
     # via jedi
@@ -308,11 +256,7 @@ pure-eval==0.2.2
 pycparser==2.21
     # via cffi
 pydantic==2.6.4
-    # via
-    #   -r requirements.in
-    #   langchain
-    #   langchain-core
-    #   langsmith
+    # via -r requirements.in
 pydantic-core==2.16.3
     # via pydantic
 pygit2==1.14.1
@@ -349,9 +293,6 @@ pyyaml==6.0
     #   ansible-risk-insight
     #   drf-spectacular
     #   huggingface-hub
-    #   langchain
-    #   langchain-community
-    #   langchain-core
     #   tablib
     #   transformers
     #   yamllint
@@ -369,9 +310,6 @@ requests==2.32.0
     #   ansible-risk-insight
     #   django-oauth-toolkit
     #   huggingface-hub
-    #   langchain
-    #   langchain-community
-    #   langsmith
     #   opensearch-py
     #   requests-oauthlib
     #   segment-analytics-python
@@ -427,10 +365,6 @@ social-auth-core==4.5.4
     # via
     #   -r requirements.in
     #   social-auth-app-django
-sqlalchemy==2.0.29
-    # via
-    #   langchain
-    #   langchain-community
 sqlparse==0.5.0
     # via
     #   -r requirements.in
@@ -447,11 +381,6 @@ tablib[html,ods,xls,xlsx,yaml]==3.6.1
     # via django-import-export
 tabulate==0.9.0
     # via ansible-risk-insight
-tenacity==8.2.3
-    # via
-    #   langchain
-    #   langchain-community
-    #   langchain-core
 threadpoolctl==3.4.0
     # via scikit-learn
 tokenizers==0.15.2
@@ -485,11 +414,7 @@ typing-extensions==4.11.0
     #   psycopg
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy
     #   torch
-    #   typing-inspect
-typing-inspect==0.9.0
-    # via dataclasses-json
 uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.18
@@ -513,5 +438,3 @@ xlwt==1.3.0
     # via tablib
 yamllint==1.35.1
     # via ansible-lint
-yarl==1.9.4
-    # via aiohttp

--- a/requirements.in
+++ b/requirements.in
@@ -34,8 +34,6 @@ jwcrypto==1.5.6
 # pin jinja2 on 3.1.4 to address GHSA-h75v-3vvj-5mfj
 # remove this once ansible-core or torch are updated
 jinja2==3.1.4
-langchain==0.2.3
-langchain-community==0.2.4
 launchdarkly-server-sdk==8.3.0
 opensearch-py==2.1.1
 protobuf==4.25.3

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -109,6 +109,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     dnf install -y inotify-tools && \
     dnf remove -y epel-release && \
     dnf clean all
+# Install extra dependencies
+RUN /var/www/venv/bin/python3.11 -m pip --no-cache-dir --use-feature=langchain -e/var/www/ansible-wisdom-service/
 COPY tools/scripts/auto-reload.sh /usr/bin/auto-reload.sh
 RUN mkdir /etc/supervisor/supervisord.d/
 COPY tools/configs/supervisord.d/auto-reload.conf /etc/supervisor/supervisord.d/auto-reload.conf


### PR DESCRIPTION
Langchain is not an optional dependency that can be enabled with the `langchain` variant
of the package. e.g:`pip install --use-feature=langchain .`

As a result, the default image with the prod label won't embed langchain. However, the
default dev image will continue to include it.

See: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies
See: https://docs.podman.io/en/latest/markdown/podman-build.1.html#target-stagename
