### PR TITLE
requirements: upgrade Django to 4.2.14

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -80,7 +80,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.11
+django==4.2.14
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -80,7 +80,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.11
+django==4.2.14
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ certifi==2024.7.4
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==42.0.6
 # pin Django on 4.2.11 to address PYSEC-2024-47.
-Django==4.2.11
+Django==4.2.14
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
This to address the following recent security issues:

```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
django | 4.2.11 | PYSEC-2024-58 | 4.2.14,5.0.7 | An issue was discovered in Django 5.0 before 5.0.7 and 4.2 before 4.2.14. Derived classes of the django.core.files.storage.Storage base class, when they override generate_filename() without replicating the file-path validations from the parent class, potentially allow directory traversal via certain inputs during a save() call. (Built-in Storage sub-classes are unaffected.)
django | 4.2.11 | PYSEC-2024-57 | 4.2.14,5.0.7 | An issue was discovered in Django 5.0 before 5.0.7 and 4.2 before 4.2.14. The django.contrib.auth.backends.ModelBackend.authenticate() method allows remote attackers to enumerate users via a timing attack involving login requests for users with an unusable password.
django | 4.2.11 | PYSEC-2024-56 | 4.2.14,5.0.7 | An issue was discovered in Django 4.2 before 4.2.14 and 5.0 before 5.0.7. urlize and urlizetrunc were subject to a potential denial of service attack via certain inputs with a very large number of brackets.
django | 4.2.11 | PYSEC-2024-59 | 4.2.14,5.0.7 | An issue was discovered in Django 5.0 before 5.0.7 and 4.2 before 4.2.14. get_supported_language_variant() was subject to a potential denial-of-service attack when used with very long strings containing specific characters.
```

Changelog: https://docs.djangoproject.com/en/5.0/releases/#id1
