### PR TITLE
[DRAFT] AAP-25690

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -176,7 +176,7 @@ spec:
         - name: name
           value: git-clone
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:ae1249aa49e82da5f99cc23b256172dce8f7c7951ece68ca0419240c4ecb52e2
+          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:2be7c9c83159c5247f1f9aab8fa1a2cb29d0df66f6c5bb48a012320bdcb03c7d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -236,7 +236,7 @@ spec:
       - name: TARGET_STAGE
         value: production
       - name: BUILD_ARGS
-        value: ["IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)"]
+        value: ["IMAGE_TAGS=pr-{{pull_request_number}} pr-{{pull_request_number}}.$(tasks.format-commit-timestamp.results.formatted-commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)"]
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -261,7 +261,7 @@ spec:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: ADDITIONAL_TAGS
-        value: ["pr-{{pull_request_number}}", "pr-{{pull_request_number}}.$(tasks.git-metadata.results.commit-timestamp)"]
+        value: ["pr-{{pull_request_number}}", "pr-{{pull_request_number}}.$(tasks.format-commit-timestamp.results.formatted-commit-timestamp)"]
       runAfter:
       - build-container
       taskRef:
@@ -273,25 +273,18 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-    - name: git-metadata
+    - name: format-commit-timestamp
       runAfter:
       - clone-repository
-      workspaces:
-        - name: source
-          workspace: workspace
       taskSpec:
-        workspaces:
-          - name: source
         steps:
-          - name: get-commit-timestamp
+          - name: format-commit-timestamp
             image: alpine/git
             script: |
               #!/bin/sh
-              set -euo pipefail
-              cd "$(workspaces.source.path)/source"
-              echo -n $(date -d @$(git log -1 --format=%at) "+%Y%m%d%H%M") > $(results.commit-timestamp.path)
+              echo -n $(date -d @$(tasks.clone-repository.results.commit-timestamp) "+%Y%m%d%H%M") > $(results.formatted-commit-timestamp.path)
         results:
-          - name: commit-timestamp
+          - name: formatted-commit-timestamp
     - name: build-source-image
       params:
       - name: BINARY_IMAGE

--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -169,7 +169,7 @@ spec:
         - name: name
           value: git-clone
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:ae1249aa49e82da5f99cc23b256172dce8f7c7951ece68ca0419240c4ecb52e2
+          value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:2be7c9c83159c5247f1f9aab8fa1a2cb29d0df66f6c5bb48a012320bdcb03c7d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -229,7 +229,7 @@ spec:
       - name: TARGET_STAGE
         value: production
       - name: BUILD_ARGS
-        value: ["IMAGE_TAGS=latest 1.0.$(tasks.git-metadata.results.commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)"]
+        value: ["IMAGE_TAGS=latest 1.0.$(tasks.format-commit-timestamp.results.formatted-commit-timestamp)", "GIT_COMMIT=$(tasks.clone-repository.results.commit)"]
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -254,7 +254,7 @@ spec:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: ADDITIONAL_TAGS
-        value: ["latest", "1.0.$(tasks.git-metadata.results.commit-timestamp)"]
+        value: ["latest", "1.0.$(tasks.format-commit-timestamp.results.formatted-commit-timestamp)"]
       runAfter:
       - build-container
       taskRef:
@@ -266,25 +266,18 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-    - name: git-metadata
+    - name: format-commit-timestamp
       runAfter:
       - clone-repository
-      workspaces:
-        - name: source
-          workspace: workspace
       taskSpec:
-        workspaces:
-          - name: source
         steps:
-          - name: get-commit-timestamp
+          - name: format-commit-timestamp
             image: alpine/git
             script: |
               #!/bin/sh
-              set -euo pipefail
-              cd "$(workspaces.source.path)/source"
-              echo -n $(date -d @$(git log -1 --format=%at) "+%Y%m%d%H%M") > $(results.commit-timestamp.path)
+              echo -n $(date -d @$(tasks.clone-repository.results.commit-timestamp) "+%Y%m%d%H%M") > $(results.formatted-commit-timestamp.path)
         results:
-          - name: commit-timestamp
+          - name: formatted-commit-timestamp
     - name: build-source-image
       params:
       - name: BINARY_IMAGE


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-25690
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
The existing method to retrieve latest commit timestamps requires a custom [git-metadata](https://github.com/ansible/ansible-ai-connect-service/blob/47ad1648a4e3812bdafb11932eb37fa54c0dc798/.tekton/ansible-ai-connect-service-push.yaml#L269-L287) task. The Konflux team has added this timestamp within the default [git-clone](https://github.com/konflux-ci/build-definitions/blob/1981d6b28737e7e2ac165af439577118006da8f2/task/git-clone/0.1/git-clone.yaml#L240) task therefore eliminating the need for our custom timestamp retrieval task.


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Create PR to main and check in [ansible-ai-connect-service quay repo](https://quay.io/repository/ansible/ansible-ai-connect-service?tab=tags&tag=latest) to ensure tags are correct

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
As described above
## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
