### PR TITLE
Add backoff exception logs to wca_client

### DIFF
--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -15,6 +15,7 @@
 import base64
 import json
 import logging
+import sys
 from abc import abstractmethod
 from typing import Any, Dict, Optional
 
@@ -201,23 +202,37 @@ class BaseWCAClient(ModelMeshClient):
             return False
 
     @staticmethod
+    def log_backoff_exception(details):
+        _, exc, _ = sys.exc_info()
+        logger.info(str(exc))
+        logger.info(
+            f"Caught retryable error after {details['tries']} tries. "
+            f"Waiting {details['wait']} more seconds then retrying..."
+        )
+
+    @staticmethod
     def on_backoff_inference(details):
+        BaseWCAClient.log_backoff_exception(details)
         wca_codegen_retry_counter.inc()
 
     @staticmethod
     def on_backoff_codematch(details):
+        BaseWCAClient.log_backoff_exception(details)
         wca_codematch_retry_counter.inc()
 
     @staticmethod
     def on_backoff_codegen_playbook(details):
+        BaseWCAClient.log_backoff_exception(details)
         wca_codegen_playbook_retry_counter.inc()
 
     @staticmethod
     def on_backoff_explain_playbook(details):
+        BaseWCAClient.log_backoff_exception(details)
         wca_explain_playbook_retry_counter.inc()
 
     @staticmethod
     def on_backoff_ibm_cloud_identity_token(details):
+        BaseWCAClient.log_backoff_exception(details)
         ibm_cloud_identity_token_retry_counter.inc()
 
     def infer(self, request, model_input, model_id: str = "", suggestion_id=None) -> Dict[str, Any]:

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -339,6 +339,14 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
+        "ansible_ai_connect.ai.api.model_client.wca_client": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "ansible_ai_connect.users.authz_checker": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
         "ansible_ai_connect.users.signals": {
             "handlers": ["console"],
             "level": "INFO",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a. This is for getting more info for [wca-feedback issue#62](https://github.com/rh-ibm-synergy/wca-feedback/issues/62)
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Add exception log when exceptions are thrown while WCA API is processed. The backoff tool provided the retry mechanism, but we have not logged those exceptions and did not have detailed information on them.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->

Unit test cases are provided with the PR.  In addition to test cases and log level setting for WCA API, changes for AMS API (log level setting and test cases) are also provided.

### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
