### PR TITLE
fix allow list event names

### DIFF
--- a/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_wisdom/ai/api/utils/seated_users_allow_list.py
@@ -298,7 +298,7 @@ ALLOW_LIST = {
         "rh_user_org_id": None,
         "timestamp": None,
     },
-    "explanation": {
+    "explainPlaybook": {
         "duration": None,
         "exception": None,
         "explanationId": None,
@@ -310,7 +310,7 @@ ALLOW_LIST = {
         "rh_user_org_id": None,
         "timestamp": None,
     },
-    "generation": {
+    "codegenPlaybook": {
         "duration": None,
         "exception": None,
         "generationId": None,


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-22663

## Description
Follow-up to https://github.com/ansible/ansible-ai-connect-service/pull/1144. I missed updating the allow list for the telemetry event renames. 

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the service
3. Test a playbook generation and explanation
4. Confirm codegenPlaybook and explainPlaybook are created in Segment

### Scenarios tested
Described above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
