### PR TITLE
settings: ensure we fallback on "saas" if DEPLOYMENT_MODE is unset

### DIFF
--- a/ansible_wisdom/main/settings/base.py
+++ b/ansible_wisdom/main/settings/base.py
@@ -195,9 +195,7 @@ AUTHZ_SSO_TOKEN_SERVICE_RETRY_COUNT = int(os.getenv("AUTHZ_SSO_TOKEN_SERVICE_RET
 AUTHZ_AMS_SERVICE_RETRY_COUNT = int(os.getenv("AMS_SERVICE_RETRY_COUNT", "3"))
 
 t_deployment_mode = Literal["saas", "upstream", "onprem"]
-DEPLOYMENT_MODE: t_deployment_mode = os.environ.get(
-    "DEPLOYMENT_MODE", cast(t_deployment_mode, "saas")
-)
+DEPLOYMENT_MODE: t_deployment_mode = cast(t_deployment_mode, os.environ.get("DEPLOYMENT_MODE") or "saas")
 AUTHENTICATION_BACKENDS = [
     (
         "social_core.backends.github.GithubTeamOAuth2"


### PR DESCRIPTION
## Description

As defined in the configuration, `podman-compose` will always define  `DEPLOYMENT_MODE`. However, the environment variable may be empty.

This change ensures we fallback on the value `saas` in such situation.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: