### PR TITLE
do not default ANSIBLE_AI_MODEL_MESH_MODEL_ID

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -1364,7 +1364,7 @@ class TestCompletionView(WisdomServiceAPITestCaseBase):
             "suggestionId": str(uuid.uuid4()),
         }
         response_data = {
-            "model_id": settings.ANSIBLE_AI_MODEL_MESH_MODEL_ID,
+            "model_id": "wisdom",
             "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
         }
         self.client.force_authenticate(user=self.user)

--- a/ansible_ai_connect/healthcheck/tests/test_healthcheck.py
+++ b/ansible_ai_connect/healthcheck/tests/test_healthcheck.py
@@ -120,7 +120,6 @@ class BaseTestHealthCheck(WisdomAppsBackendMocking, APITestCase, WisdomServiceLo
         data = json.loads(r.content)
         self.assert_common_data(data, expected_status, deployed_region)
         timestamp = data["timestamp"]
-        self.assertIsNotNone(data["model_name"])
         dependencies = data.get("dependencies", [])
         self.assertEqual(4, len(dependencies))
         for dependency in dependencies:

--- a/ansible_ai_connect/healthcheck/views.py
+++ b/ansible_ai_connect/healthcheck/views.py
@@ -30,7 +30,6 @@ from health_check.views import MainView
 from rest_framework import permissions
 from rest_framework.views import APIView
 
-from ansible_ai_connect.ai.feature_flags import FeatureFlags
 from ansible_ai_connect.healthcheck.backends import BaseLightspeedHealthCheck
 
 from .version_info import VersionInfo
@@ -69,16 +68,7 @@ class HealthCheckCustomView(MainView):
         return self.render_to_response_json(self.plugins, status_code, request.user)
 
     def render_to_response_json(self, plugins, status, user):  # customize JSON output
-        model_name = settings.ANSIBLE_AI_MODEL_MESH_MODEL_ID
-        if settings.LAUNCHDARKLY_SDK_KEY:
-            # Lazy instantiation of FeatureFlags to ensure it honours settings.LAUNCHDARKLY_SDK_KEY
-            model_tuple = FeatureFlags().get("model_name", user, f".:.:{model_name}:.")
-            model_parts = model_tuple.split(":")
-            if len(model_parts) == 4:
-                _, _, model_name, _ = model_parts
-
         data = common_data()
-        data["model_name"] = model_name
         data["status"] = "error" if self.errors else "ok"
 
         dependencies = []

--- a/ansible_ai_connect/healthcheck/views.py
+++ b/ansible_ai_connect/healthcheck/views.py
@@ -113,7 +113,6 @@ class WisdomServiceHealthView(APIView):
                     "timestamp": "2023-03-13T17:25:17.240683",
                     "version": "latest 0.1.202303131417",
                     "git_commit": "b987bc43b90f8aca2deaf3bda85596f4b95a10a0",
-                    "model_name": "ansible-wisdom-v09",
                     "deployed_region": "dev",
                     "dependencies": [
                         {"name": "db", "status": "ok", "time_taken": 233.538},

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -54,7 +54,7 @@ ANSIBLE_AI_MODEL_MESH_API_URL = (
 )
 
 ANSIBLE_AI_MODEL_MESH_API_KEY = os.getenv("ANSIBLE_AI_MODEL_MESH_API_KEY")
-ANSIBLE_AI_MODEL_MESH_MODEL_ID = os.getenv("ANSIBLE_AI_MODEL_MESH_MODEL_ID") or "wisdom"
+ANSIBLE_AI_MODEL_MESH_MODEL_ID = os.getenv("ANSIBLE_AI_MODEL_MESH_MODEL_ID")
 if "ANSIBLE_AI_MODEL_MESH_MODEL_NAME" in os.environ:
     logger.warning(
         "Use of ANSIBLE_AI_MODEL_MESH_MODEL_NAME is deprecated and "
@@ -69,7 +69,7 @@ if "ANSIBLE_AI_MODEL_MESH_MODEL_NAME" in os.environ:
             "Setting the value of ANSIBLE_AI_MODEL_MESH_MODEL_ID to "
             "the value of ANSIBLE_AI_MODEL_MESH_MODEL_NAME."
         )
-        ANSIBLE_AI_MODEL_MESH_MODEL_ID = os.getenv("ANSIBLE_AI_MODEL_MESH_MODEL_NAME") or "wisdom"
+        ANSIBLE_AI_MODEL_MESH_MODEL_ID = os.getenv("ANSIBLE_AI_MODEL_MESH_MODEL_NAME")
 
 # Model API Timeout (in seconds). Default is None.
 ANSIBLE_AI_MODEL_MESH_API_TIMEOUT = os.getenv("ANSIBLE_AI_MODEL_MESH_API_TIMEOUT")

--- a/ansible_ai_connect/main/tests/test_middleware.py
+++ b/ansible_ai_connect/main/tests/test_middleware.py
@@ -36,6 +36,7 @@ class TestMiddleware(WisdomServiceAPITestCaseBase):
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="DUMMY_KEY_ANALYTICS_VALUE")
+    @override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_ID="wisdom")
     def test_full_payload(self):
         suggestionId = str(uuid.uuid4())
         activityId = str(uuid.uuid4())

--- a/ansible_ai_connect/main/tests/test_settings.py
+++ b/ansible_ai_connect/main/tests/test_settings.py
@@ -139,3 +139,7 @@ class TestSettings(SimpleTestCase, WisdomLogAwareMixin):
                     "ANSIBLE_AI_MODEL_MESH_MODEL_ID is set and will take precedence", log
                 )
             )
+
+    def test_ansible_ai_model_mesh_model_id_has_no_default(self):
+        settings = self.reload_settings()
+        self.assertIsNone(settings.ANSIBLE_AI_MODEL_MESH_MODEL_ID)

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -525,7 +525,6 @@ paths:
                     timestamp: '2023-03-13T17:25:17.240683'
                     version: latest 0.1.202303131417
                     git_commit: b987bc43b90f8aca2deaf3bda85596f4b95a10a0
-                    model_name: ansible-wisdom-v09
                     deployed_region: dev
                     dependencies:
                     - name: db


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-24704

## Description
Reverts default value for ANSIBLE_AI_MODEL_MESH_MODEL_ID. When this env var is set, we no longer retrieve the model id from secrets manager, which breaks us when deploying in SaaS mode. This PR also removes model_name from the status endpoint since it is not useful in its current form.

## Testing
### Steps to test
1. Pull down the PR
2. Run the wisdom service in SaaS mode
3. Run a polaybook generation
4. Confirm the model id is pulled from secrets manager, not hardcoded to "wisdom"

### Scenarios tested
above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production: Changes will be needed in ansible-wisdom-testing since model_name is being removed from the status endpoint.
