### PR TITLE
AAP 26233 - expose /me endpoint as markdown

### DIFF
--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase, modify_settings, override_settings
 from django.urls import reverse
 from rest_framework.test import APITransactionTestCase
 
@@ -173,3 +173,15 @@ class TestMetricsView(APITransactionTestCase):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse("prometheus-metrics"))
         self.assertEqual(r.status_code, HTTPStatus.OK)
+
+
+@modify_settings()
+@override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+class TestMarkdownMe(TestCase):
+    def test_get_view(self):
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        self.client.force_login(user=user)
+
+        r = self.client.get(reverse("me_summary"))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Logged in as: test_user_name")

--- a/ansible_ai_connect/main/urls.py
+++ b/ansible_ai_connect/main/urls.py
@@ -54,6 +54,7 @@ from ansible_ai_connect.main.views import (
 from ansible_ai_connect.users.views import (
     CurrentUserView,
     HomeView,
+    MarkdownCurrentUserView,
     TermsOfService,
     TrialTermsOfService,
     TrialView,
@@ -72,6 +73,11 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path(f"api/{WISDOM_API_VERSION}/ai/", include("ansible_ai_connect.ai.api.urls")),
     path(f"api/{WISDOM_API_VERSION}/me/", CurrentUserView.as_view(), name="me"),
+    path(
+        f"api/{WISDOM_API_VERSION}/me/summary/",
+        MarkdownCurrentUserView.as_view(),
+        name="me_summary",
+    ),
     path("unauthorized/", UnauthorizedView.as_view(), name="unauthorized"),
     path("check/status/", WisdomServiceHealthView.as_view(), name="health_check"),
     path("check/", WisdomServiceLivenessProbeView.as_view(), name="liveness_probe"),


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [<https://issues.redhat.com/browse/AAP-26233>]
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

This PR creates the `/me/summary` API endpoint exposing markdown user information which can be used to populate user information HTML views in the Ansible VS Code extension.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Start the service
3. Navigate to [http://localhost:8000/api/v0/me/summary/](url) to view markdown user information

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
