### PR TITLE
one-click trial landing page

### DIFF
--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -563,3 +563,7 @@ ALLOW_METRICS_FOR_ANONYMOUS_USERS = (
     os.getenv("ALLOW_METRICS_FOR_ANONYMOUS_USERS", "True").lower() == "true"
 )
 # ==========================================
+
+ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL = (
+    os.getenv("ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL", "False").lower() == "true"
+)

--- a/ansible_ai_connect/main/urls.py
+++ b/ansible_ai_connect/main/urls.py
@@ -55,6 +55,8 @@ from ansible_ai_connect.users.views import (
     CurrentUserView,
     HomeView,
     TermsOfService,
+    TrialTermsOfService,
+    TrialView,
     UnauthorizedView,
 )
 
@@ -81,6 +83,8 @@ urlpatterns = [
         name="login",
     ),
     path("logout/", LogoutView.as_view(), name="logout"),
+    path("trial/", TrialView.as_view(), name="trial"),
+    path("trial/terms/", TrialTermsOfService.as_view(), name="trial_terms"),
 ]
 
 if settings.DEBUG or settings.DEPLOYMENT_MODE == "saas":

--- a/ansible_ai_connect/users/templates/users/home.html
+++ b/ansible_ai_connect/users/templates/users/home.html
@@ -118,6 +118,16 @@
               {% if user.rh_user_is_org_admin or user.rh_user_has_seat %}
                 <p>Role: {% if user.rh_user_is_org_admin %}administrator{% endif %}{% if user.rh_user_is_org_admin and user.rh_user_has_seat %}, {% endif %}{% if user.rh_user_has_seat %}licensed user{% endif %}</p>
               {% endif %}
+
+                <!--
+                {% if not user.commercial_terms_accepted %}
+                <a href="{% url 'community_terms' %}">Please accept the Terms and Condition</a>.
+                {% else %}
+                <p>Term and condition: {{ user.commercial_terms_accepted }}
+                {% endif %}
+                #}
+                -->
+
             </div>
 
             <form id="logout-form" method="post" action="{% url 'logout' %}">

--- a/ansible_ai_connect/users/templates/users/trial.html
+++ b/ansible_ai_connect/users/templates/users/trial.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+
+{% if start_trial_button and accept_trial_terms is False %}
+<div class="pf-c-alert pf-m-info" aria-label="Information alert">
+  <div class="pf-c-alert__icon">
+    <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+  </div>
+  <p class="pf-c-alert__title">
+    Please accept the Term and Condition.
+  </p>
+</div>
+{% endif %}
+
+<section class="pf-c-page__main-section pf-m-light">
+  <div class="pf-l-bullseye">
+    <div class="pf-l-bullseye__item">
+      <div class="pf-c-empty-state">
+        <div class="pf-c-empty-state__content">
+
+          <div class="pf-l-bullseye pf-u-p-xl ls_logo_home">
+            <img src="{% static 'users/lightspeed.png' %}" width="95px" alt="{{ project_name }} logo"/>
+          </div>
+
+
+          <h1 class="pf-c-title pf-m-lg">{{ project_name }}</h1>
+
+          {% if user.is_authenticated %}
+          <div class="ls_message_body">
+            <p>{% firstof user.external_username user.username %}</p>
+          </div>
+
+
+          {% if deployment_mode != "saas" %}
+          <!-- Not supported -->
+          {% elif has_active_plan %}
+          <div class="ls_message_body">
+            You have an active <i>{{ has_active_plan.plan.name }}</i> that will end the {{ has_active_plan.expired_at }}
+          </div>
+
+
+          <!--
+              <div class="pf-v5-c-form__group pf-m-action">
+                <div class="pf-v5-c-form__actions">
+                  <a href="vscode://">
+                    <button class="pf-c-button pf-m-primary" type="submit">
+                      Open VS Code
+                    </button>
+                  </a>
+                </div>
+              </div>
+              -->
+
+              {% elif has_expired_plan %}
+              You have an expired ({{ has_active_plan.plan.name }}).
+              {% else  %}
+              <form action={% url 'trial' %} method="post">{% csrf_token %}
+
+
+                <div class="ls_message_body">
+                  <p>Start a [90] days free trial with our recommanded model, <a href="https://www.ibm.com/products/watsonx-code-assistant">IBM watsonx Code Assistant</a>.
+                  <p>This will only apply to you and will not affect your organization.
+                </div>
+
+
+                <div class="pf-c-empty-state__content">
+                  <p>
+                  <input type="checkbox" name="accept_trial_terms" {% if accept_trial_terms %}checked{% endif %} />
+                  <a href="{% url 'trial_terms' %}">Accept the Terms and Conditions</a>.
+                  <p/>
+
+                  <p>
+                  <button class="pf-c-button pf-m-primary" type="submit" name="start_trial_button" value="True">
+                    Start Ansible Lightspeed trial
+                  </button>
+                  <p/>
+                </div>
+              </form>
+              {% endif %}
+
+
+              <div class="ls_message_body">
+                <form id="logout-form" method="post" action="{% url 'logout' %}">
+                  {% csrf_token %}
+                  <button class="pf-c-button pf-m-secondary" type="submit">Log out</button>
+                </form>
+              </div>
+
+
+              {% else %}
+              <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>
+              <a class="pf-c-button pf-m-primary" type="button" href="{% url 'login' %}">Log in</a>
+              {% endif %}
+
+              <div class="pf-l-level pf-m-gutter ls_bottom_menu">
+                <a class="pf-l-level__item" href="https://matrix.to/#/%23ansible-lightspeed:ansible.im" target="_blank" rel="noopener"><span class="fas fa-solid fa-comments"></span> Chat</a>
+                <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
+                <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
+
+                {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
+                <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
+                {% endif %}
+              </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/ansible_ai_connect/users/templates/users/trial/terms.html
+++ b/ansible_ai_connect/users/templates/users/trial/terms.html
@@ -1,0 +1,361 @@
+{% extends "base.html" %}
+
+{% block banner %}{% endblock %}
+
+{% block content %}
+<section class="pf-c-page__main-section pf-m-light">
+    <div class="pf-l-bullseye">
+        <div class="pf-l-bullseye__item">
+            <div class="pf-c-empty-state ls_terms_main">
+                <div class="pf-c-empty-state__content">
+                    <div class="pf-l-flex ls_terms_logo">
+                        <div class="pf-l-flex__item">
+                            <img src="/static/assets/images/Red_Hat_logo.svg" width="110px" alt="Red Hat logo">
+                        </div>
+                        <div class="pf-l-flex__item  pf-m-align-right">
+                            <img src="/static/assets/images/IBM.svg" width="170px" alt="IBM logo">
+                        </div>
+                    </div>
+                    <div class="ls_terms_external_terms">
+                        <a href="#ibm-terms" class="pf-c-button pf-m-secondary">IBM Terms</a>
+                        <a href="#red-hat-terms" class="pf-c-button pf-m-secondary">Red Hat Terms</a>
+                    </div>
+
+                    <form action={% url 'trial' %} method="post">{% csrf_token %}
+                    <input type="hidden" name="partial_token" value={{partial_token}}>
+
+                    <h1 class="pf-c-title pf-m-xl" id="ibm-terms">IBM Terms of Service</h1>
+
+                    <div class="pf-c-content">
+                        <p></p>
+                        <p>
+                            We are excited that you are interested in participating in this Tech Preview and as a
+                            benefit, receiving access to IBM’s Early Cloud Service for IBM watsonx Code Assistant (“Early
+                            Cloud Service” or “ECS.”) User may use the ECS at no cost subject to the terms of this
+                            Agreement (“Agreement”).
+                        </p>
+                        <p>
+                            <strong>
+                                BY USING THE ECS, USER SIGNIFY YOUR ACCEPTANCE OF THE AGREEMENT AND ACKNOWLEDGE YOU HAVE
+                                READ AND UNDERSTAND THE AGREEMENT TERMS. IF YOU DO NOT ACCEPT THE AGREEMENT TERMS, THEN
+                                DO NOT USE THE ECS.
+                            </strong>
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">1. Early Cloud Service</h2>
+                        <p>
+                            The Tech Preview gives access to a pre-release version of the ECS. The ECS is intended to
+                            use an AI model to create Ansible tasks and other Ansible related content, and share related
+                            data and information regarding such usage to train and improve the ECS.
+                        </p>
+                        <p>
+                            <span class="ls_text_underline">Suggestions by ECS:</span> Based on your request,
+                            the ECS will provide suggested Ansible tasks and other Ansible materials (“Suggestions”). By
+                            using the ECS, you agree that any and all Suggestions and any User data input into ECS may
+                            be used by International Business Machines Corporation (“IBM”) and its affiliates including
+                            Red Hat, Inc. (“Red Hat”), for any purpose without limitation, including to further improve
+                            and train the ECS.
+                        </p>
+                        <p>
+                            Suggestions may be similar to material used to train the machine learning model used to
+                            provide the ECS. The Suggestions will likely require modifications by User. User should
+                            evaluate whether Suggestions are appropriate for User environments. User’s use of
+                            Suggestions is at User’s discretion and risk. Any User requests or input into ECS will not
+                            be treated as confidential information.
+                        </p>
+                        <p>
+                            The ECS is not designed to comply with any specific governmental regulation or specific
+                            security measures. User agrees that no personal data will be input to the ECS, including
+                            such that may be subject to European General Data Protection Regulations (GDPR)
+                            requirements. User acknowledges that the use of the ECS meets User's requirements and
+                            processing instructions required to comply with applicable laws.
+                        </p>
+                        <p>
+                            <span class="ls_text_underline">User Feedback on ECS:</span> The ECS is a service
+                            IBM is developing and testing for release as a cloud service. User is authorized to use the
+                            ECS for the purpose of evaluating its functionality and to provide feedback on the ECS to
+                            IBM and its affiliates, who may use the feedback for any purpose without limitation.
+                        </p>
+                        <p>
+                            <span class="ls_text_underline">Code:</span> Code is defined as the content User
+                            creates using the ECS, including User’s modifications to Suggestions. IBM does not claim any
+                            intellectual property rights with respect to any Suggestions.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">2. Right to Use and User Responsibilities</h2>
+                        <p>
+                            To use the ECS you need to install the Ansible Visual Studio Code extension and authenticate
+                            via your GitHub account that you have been authorized to use with the Ansible Service.
+                        </p>
+                        <p>
+                            IBM is neither a party to the Red Hat Enterprise Agreement nor the Visual Studio Code
+                            agreement and is not responsible for the Ansible Service. User is responsible for the use of
+                            the ECS by any user who accesses the ECS with User's account credentials. User is
+                            responsible for obtaining all necessary rights and permissions to permit processing of data
+                            in the ECS.
+                        </p>
+                        <p>
+                            With respect to Code, User shall apply meaningful testing and human oversight of the Code
+                            the User produces while using ECS to find and mitigate errors and vulnerabilities.
+                        </p>
+                        <p>
+                            <strong>
+                                The ECS is not designed for use in a production environment or for commercial purposes
+                                and any such use is at User’s own risk.
+                            </strong>
+                            If the offering becomes generally available, IBM is under no obligation to offer migration
+                            capabilities or services.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">3. No Warranties, Service Levels or Technical Support</h2>
+                        <p>
+                            THE ECS IS PROVIDED AS-IS WITH NO WARRANTIES OF ANY KIND (WHETHER EXPRESS OR IMPLIED)
+                            INCLUDING I) NO WARRANTY FOR UNINTERRUPTED OR ERROR-FREE OPERATION OF THE ECS; AND II) NO
+                            OTHER WARRANTIES SUCH AS IMPLIED WARRANTIES OR CONDITIONS OF SATISFACTORY QUALITY,
+                            MERCHANTABILITY, NON-INFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE; AND WITH NO SERVICE
+                            LEVEL AGREEMENTS OR TECHNICAL SUPPORT.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">4. Term</h2>
+                        <p>
+                            IBM intends to offer the ECS through December, 2023 and reserves the right to periodically
+                            update, improve or discontinue the ECS or any component or functionality of the Service. IBM
+                            may terminate your use of the ECS at any time for any reason.
+                        </p>
+                        <p>
+                            User may terminate participation in the Tech Preview at any time by stopping use of the ECS.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">5. Changes</h2>
+                        <p>
+                            IBM may in its reasonable discretion, change these terms, modify the computing environment,
+                            or withdraw the ECS, in whole or in part. Continued use is User’s acceptance of any such
+                            change. If User does not accept a change, User is responsible to terminate User’s use.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">6. Acceptable Use Terms</h2>
+                        <p>
+                            The ECS may not be used to undertake any activity that:
+                        </p>
+                        <ul>
+                            <li>is unlawful, fraudulent, harmful, malicious, obscene, or offensive;</li>
+                            <li>threatens or violates the rights of others;</li>
+                            <li>disrupts or gains (or intends to disrupt or gain) unauthorized access to data, services,
+                                networks, or computing environments within or external to IBM;</li>
+                            <li>sends unsolicited, abusive, or deceptive messages of any type; or</li>
+                            <li>distributes any form of malware.</li>
+                        </ul>
+                        <p>
+                            User may not use the ECS: i) for crypto-mining; or ii) if failure or interruption of the ECS
+                            could lead to death, serious bodily injury, or property or environmental damage.
+                        </p>
+                        <p>
+                            User may not:
+                        </p>
+                        <ul>
+                            <li>reverse engineer any portion of the ECS; or</li>
+                            <li>assign or resell direct access to the ECS to a third party.</li>
+                        </ul>
+
+                        <h2 class="pf-c-title  pf-m-md">7. Liability</h2>
+                        <p>
+                            IBM's entire liability for all claims related to the Agreement will not exceed the amount of
+                            any actual direct damages incurred by User up to US $1,000, regardless of the basis of the
+                            claim. IBM will not be liable for special, incidental, exemplary, indirect or economic
+                            consequential damages, or lost profits, business, value, revenue, goodwill, or anticipated
+                            savings. These limitations apply collectively to IBM, its affiliates, contractors, and
+                            suppliers.
+                        </p>
+                        <p>
+                            IBM has no responsibility for claims based on: (1) items not provided by IBM; or (2) any
+                            violation of law or third party rights caused by User Code or User data.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">8. Business Contact and Account Usage Information</h2>
+                        <p>
+                            IBM, its affiliates, and contractors of either require use of business contact information
+                            and certain account usage information. Business contact information is used to communicate
+                            and manage business dealings with the User. Examples of business contact information include
+                            name, business telephone, address, email, user ID, and tax registration information.
+                        </p>
+                        <p>
+                            Account usage information is required to enable, provide, manage, support, administer, and
+                            improve the ECS. Examples of account usage information include digital information gathered
+                            using tracking technologies, such as cookies and web beacons during use of the ECS.
+                        </p>
+                        <p>
+                            The IBM Privacy Statement at <a href="https://www.ibm.com/privacy/">https://www.ibm.com/privacy/</a>
+                            provides additional details with respect to IBM's collection, use, and handling of business
+                            contact and account usage information. When User provides information to IBM and notice to,
+                            or consent by, the individuals is required for such processing, User will notify individuals
+                            and obtain consent.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">9. Compliance with Laws</h2>
+                        <p>
+                            Each party is also responsible for complying with:
+                        </p>
+                        <ul>
+                            <li>laws and regulations applicable to its business; and</li>
+                            <li>import, export and economic sanction laws and regulations, including the defense trade
+                                control regime of the United States of America and any applicable jurisdictions that
+                                prohibit or restrict the import, export, re-export, or transfer of products, technology,
+                                services or data, directly or indirectly, to or for certain countries, end uses or end
+                                users.</li>
+                        </ul>
+                        <p>
+                            IBM will not serve as User's exporter or importer, except as required by data protection
+                            laws.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">10. Enforcement and Other Rights</h2>
+                        <p>
+                            If a provision of the Agreement is invalid or unenforceable, the remaining provisions remain
+                            in full force and effect.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">11. Cause of Action</h2>
+                        <p>
+                            No right or cause of action for any third party is created by the Agreement. Neither party
+                            will bring a legal action arising out of or related to the Agreement more than two years
+                            after the cause of action arose.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">12. Global Resources</h2>
+                        <p>
+                            IBM may use personnel and resources in locations worldwide, including contractors, to
+                            support the ECS’s delivery.
+                        </p>
+
+                        <h2 class="pf-c-title  pf-m-md">13. General</h2>
+                        <p>
+                            IBM is an independent contractor, not User's agent, joint venturer, partner or fiduciary.
+                        </p>
+                        <p>
+                            IBM does not undertake to perform any of User's regulatory obligations or assume any
+                            responsibility for User's business or operations, and User is responsible for its use of the
+                            ECS. IBM is acting as an information technology provider only. IBM's direction, suggested
+                            usage, or guidance or use of the ECS does not constitute medical, clinical, legal,
+                            accounting, or other licensed professional advice. User should obtain their own expert
+                            advice.
+                        </p>
+                        <p>
+                            Both parties agree to the application of the laws of the State of New York, United States,
+                            without regard to conflict of law principles.
+                        </p>
+                    </div>
+
+                    <div class="pf-c-empty-state__content">
+                        <div class="ls_terms_divider_padding"></div>
+                        <hr class="pf-c-divider" />
+                        <div class="ls_terms_divider_padding"></div>
+                    </div>
+
+                    <h1 class="pf-c-title pf-m-xl" id="red-hat-terms">Red Hat Terms of Service</h1>
+                    <h2 class="pf-c-title pf-m-l">Red Hat Ansible Lightspeed with IBM watsonx Code Assistant Technical Preview Program Terms </h2>
+                    <div class="pf-c-content">
+                        <p></p>
+                        <p>
+                            We are excited that you are interested in participating in this Technical Preview Program
+                            (<strong>“Program”</strong>) and as a benefit, receiving access to Red Hat’s preview service
+                            that provides guidance on Ansible tasks and other Ansible related content (<strong>“Lightspeed”</strong>)
+                            integrated with IBM’s Early Cloud Service for IBM watsonx Code Assistant (<strong>"ECS"</strong>)
+                            (subject to a separate IBM agreement). The Program gives you access to a preview version of
+                            Lightspeed at no cost subject to these terms.
+                        </p>
+                        <p>
+                            These Program Terms govern your use of Lightspeed and are subject to the Red Hat Enterprise
+                            Agreement available at<a href="http://www.redhat.com/agreements">http://www.redhat.com/agreements</a>
+                            (the<strong>"Agreement"</strong>). When we use a capitalized term without defining it in
+                            these Program Terms, the term has the meaning defined in the Agreement. If there is a
+                            conflict between these Program Terms and the Agreement, the Program Terms will take
+                            precedence. IBM is not a party to the Agreement or these Program Terms.
+                        </p>
+                        <p>
+                            The Program gives access to a preview version of Lightspeed. Lightspeed passes your requests
+                            to ECS and uses output from ECS to refine Ansible tasks and other Ansible related content.
+                            Red Hat shares that data and related information regarding such usage with IBM to train and
+                            improve Lightspeed and ECS. Lightspeed is not supported for or intended for any other
+                            purpose.
+                        </p>
+                        <p>
+                            To use Lightspeed, you need to install the Ansible Visual Studio Code extension and
+                            authenticate via your GitHub account that you have been authorized to use for this Program.
+                            Based on your request, Lightspeed will provide suggested tasks or other Ansible related
+                            materials (<strong>"Suggestions"</strong>). By participating in this Program you agree that
+                            any and all Suggestions and any data associated with your use, may be used by Red Hat and
+                            Red Hat’s affiliated companies, including IBM, for any purpose including to further improve
+                            and train Lightspeed and ECS. The following information is collected and may be shared with
+                            IBM:
+                        </p>
+                        <ul>
+                            <li>The VS Code extension provides prompts and context to create Suggestions, and user
+                                interactions with Suggestions such as acceptance, modification or rejection.</li>
+                            <li>Lightspeed collects telemetry including Suggestions generated by ECS and refined by
+                                post-processing rules, as well as operational information (e.g. service errors and
+                                response times).</li>
+                            <li>User feedback regarding user sentiment and recommendations.</li>
+                            <li>Any program feedback provided directly to Red Hat.</li>
+                        </ul>
+                        <p>
+                            Suggestions may be similar to material used to train the machine learning model. The
+                            Suggestions will likely require additional modifications by you to be useful. Suggestions
+                            are not considered Red Hat Software and Red Hat does not claim any intellectual property
+                            rights with respect to any Suggestions. Your use of Suggestions is at your discretion and
+                            risk. Any requests or input into Lightspeed will not be treated as confidential information.
+                            Lightspeed is not intended to process personal information, so do not provide personal
+                            information except for business contact type information (name, work email address, etc.)
+                            associated with this Program. For information on how Red Hat processes your personal
+                            information, see the Red Hat Privacy Statement.
+                        </p>
+                        <p>
+                            Red Hat makes no warranties or guarantees with respect to Lightspeed including Suggestions,
+                            except those explicitly required by law, and you should confirm that use of Lightspeed or
+                            any Suggestions is appropriate for your environment. If you believe Red Hat or its
+                            affiliates are using your material in a non-compliant manner, you agree to provide Red Hat
+                            with written notice and allow Red Hat ninety days to address your issue.
+                        </p>
+                        <p>
+                            Red Hat reserves the right to periodically update, improve or discontinue Lightspeed or any
+                            component or functionality at any time. Red Hat may terminate your use of Lightspeed at any
+                            time for any reason.
+                        </p>
+                        <p>
+                            These Program Terms establish the rights and obligations associated with Lightspeed and are
+                            not intended to limit your rights to software code under the terms of an open source
+                            license.
+                        </p>
+                        <p>
+                            PLEASE READ THESE PROGRAM TERMS CAREFULLY BEFORE USING LIGHTSPEED. BY USING THE SERVICE, YOU
+                            SIGNIFY YOUR ACCEPTANCE OF THESE PROGRAM TERMS AND ACKNOWLEDGE YOU HAVE READ AND UNDERSTAND
+                            THE PROGRAM TERMS. IF YOU DO NOT ACCEPT THE PROGRAM TERMS, THEN DO NOT USE LIGHTSPEED.
+                        </p>
+                        <p>
+                            June, 2023
+                        </p>
+                        <div class="ls_terms_bottom"></div>
+                    </div>
+
+
+                    <div class="pf-c-empty-state__content">
+                        <p>
+                            Click to accept both the Red Hat Ansible Lightspeed
+                            Technical Preview terms and the IBM watsonx Code Assistant
+                            Technical Preview terms.
+                        </p>
+                        <div class="ls_terms_accept_buttons"></div>
+                        <button class="pf-c-button pf-m-primary" type="submit" name="accept_trial_terms" value="True">
+                            <span class="pf-c-button__icon"><i class="fa fa-check-circle"></i></span>
+                            Agree
+                        </button>
+                        <button class="pf-c-button pf-m-secondary" type="submit" name="accepted" value="False">
+                            Disagree
+                        </button>
+                    </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-26231>

## Description

Landing page for the 90 days Trial.

![image](https://github.com/ansible/ansible-ai-connect-service/assets/49379/9f37781c-faa5-47aa-8074-d40d2d80f22c)

## Testing

- Set `ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL` True
- Connect to the service with OIDC user, the Org should not have any key set
- You should be able to accept the T&C and start a Trial period

No API permission changes should be triggered at this stage. Another PR will come for that.

## Production deployment

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: