### PR TITLE
test_middleware: remove ANSIBLE_AI_ENABLE_TECH_PREVIEW=True

### DIFF
--- a/ansible_ai_connect/ai/tests/test_feature_flags.py
+++ b/ansible_ai_connect/ai/tests/test_feature_flags.py
@@ -20,10 +20,10 @@ from django.test import override_settings
 from ldclient.config import Config
 
 import ansible_ai_connect.ai.feature_flags as feature_flags
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 
 
-class TestFeatureFlags(WisdomServiceAPITestCaseBase):
+class TestFeatureFlags(WisdomServiceAPITestCaseBaseOIDC):
     def setUp(self):
         super().setUp()
         feature_flags.FeatureFlags.instance = None

--- a/ansible_ai_connect/main/tests/test_console_views.py
+++ b/ansible_ai_connect/main/tests/test_console_views.py
@@ -25,11 +25,11 @@ from ansible_ai_connect.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 from ansible_ai_connect.organizations.models import Organization
 
 
-class TestConsoleView(WisdomServiceAPITestCaseBase):
+class TestConsoleView(WisdomServiceAPITestCaseBaseOIDC):
     def setUp(self):
         super().setUp()
         feature_flags.FeatureFlags.instance = None

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -33,19 +33,19 @@ from ansible_ai_connect.users.constants import (
 from ansible_ai_connect.users.tests.test_users import create_user
 
 
-def create_user_with_provider(user_provider, **kwargs):
+def create_user_with_provider(**kwargs):
+    kwargs.setdefault("username", "test_user_name")
+    kwargs.setdefault("password", "test_passwords")
+    kwargs.setdefault("provider", USER_SOCIAL_AUTH_PROVIDER_OIDC)
+    kwargs.setdefault("external_username", "anexternalusername")
     return create_user(
-        username="test_user_name",
-        password="test_passwords",
-        provider=user_provider,
-        external_username="anexternalusername",
         **kwargs,
     )
 
 
 class LogoutTest(TestCase):
     def test_rht_sso_redirect(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
 
         response = self.client.get(reverse("logout"))
@@ -57,7 +57,7 @@ class LogoutTest(TestCase):
         )
 
     def test_gh_sso_redirect(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_GITHUB)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_GITHUB)
         self.client.force_login(user)
 
         response = self.client.get(reverse("logout"))
@@ -65,7 +65,7 @@ class LogoutTest(TestCase):
 
     @override_settings(AAP_API_URL="http://aap/api")
     def test_aap_sso_redirect(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_AAP)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_AAP)
         self.client.force_login(user)
 
         response = self.client.get(reverse("logout"))

--- a/ansible_ai_connect/users/tests/test_throttling.py
+++ b/ansible_ai_connect/users/tests/test_throttling.py
@@ -14,13 +14,13 @@
 
 from django.conf import settings
 
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBase
+from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 from ansible_ai_connect.ai.api.views import Completions, Feedback
 
 from ..throttling import GroupSpecificThrottle
 
 
-class TestThrottling(WisdomServiceAPITestCaseBase):
+class TestThrottling(WisdomServiceAPITestCaseBaseOIDC):
     def test_get_cache_key(self):
         class DummyRequest:
             def __init__(self, user):

--- a/ansible_ai_connect/users/tests/test_users.py
+++ b/ansible_ai_connect/users/tests/test_users.py
@@ -51,6 +51,7 @@ def create_user(
     username: str = None,
     password: str = None,
     provider: str = None,
+    email: str = None,
     social_auth_extra_data: any = {},
     external_username: str = "",
     rh_user_is_org_admin: Optional[bool] = None,
@@ -61,7 +62,7 @@ def create_user(
     (org, _) = Organization.objects.get_or_create(id=rh_org_id, telemetry_opt_out=org_opt_out)
     username = username or "u" + "".join(random.choices(string.digits, k=5))
     password = password or "secret"
-    email = username + "@example.com"
+    email = email or username + "@example.com"
     user = get_user_model().objects.create_user(
         username=username,
         email=email,

--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -280,14 +280,14 @@ class TestHomeDocumentationUrl(WisdomAppsBackendMocking, APITransactionTestCase)
 @override_settings(AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION="*")
 class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
     def test_redirect(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
         r = self.client.get(reverse("home"))
         self.assertEqual(r.status_code, 302)
         self.assertEqual(r.url, "/trial/")
 
     def test_accept_trial_terms(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
         self.client.get(reverse("trial"))
         r = self.client.post(
@@ -298,7 +298,7 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         self.assertIn('accept_trial_terms" checked', str(r.content))
 
     def test_accept_trial_without_terms(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
         self.client.get(reverse("trial"))
         r = self.client.post(
@@ -309,7 +309,7 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         self.assertIn("Information alert", str(r.content))
 
     def test_accept_trial(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
         self.client.get(reverse("trial"))
         r = self.client.post(
@@ -325,8 +325,8 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         self.assertTrue(user.userplan_set.first().expired_at)
 
     @override_settings(ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=False)
-    def test__no_trial_for_you(self):
-        user = create_user_with_provider(USER_SOCIAL_AUTH_PROVIDER_OIDC)
+    def test_no_trial_for_you(self):
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)
         r = self.client.get(reverse("home"))
         self.assertEqual(r.status_code, 200)  # No redirect


### PR DESCRIPTION
The change breaks the `ANSIBLE_AI_ENABLE_TECH_PREVIEW=True` dependency in `test_middleware.py` and also introduces `WisdomServiceAPITestCaseBaseOIDC` which is `WisdomServiceAPITestCaseBase` with an OIDC user. This is a more realistic scenario and the new class should supersede the old one.