### PR TITLE
Add more buckets to Prometheus histgrams for WCA APIs

### DIFF
--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -67,32 +67,58 @@ MODEL_MESH_HEALTH_CHECK_TOKENS = "tokens"
 
 WCA_REQUEST_ID_HEADER = "X-Request-ID"
 
+# from django_prometheus.middleware.DEFAULT_LATENCY_BUCKETS
+DEFAULT_LATENCY_BUCKETS = (
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+    25.0,
+    50.0,
+    75.0,
+    float("inf"),
+)
+
 logger = logging.getLogger(__name__)
 
 wca_codegen_hist = Histogram(
     "wca_codegen_latency_seconds",
     "Histogram of WCA codegen API processing time",
     namespace=NAMESPACE,
+    buckets=DEFAULT_LATENCY_BUCKETS,
 )
 wca_codematch_hist = Histogram(
     "wca_codematch_latency_seconds",
     "Histogram of WCA codematch API processing time",
     namespace=NAMESPACE,
+    buckets=DEFAULT_LATENCY_BUCKETS,
 )
 wca_codegen_playbook_hist = Histogram(
     "wca_codegen_playbook_latency_seconds",
     "Histogram of WCA codegen-playbook API processing time",
     namespace=NAMESPACE,
+    buckets=DEFAULT_LATENCY_BUCKETS,
 )
 wca_explain_playbook_hist = Histogram(
     "wca_explain_playbook_latency_seconds",
     "Histogram of WCA explain-playbook API processing time",
     namespace=NAMESPACE,
+    buckets=DEFAULT_LATENCY_BUCKETS,
 )
 ibm_cloud_identity_token_hist = Histogram(
     "wca_ibm_identity_token_latency_seconds",
     "Histogram of IBM Cloud identity token API processing time",
     namespace=NAMESPACE,
+    buckets=DEFAULT_LATENCY_BUCKETS,
 )
 wca_codegen_retry_counter = Counter(
     "wca_codegen_retries",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: [AAP-25884](https://issues.redhat.com/browse/AAP-25884)
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

This is the continuation of #1183. Even though #1183 successfully added Prometheus metrics (histogram/counter) on Playbook Generation/Explanation APIs, we realized those APIs are slow and often exceeds 10 secs, which is the upper limit of the last (excl. infinity) bucket of the histogram. We should add more buckets to capture more meaningful metrics.

![image](https://github.com/ansible/ansible-ai-connect-service/assets/27698807/8a9baaef-9531-48d3-ada5-67847a448cd2)

This PR reuses the default buckets used in the django-prometheus library, which contains additional buckets whose upper limits are `25`, `50`, `75` secs in addition to the existing ones (`0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `0.75`, `1.0`, `2.5`, `5.0`, `7.5` and `10.0`)

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
No test was done.

### Steps to test
n/a

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
No test was performed.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
