### PR TITLE
unredact inlineSuggestionFeedback for opted in orgs

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_serializers.py
+++ b/ansible_ai_connect/ai/api/tests/test_serializers.py
@@ -236,10 +236,6 @@ class FeedbackRequestSerializerTest(TestCase):
             },
         )
 
-        # inlineSuggestion feedback raises exception when seat
-        with self.assertRaises(serializers.ValidationError):
-            serializer.is_valid(raise_exception=True)
-
         # inlineSuggestion feedback raises exception when seat and not telemetry enabled
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)

--- a/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
@@ -63,6 +63,17 @@ ALLOW_LIST = {
         "rh_user_org_id": None,
         "timestamp": None,
     },
+    "inlineSuggestionFeedback": {
+        "action": None,
+        "suggestionId": None,
+        "modelName": None,
+        "imageTags": None,
+        "hostname": None,
+        "groups": None,
+        "rh_user_has_seat": None,
+        "rh_user_org_id": None,
+        "timestamp": None,
+    },
     "prediction": {
         "duration": None,
         "exception": None,

--- a/ansible_ai_connect/ai/api/utils/tests/test_segment.py
+++ b/ansible_ai_connect/ai/api/utils/tests/test_segment.py
@@ -166,11 +166,11 @@ class TestSegment(TestCase):
         }
 
         with self.assertLogs(logger="root") as log:
-            send_segment_event(event, "inlineSuggestionFeedback", user)
+            send_segment_event(event, "someUnallowedFeedback", user)
             self.assertEqual(
                 log.output[0],
                 "ERROR:ansible_ai_connect.ai.api.utils.segment:It is not allowed to track"
-                + " inlineSuggestionFeedback events for seated users",
+                + " someUnallowedFeedback events for seated users",
             )
 
     @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.track")


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-20367

## Description
Allows collection of inlineSuggestionFeedback for licensed users who have not opted out of analytics telemetry.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Test an inlineSuggestionFeedback as a user in a not opted out org
3. inlineSuggestionFeedback flows to Segment
4. Test an inlineSuggestionFeedback as a user in an opted out org
5. Request fails with a 400

### Scenarios tested
As described above. Also, there were already existing unit tests to confirm the serializer enforces inlineSuggestionFeedback not being available to users in opted out orgs, so nothing additional to add.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
