### PR TITLE
AAP-23235: Include variable values with enhanced context sent from VSCode

### DIFF
--- a/ansible_ai_connect/ai/api/fields.py
+++ b/ansible_ai_connect/ai/api/fields.py
@@ -48,3 +48,7 @@ class AnonymizedCharField(AnonymizedFieldMixin, serializers.CharField):
 
 class AnonymizedPromptCharField(AnonymizedPromptMixin, serializers.CharField):
     pass
+
+
+class AnonymizedAdditionalContextField(AnonymizedFieldMixin, serializers.DictField):
+    pass

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -30,7 +30,11 @@ from drf_spectacular.utils import (
 from rest_framework import serializers
 
 from . import formatter as fmtr
-from .fields import AnonymizedCharField, AnonymizedPromptCharField
+from .fields import (
+    AnonymizedAdditionalContextField,
+    AnonymizedCharField,
+    AnonymizedPromptCharField,
+)
 
 
 class Metadata(serializers.Serializer):
@@ -67,7 +71,7 @@ class CompletionMetadata(Metadata):
         label="Ansible File Type",
         help_text="Ansible file type (playbook/tasks_in_role/tasks)",
     )
-    additionalContext = serializers.DictField(
+    additionalContext = AnonymizedAdditionalContextField(
         required=False,
         label="Additional Context",
         help_text="Additional context for completion API",

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -263,6 +263,42 @@ class TestCompletionWCAView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBa
         )
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS="1:valid")
+    @override_settings(ENABLE_ADDITIONAL_CONTEXT=True)
+    @override_settings(ENABLE_ARI_POSTPROCESS=False)
+    def test_wca_completion_anonymized_additional_context(self):
+        self.user.rh_user_has_seat = True
+        self.user.organization = Organization.objects.get_or_create(id=1)[0]
+        self.client.force_authenticate(user=self.user)
+
+        stub = self.stub_wca_client(
+            200,
+        )
+        model_client, model_input = stub
+        model_input["metadata"] = {
+            "additionalContext": {
+                "playbookContext": {
+                    "varInfiles": {
+                        "vars.yml": "external_var_1: value1\n"
+                        "external_var_2: value2\n"
+                        "password: magic\n"
+                    },
+                    "roles": {},
+                    "includeVars": {},
+                },
+                "roleContext": {},
+                "standaloneTaskContext": {},
+            },
+        }
+        self.mock_model_client_with(model_client)
+        r = self.client.post(reverse("completions"), model_input, format="json")
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        prompt = model_client.session.post.call_args.kwargs["json"]["prompt"]
+        self.assertTrue("external_var_1: value1" in prompt)
+        self.assertTrue("external_var_2: value2" in prompt)
+        self.assertTrue("password:" in prompt)
+        self.assertFalse("magic" in prompt)
+
+    @override_settings(WCA_SECRET_DUMMY_SECRETS="1:valid")
     @override_settings(ENABLE_ARI_POSTPROCESS=False)
     @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
     def test_wca_completion_seated_user_missing_api_key(self):


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-23235

## Description
Anonymize context variables before passing onto WCA.

## Testing
_Locally_ you need to put a break-point in `wca_client.py` on `BaseWCAClient.infer(..)`.

Submit a completion request from VSCode (compiled including the applicable enhancement, see below) with a playbook in VSCode that includes an external variables file (or other mechanism to provide _additional context_). Examine the value of `context` in `BaseWCAClient.infer(..)`. PII fields should be anonymized.

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Set a break-point as above.
5. Run service in "debug mode".
6. Run VSCode and use the Ansible `.vsix` attached to JIRA.
7. Configure it to use your local `ansible-ai-connect-service` i.e. Lightspeed URL: http://localhost:8000
8. Create a playbook:
```
---
- name: Test the vscode extension
  hosts: all
  vars:
    favcolor: blue
  vars_files:
    - vars.yml

  tasks:
    - name: install apache
```
9. Create a variables file (called `vars.yml`):
```
---
external_var_1: value1
external_var_2: value2
password: magic
```
10. Submit a completion request (i.e. press <enter> after "install apache" in the playbook task).
11. Observe the `context` used to construct the `prompt` sent to WCA.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

VSCode needs changing for the enhancement to be complete however it does not block this PR being merged.

See https://github.com/ansible/vscode-ansible/pull/1380