### PR TITLE
completion_stages/response: only set model when True

### DIFF
--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/response.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/response.py
@@ -43,9 +43,11 @@ class ResponseStage(PipelineElement):
         try:
             response_data = {
                 "predictions": post_processed_predictions["predictions"],
-                "model": predictions["model_id"],
                 "suggestionId": payload.suggestionId,
             }
+            if model_from_prediction := predictions.get("model_id"):
+                response_data["model"] = model_from_prediction
+
             response_serializer = CompletionResponseSerializer(data=response_data)
             response_serializer.is_valid(raise_exception=True)
         except Exception:


### PR DESCRIPTION
Only define the model key when the model is Truthy and avoid the
situation where the model key is set to `None` or `''`, which will
raise the following validation error:

```
'{"model":["This field may not be blank."]}'
```
