### PR TITLE
return permission_denied__can_apply_for_trial for trial candidate

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -69,6 +69,7 @@ from .permissions import (
     BlockUserWithoutSeat,
     BlockUserWithoutSeatAndWCAReadyOrg,
     BlockUserWithSeatButWCANotReady,
+    BlockWCANotReadyButTrialAvailable,
     IsAAPLicensed,
 )
 from .serializers import (
@@ -126,6 +127,7 @@ PERMISSIONS_MAP = {
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
+        BlockWCANotReadyButTrialAvailable,
         BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ],
@@ -380,6 +382,7 @@ class ContentMatches(GenericAPIView):
             permissions.IsAuthenticated,
             IsAuthenticatedOrTokenHasScope,
             BlockUserWithoutSeat,
+            BlockWCANotReadyButTrialAvailable,
         ]
     )
 
@@ -605,6 +608,7 @@ class Explanation(APIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
+        BlockWCANotReadyButTrialAvailable,
         BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ]
@@ -772,6 +776,7 @@ class Generation(APIView):
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
         BlockUserWithoutSeat,
+        BlockWCANotReadyButTrialAvailable,
         BlockUserWithoutSeatAndWCAReadyOrg,
         BlockUserWithSeatButWCANotReady,
     ]


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-26581>

## Description

When the user's org is not configured yet, we return a different
error message to let the VSCode extension know the user can apply for
a Trial.

## Testing

- Switch `ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL` to `True`
- Connect with a user with a valid Org but no secret
- Call the API, you should get the `permission_denied__can_apply_for_trial` error code :partying_face: 

## Production deployment

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:



