### PR TITLE
AAP-25893: Set x-request-id header on playbook explanation/generation endpoints

### DIFF
--- a/ansible_ai_connect/ai/api/exceptions.py
+++ b/ansible_ai_connect/ai/api/exceptions.py
@@ -116,10 +116,13 @@ class WcaNoDefaultModelIdException(WisdomAccessDenied):
     default_detail = "No default WCA Model ID was found."
 
 
-class WcaSuggestionIdCorrelationFailureException(BaseWisdomAPIException):
+class WcaRequestIdCorrelationFailureException(BaseWisdomAPIException):
     status_code = 500
-    default_code = "error__wca_suggestion_correlation_failed"
-    default_detail = "WCA Request/Response Suggestion ID correlation failed."
+    # This is the old code for when this was used solely for Completions correlation.
+    # VSCode will handle both codes identically to maintain compatibility with older services.
+    # default_code = "error__wca_suggestion_correlation_failed"
+    default_code = "error__wca_request_id_correlation_failed"
+    default_detail = "WCA Request/Response Request Id correlation failed."
 
 
 class WcaEmptyResponseException(WisdomEmptyResponse):

--- a/ansible_ai_connect/ai/api/model_client/base.py
+++ b/ansible_ai_connect/ai/api/model_client/base.py
@@ -54,11 +54,16 @@ class ModelMeshClient:
         raise NotImplementedError
 
     def generate_playbook(
-        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+        self,
+        request,
+        text: str = "",
+        create_outline: bool = False,
+        outline: str = "",
+        generation_id: str = "",
     ) -> tuple[str, str]:
         raise NotImplementedError
 
-    def explain_playbook(self, request, content) -> str:
+    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_client/dummy_client.py
+++ b/ansible_ai_connect/ai/api/model_client/dummy_client.py
@@ -87,11 +87,16 @@ class DummyClient(ModelMeshClient):
         return response_body
 
     def generate_playbook(
-        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+        self,
+        request,
+        text: str = "",
+        create_outline: bool = False,
+        outline: str = "",
+        generation_id: str = "",
     ) -> tuple[str, str]:
         if create_outline:
             return PLAYBOOK, OUTLINE
         return PLAYBOOK, ""
 
-    def explain_playbook(self, request, content) -> str:
+    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
         return EXPLANATION

--- a/ansible_ai_connect/ai/api/model_client/exceptions.py
+++ b/ansible_ai_connect/ai/api/model_client/exceptions.py
@@ -98,8 +98,8 @@ class WcaCodeMatchFailure(WcaException):
 
 
 @dataclass
-class WcaSuggestionIdCorrelationFailure(WcaException):
-    """WCA Request/Response Suggestion Id correlation failed."""
+class WcaRequestIdCorrelationFailure(WcaException):
+    """WCA Request/Response X-Request-ID correlation failed."""
 
     def __init__(self, model_id, x_request_id: uuid.uuid4):
         super().__init__(model_id)

--- a/ansible_ai_connect/ai/api/model_client/langchain.py
+++ b/ansible_ai_connect/ai/api/model_client/langchain.py
@@ -121,7 +121,12 @@ class LangChainClient(ModelMeshClient):
             raise ModelTimeoutError
 
     def generate_playbook(
-        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+        self,
+        request,
+        text: str = "",
+        create_outline: bool = False,
+        outline: str = "",
+        generation_id: str = "",
     ) -> tuple[str, str]:
         SYSTEM_MESSAGE_TEMPLATE = """
         You are an Ansible expert.
@@ -178,7 +183,7 @@ class LangChainClient(ModelMeshClient):
 
         return playbook, outline
 
-    def explain_playbook(self, request, content) -> str:
+    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
         SYSTEM_MESSAGE_TEMPLATE = """
         You're an Ansible expert.
         You format your output with Markdown.

--- a/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
@@ -44,7 +44,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaKeyNotFound,
     WcaModelIdNotFound,
     WcaNoDefaultModelId,
-    WcaSuggestionIdCorrelationFailure,
+    WcaRequestIdCorrelationFailure,
     WcaTokenFailure,
 )
 from ansible_ai_connect.ai.api.model_client.wca_client import (
@@ -65,7 +65,7 @@ from ansible_ai_connect.test_utils import (
 from ansible_ai_connect.users.constants import FAUX_COMMERCIAL_USER_ORG_ID
 from ansible_ai_connect.users.tests.test_users import create_user
 
-DEFAULT_SUGGESTION_ID = uuid.uuid4()
+DEFAULT_REQUEST_ID = uuid.uuid4()
 
 
 class MockResponse:
@@ -103,7 +103,7 @@ def stub_wca_client(
     response = MockResponse(
         json=response_data,
         status_code=status_code,
-        headers={WCA_REQUEST_ID_HEADER: str(DEFAULT_SUGGESTION_ID)},
+        headers={WCA_REQUEST_ID_HEADER: str(DEFAULT_REQUEST_ID)},
     )
     model_client = WCAClient(inference_url="https://wca_api_url")
     model_client.session.post = Mock(return_value=response)
@@ -261,6 +261,7 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
         response = Mock
         response.text = '{"playbook": "Oh!", "outline": "Ahh!", "explanation": "!Óh¡"}'
         response.status_code = 200
+        response.headers = {WCA_REQUEST_ID_HEADER: WCA_REQUEST_ID_HEADER}
         response.raise_for_status = Mock()
         wca_client.session.post.return_value = response
         self.wca_client = wca_client
@@ -309,6 +310,37 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
         )
         # Ensure nothing was done
         self.assertEqual(playbook, "Oh!")
+
+    def test_playbook_gen_request_id_correlation_failure(self):
+        request = Mock()
+        request.user.organization = None
+
+        self.wca_client.session.post.return_value = MockResponse(
+            json={},
+            status_code=200,
+            headers={WCA_REQUEST_ID_HEADER: "some-other-uuid"},
+        )
+        with self.assertRaises(WcaRequestIdCorrelationFailure):
+            self.wca_client.generate_playbook(
+                request=Mock(),
+                text="Install Wordpress",
+                create_outline=True,
+                generation_id=str(DEFAULT_REQUEST_ID),
+            )
+
+    def test_playbook_exp_request_id_correlation_failure(self):
+        request = Mock()
+        request.user.organization = None
+
+        self.wca_client.session.post.return_value = MockResponse(
+            json={},
+            status_code=200,
+            headers={WCA_REQUEST_ID_HEADER: "some-other-uuid"},
+        )
+        with self.assertRaises(WcaRequestIdCorrelationFailure):
+            self.wca_client.explain_playbook(
+                request, content="Some playbook", explanation_id=str(DEFAULT_REQUEST_ID)
+            )
 
 
 @override_settings(ANSIBLE_WCA_RETRY_COUNT=1)
@@ -377,24 +409,24 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     @assert_call_count_metrics(metric=wca_codegen_hist)
     def test_infer(self):
         self._do_inference(
-            suggestion_id=str(DEFAULT_SUGGESTION_ID), request_id=str(DEFAULT_SUGGESTION_ID)
+            suggestion_id=str(DEFAULT_REQUEST_ID), request_id=str(DEFAULT_REQUEST_ID)
         )
 
     @assert_call_count_metrics(metric=wca_codegen_hist)
     def test_infer_organization_id_is_none(self):
         self._do_inference(
-            suggestion_id=str(DEFAULT_SUGGESTION_ID),
+            suggestion_id=str(DEFAULT_REQUEST_ID),
             organization_id=None,
-            request_id=str(DEFAULT_SUGGESTION_ID),
+            request_id=str(DEFAULT_REQUEST_ID),
         )
 
     @assert_call_count_metrics(metric=wca_codegen_hist)
     def test_infer_without_suggestion_id(self):
-        self._do_inference(suggestion_id=None, request_id=str(DEFAULT_SUGGESTION_ID))
+        self._do_inference(suggestion_id=None, request_id=str(DEFAULT_REQUEST_ID))
 
     @assert_call_count_metrics(metric=wca_codegen_hist)
     def test_infer_without_request_id_header(self):
-        self._do_inference(suggestion_id=str(DEFAULT_SUGGESTION_ID), request_id=None)
+        self._do_inference(suggestion_id=str(DEFAULT_REQUEST_ID), request_id=None)
 
     def _do_inference(
         self,
@@ -495,7 +527,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -530,7 +562,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -570,7 +602,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                     request=Mock(),
                     model_input=model_input,
                     model_id=model_id,
-                    suggestion_id=DEFAULT_SUGGESTION_ID,
+                    suggestion_id=DEFAULT_REQUEST_ID,
                 )
         self.assertEqual(e.exception.model_id, model_id)
         self.assertInLog(
@@ -611,12 +643,12 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_client.get_model_id = Mock(return_value=model_id)
         model_client.get_api_key = Mock(return_value=api_key)
 
-        with self.assertRaises(WcaSuggestionIdCorrelationFailure) as e:
+        with self.assertRaises(WcaRequestIdCorrelationFailure) as e:
             model_client.infer(
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -633,7 +665,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -646,7 +678,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -659,7 +691,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
         self.assertEqual(e.exception.model_id, model_id)
 
@@ -681,7 +713,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
                 request=Mock(),
                 model_input=model_input,
                 model_id=model_id,
-                suggestion_id=DEFAULT_SUGGESTION_ID,
+                suggestion_id=DEFAULT_REQUEST_ID,
             )
 
     @assert_call_count_metrics(metric=wca_codegen_hist)
@@ -716,7 +748,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
             request=Mock(user=user),
             model_input=model_input,
             model_id=None,
-            suggestion_id=DEFAULT_SUGGESTION_ID,
+            suggestion_id=DEFAULT_REQUEST_ID,
         )
 
         model_client.get_model_id.assert_called_once_with(FAUX_COMMERCIAL_USER_ORG_ID, None)
@@ -725,8 +757,8 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     @assert_call_count_metrics(metric=wca_codegen_hist)
     def test_infer_multitask_with_task_preamble(self):
         self._do_inference(
-            suggestion_id=str(DEFAULT_SUGGESTION_ID),
-            request_id=str(DEFAULT_SUGGESTION_ID),
+            suggestion_id=str(DEFAULT_REQUEST_ID),
+            request_id=str(DEFAULT_REQUEST_ID),
             prompt="# - name: install ffmpeg on Red Hat Enterprise Linux",
             codegen_prompt="# install ffmpeg on red hat enterprise linux\n",
         )

--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -58,7 +58,7 @@ from .exceptions import (
     WcaKeyNotFound,
     WcaModelIdNotFound,
     WcaNoDefaultModelId,
-    WcaSuggestionIdCorrelationFailure,
+    WcaRequestIdCorrelationFailure,
     WcaTokenFailure,
     WcaUsernameNotFound,
 )
@@ -199,7 +199,7 @@ class BaseWCAClient(ModelMeshClient):
         }
         logger.debug(f"Inference API request payload: {json.dumps(data)}")
 
-        headers = self.get_inference_headers(api_key, suggestion_id)
+        headers = self.get_request_headers(api_key, suggestion_id)
         task_count = len(get_task_names_from_prompt(prompt))
         # path matches ANSIBLE_WCA_INFERENCE_URL="https://api.dataplatform.test.cloud.ibm.com"
         prediction_url = f"{self._inference_url}/v1/wca/codegen/ansible"
@@ -228,7 +228,7 @@ class BaseWCAClient(ModelMeshClient):
                 # request/payload suggestion_id is a UUID not a string whereas
                 # HTTP headers are strings.
                 if x_request_id != str(suggestion_id):
-                    raise WcaSuggestionIdCorrelationFailure(
+                    raise WcaRequestIdCorrelationFailure(
                         model_id=model_id, x_request_id=x_request_id
                     )
 
@@ -300,8 +300,8 @@ class BaseWCAClient(ModelMeshClient):
             raise ModelTimeoutError(model_id=model_id)
 
     @abstractmethod
-    def get_inference_headers(
-        self, api_key: str, suggestion_id: Optional[str]
+    def get_request_headers(
+        self, api_key: str, identifier: Optional[str]
     ) -> dict[str, Optional[str]]:
         raise NotImplementedError
 
@@ -414,13 +414,13 @@ class WCAClient(BaseWCAClient):
         logger.error("Seated user's organization doesn't have default model ID set")
         raise WcaModelIdNotFound(model_id=requested_model_id)
 
-    def get_inference_headers(
-        self, api_key: str, suggestion_id: Optional[str]
+    def get_request_headers(
+        self, api_key: str, identifier: Optional[str]
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
-            WCA_REQUEST_ID_HEADER: str(suggestion_id) if suggestion_id else None,
+            WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
         }
 
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
@@ -471,13 +471,18 @@ class WCAClient(BaseWCAClient):
         return summary
 
     def generate_playbook(
-        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+        self,
+        request,
+        text: str = "",
+        create_outline: bool = False,
+        outline: str = "",
+        generation_id: str = "",
     ) -> tuple[str, str]:
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(organization_id)
         model_id = self.get_model_id(organization_id)
 
-        headers = self._get_base_headers(api_key)
+        headers = self.get_request_headers(api_key, generation_id)
         data = {
             "model_id": model_id,
             "text": text,
@@ -491,6 +496,13 @@ class WCAClient(BaseWCAClient):
             headers=headers,
             json=data,
         )
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if generation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(generation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
 
         context = Context(model_id, result, False)
         InferenceResponseChecks().run_checks(context)
@@ -506,12 +518,12 @@ class WCAClient(BaseWCAClient):
 
         return playbook, outline
 
-    def explain_playbook(self, request, content: str) -> str:
+    def explain_playbook(self, request, content: str, explanation_id: str = "") -> str:
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(organization_id)
         model_id = self.get_model_id(organization_id)
 
-        headers = self._get_base_headers(api_key)
+        headers = self.get_request_headers(api_key, explanation_id)
         data = {
             "model_id": model_id,
             "playbook": content,
@@ -521,6 +533,13 @@ class WCAClient(BaseWCAClient):
             headers=headers,
             json=data,
         )
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if explanation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(explanation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
 
         context = Context(model_id, result, False)
         InferenceResponseChecks().run_checks(context)
@@ -557,13 +576,13 @@ class WCAOnPremClient(BaseWCAClient):
 
         raise WcaModelIdNotFound()
 
-    def get_inference_headers(
-        self, api_key: str, suggestion_id: Optional[str]
+    def get_request_headers(
+        self, api_key: str, identifier: Optional[str]
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
-            WCA_REQUEST_ID_HEADER: str(suggestion_id) if suggestion_id else None,
+            WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
         }
 
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
@@ -603,9 +622,14 @@ class WCAOnPremClient(BaseWCAClient):
         return summary
 
     def generate_playbook(
-        self, request, text: str = "", create_outline: bool = False, outline: str = ""
+        self,
+        request,
+        text: str = "",
+        create_outline: bool = False,
+        outline: str = "",
+        generation_id: str = "",
     ) -> tuple[str, str]:
         raise FeatureNotAvailable
 
-    def explain_playbook(self, request, content: str) -> str:
+    def explain_playbook(self, request, content: str, explanation_id: str = "") -> str:
         raise FeatureNotAvailable

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
@@ -35,7 +35,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
     WcaNoDefaultModelIdException,
-    WcaSuggestionIdCorrelationFailureException,
+    WcaRequestIdCorrelationFailureException,
     WcaUserTrialExpiredException,
     process_error_count,
 )
@@ -48,7 +48,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaKeyNotFound,
     WcaModelIdNotFound,
     WcaNoDefaultModelId,
-    WcaSuggestionIdCorrelationFailure,
+    WcaRequestIdCorrelationFailure,
     WcaUserTrialExpired,
 )
 from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
@@ -138,13 +138,13 @@ class InferenceStage(PipelineElement):
             logger.info(f"A WCA Model ID was expected but not found for suggestion {suggestion_id}")
             raise WcaModelIdNotFoundException(cause=e)
 
-        except WcaSuggestionIdCorrelationFailure as e:
+        except WcaRequestIdCorrelationFailure as e:
             exception = e
             logger.info(
                 f"WCA Request/Response SuggestionId correlation failed for "
                 f"suggestion_id: '{suggestion_id}' and x_request_id: '{e.x_request_id}'."
             )
-            raise WcaSuggestionIdCorrelationFailureException(cause=e)
+            raise WcaRequestIdCorrelationFailureException(cause=e)
 
         except WcaEmptyResponse as e:
             exception = e


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-25893

## Description
Include `X-Request-ID` header in the `POST`'s for Playbook generation/explanation.

Also include a check that the response contains the same identifier and raise an exception if not accordingly.
 
## Testing
It is not possible to test for real since it requires WCA to fail.

Unit tests emulate such failures.

### Scenarios tested
Unit tests.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

VSCode change to support new error code: https://github.com/ansible/vscode-ansible/pull/1414