### PR TITLE
Enhanced context processing updates

### DIFF
--- a/ansible_ai_connect/ai/api/formatter.py
+++ b/ansible_ai_connect/ai/api/formatter.py
@@ -131,8 +131,13 @@ def expand_vars_playbook(data, additional_context):
             # for proper placement of the prompt
             last_key = list(d.keys())[-1]
             last_key_value = d.pop(last_key)
-            d["vars"] = merged_vars if "vars" not in d else (merged_vars | d["vars"])
+            d["vars"] = merged_vars if "vars" not in d else (d["vars"] | merged_vars)
             d[last_key] = last_key_value
+            if "vars_files" in d:
+                for vars_file in playbook_context.get("varInfiles", {}).keys():
+                    d["vars_files"] = [file for file in d["vars_files"] if file != vars_file]
+                if len(d["vars_files"]) == 0:
+                    del d["vars_files"]
 
 
 def expand_vars_tasks_in_role(data, additional_context):


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20564

## Description
Per [Ansible variable precedence](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence), we want vars from enhanced context to be listed after vars contained originally in the playbook. In addition, if we get the contents of vars_files files in the enhanced context, we can remove these files from the vars_files list.  

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Start the wisdom service 
3. Confirm the three scenarios listed [here](https://issues.redhat.com/browse/AAP-20564?focusedId=24100150&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24100150) all give the same task output

### Scenarios tested
As described above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
