### PR TITLE
remove the BlockUserWithoutSeatAndWCAReadyOrg permission

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_permissions.py
+++ b/ansible_ai_connect/ai/api/tests/test_permissions.py
@@ -20,13 +20,12 @@ from django.urls import reverse
 
 from ansible_ai_connect.ai.api.permissions import (
     BlockUserWithoutSeat,
-    BlockUserWithoutSeatAndWCAReadyOrg,
     BlockUserWithSeatButWCANotReady,
     BlockWCANotReadyButTrialAvailable,
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 from ansible_ai_connect.test_utils import WisdomAppsBackendMocking
 from ansible_ai_connect.users.models import Plan
 from ansible_ai_connect.users.tests.test_users import create_user
@@ -37,7 +36,7 @@ BLOCK = False
 
 @patch.object(IsOrganisationAdministrator, "has_permission", return_value=False)
 @patch.object(IsOrganisationLightspeedSubscriber, "has_permission", return_value=True)
-class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
+class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBaseOIDC):
     def test_user_rh_user_is_org_admin(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse("wca_api_key"))
@@ -49,7 +48,7 @@ class TestIfUserIsOrgAdministrator(WisdomServiceAPITestCaseBase):
 
 @patch.object(IsOrganisationAdministrator, "has_permission", return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, "has_permission", return_value=False)
-class TestIfOrgIsLightspeedSubscriber(WisdomServiceAPITestCaseBase):
+class TestIfOrgIsLightspeedSubscriber(WisdomServiceAPITestCaseBaseOIDC):
     def test_user_is_lightspeed_subscriber_admin(self, *args):
         self.client.force_authenticate(user=self.user)
         r = self.client.get(reverse("wca_api_key"))
@@ -57,39 +56,6 @@ class TestIfOrgIsLightspeedSubscriber(WisdomServiceAPITestCaseBase):
         self.assert_error_detail(
             r, IsOrganisationLightspeedSubscriber.code, IsOrganisationLightspeedSubscriber.message
         )
-
-
-@override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
-@override_settings(WCA_SECRET_DUMMY_SECRETS="1234567:valid")
-class TestBlockUserWithoutSeatAndWCAReadyOrg(WisdomAppsBackendMocking):
-    def setUp(self):
-        super().setUp()
-        self.user = create_user(provider="oidc")
-        self.request = Mock()
-        self.request.user = self.user
-        self.p = BlockUserWithoutSeatAndWCAReadyOrg()
-
-    def tearDown(self):
-        self.user.delete()
-        super().tearDown()
-
-    def test_ensure_user_with_no_org_are_allowed(self):
-        self.user.organization = None
-        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
-
-    def test_ensure_seated_user_are_allowed(self):
-        self.user.rh_user_has_seat = True
-        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
-
-    def test_ensure_unseated_user_are_blocked(self):
-        self.user.rh_user_has_seat = False
-        self.assertEqual(self.p.has_permission(self.request, None), BLOCK)
-
-    @override_settings(ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=True)
-    def test_ensure_trial_user_can_pass_through(self):
-        demo_plan, _ = Plan.objects.get_or_create(name="demo_90_days", expires_after="90 days")
-        self.user.plans.add(demo_plan)
-        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
 
 
 @override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
@@ -140,11 +106,6 @@ class TestBlockUserWithoutSeat(WisdomAppsBackendMocking):
         self.user.delete()
         super().tearDown()
 
-    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
-    def test_no_seat_users_are_allowed_with_tech_preview(self):
-        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
-
-    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     def test_no_seat_users_are_not_allowed_without_tech_preview(self):
         self.assertEqual(self.p.has_permission(self.request, None), BLOCK)
 

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -67,7 +67,6 @@ from .data.data_model import ContentMatchPayloadData, ContentMatchResponseDto
 from .model_client.exceptions import ModelTimeoutError
 from .permissions import (
     BlockUserWithoutSeat,
-    BlockUserWithoutSeatAndWCAReadyOrg,
     BlockUserWithSeatButWCANotReady,
     BlockWCANotReadyButTrialAvailable,
     IsAAPLicensed,
@@ -128,7 +127,6 @@ PERMISSIONS_MAP = {
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
         BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ],
 }
@@ -609,7 +607,6 @@ class Explanation(APIView):
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
         BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ]
     required_scopes = ["read", "write"]
@@ -777,7 +774,6 @@ class Generation(APIView):
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
         BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ]
     required_scopes = ["read", "write"]


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-26773>


## Description

We don't use this permission since the removal of the seat system.

## Testing

SAAS already ignores this permission.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: