### PR TITLE
limit hosts matched by regex

### DIFF
--- a/tools/authz/validate_ams.py
+++ b/tools/authz/validate_ams.py
@@ -25,8 +25,8 @@ from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
-AUTHZ_SSO_PATTERN = r"^sso.(.+\.)?redhat.com$"
-AUTHZ_API_PATTERN = r"^api.(.+\.)?openshift.com$"
+AUTHZ_SSO_PATTERN = r"^sso\.(.+\.)?redhat.com$"
+AUTHZ_API_PATTERN = r"^api\.(.+\.)?openshift.com$"
 
 
 class AuthzURLError(URLError):


### PR DESCRIPTION
Closes: https://github.com/ansible/ansible-ai-connect-service/issues/1197

The current regexes will more hosts than intended; example:

<img width="396" alt="image" src="https://github.com/ansible/ansible-ai-connect-service/assets/13005641/371f60a7-36fc-49d3-af5a-629d214725b7">
