### PR TITLE
pip-compile: set the SELinux context

### DIFF
--- a/tools/docker-compose/pip-compile.yaml
+++ b/tools/docker-compose/pip-compile.yaml
@@ -5,7 +5,7 @@ services:
     image: registry.access.redhat.com/ubi9/ubi:latest
     working_dir: /var/www/wisdom
     volumes:
-      - $PWD:/var/www/wisdom
+      - $PWD:/var/www/wisdom:Z
     command:
       - /var/www/wisdom/tools/scripts/pip-compile.sh
 
@@ -14,6 +14,6 @@ services:
     image: registry.access.redhat.com/ubi9/ubi:latest
     working_dir: /var/www/wisdom
     volumes:
-      - $PWD:/var/www/wisdom
+      - $PWD:/var/www/wisdom:Z
     command:
       - /var/www/wisdom/tools/scripts/pip-compile.sh


### PR DESCRIPTION
Ensure we set the SELinux label `container_file_t` on the shared volume.

See: https://docs.podman.io/en/latest/markdown/podman-run.1.html
Similar to what was done with 35e4fbc749a20c330d370239fce0927845c8499e.
