### PR TITLE
home view: Don't use DOCUMENTATION_URL anymore

### DIFF
--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -147,7 +147,6 @@ COMMERCIAL_DOCUMENTATION_URL = os.getenv(
     "https://access.redhat.com/documentation/en-us/"
     "red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest",
 )
-DOCUMENTATION_URL = os.getenv("DOCUMENTATION_URL") or "https://docs.ai.ansible.redhat.com"
 TERMS_NOT_APPLICABLE = os.environ.get("TERMS_NOT_APPLICABLE", False)
 
 SOCIAL_AUTH_JSONFIELD_ENABLED = True

--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -254,20 +254,6 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertIn("https://official_docs", str(r.content))
 
-    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
-    @override_settings(DOCUMENTATION_URL="https://community_docs")
-    @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
-    def test_docs_url_for_unseated_user_with_tech_preview(self):
-        self.user = create_user(
-            password=self.password,
-            provider=USER_SOCIAL_AUTH_PROVIDER_GITHUB,
-        )
-        self.client.login(username=self.user.username, password=self.password)
-        r = self.client.get(reverse("home"))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertContains(r, "pf-c-alert__title", count=1)
-        self.assertIn("https://community_docs", str(r.content))
-
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     @override_settings(ANSIBLE_AI_PROJECT_NAME="Project Name")
     @patch.object(ansible_ai_connect.users.models.User, "rh_user_has_seat", False)
@@ -280,13 +266,6 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
         r = self.client.get(reverse("home"))
         self.assertContains(r, "Your organization doesn't have access to Project Name.")
         self.assertIn(settings.COMMERCIAL_DOCUMENTATION_URL, str(r.content))
-
-    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
-    @override_settings(DOCUMENTATION_URL="https://community_docs")
-    def test_docs_url_for_not_logged_in_user_with_tech_preview(self):
-        r = self.client.get(reverse("home"))
-        self.assertEqual(r.status_code, HTTPStatus.OK)
-        self.assertIn("https://community_docs", str(r.content))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     def test_docs_url_for_not_logged_in_user_without_tech_preview(self):

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -63,12 +63,7 @@ class HomeView(TemplateView):
             )
             context["org_has_api_key"] = org_has_api_key
 
-        if settings.ANSIBLE_AI_ENABLE_TECH_PREVIEW and not (
-            self.request.user.is_authenticated and self.request.user.rh_user_has_seat
-        ):
-            context["documentation_url"] = settings.DOCUMENTATION_URL
-        else:
-            context["documentation_url"] = settings.COMMERCIAL_DOCUMENTATION_URL
+        context["documentation_url"] = settings.COMMERCIAL_DOCUMENTATION_URL
 
         return context
 


### PR DESCRIPTION
DOCUMENTATION_URL was associated with the Tech Preview which is now done.
