### PR TITLE
rename telemetry events to represent WCA calls

### DIFF
--- a/ansible_wisdom/ai/api/views.py
+++ b/ansible_wisdom/ai/api/views.py
@@ -790,7 +790,7 @@ class Explanation(APIView):
             "duration": duration,
             "playbook_length": playbook_length,
         }
-        send_segment_event(event, "explanation", user)
+        send_segment_event(event, "explainPlaybook", user)
 
 
 class Generation(APIView):
@@ -894,4 +894,4 @@ class Generation(APIView):
             "create_outline": create_outline,
             "playbook_length": playbook_length,
         }
-        send_segment_event(event, "generation", user)
+        send_segment_event(event, "codegenPlaybook", user)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-22663

## Description
Our current telemetry for playbook gen/explanation is similar to our "prediction" event in that it maps to a call to WCA. We'll need to add events similar to our "completion" event that we create from our middleware and capture response status code etc. I prefer to reserve the names "generation" and "explanation" for those future events to match the API, and have renamed the existing events to map to the WCA endpoint names.

## Testing
N/A

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
