### PR TITLE
trial: send schema1 event after new subscription

### DIFF
--- a/ansible_ai_connect/ai/api/telemetry/schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema1.py
@@ -1,0 +1,100 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import logging
+import platform
+
+from attr import Factory, asdict, field
+from attrs import define, validators
+from django.utils import timezone
+
+from ansible_ai_connect.healthcheck.version_info import VersionInfo
+from ansible_ai_connect.users.models import User
+
+logger = logging.getLogger(__name__)
+version_info = VersionInfo()
+
+
+@define
+class RequestPayload:
+    method: str = field(validator=validators.instance_of(str), converter=str, default="")
+    path: str = field(validator=validators.instance_of(str), converter=str, default="")
+
+
+@define
+class PlanEntry:
+    accept_marketing: bool = False
+    created_at: str = field(validator=validators.instance_of(str), converter=str, default="")
+    expired_at: str = field(validator=validators.instance_of(str), converter=str, default="")
+    is_active: bool = False
+    name: str = field(validator=validators.instance_of(str), converter=str, default="")
+    plan_id: int = 0
+
+
+@define
+class Schema1Event:
+    imageTags: str = field(
+        validator=validators.instance_of(str), converter=str, default=version_info.image_tags
+    )
+    hostname: str = field(
+        validator=validators.instance_of(str), converter=str, default=platform.node()
+    )
+    groups: list[str] = Factory(list)
+
+    rh_user_has_seat: bool = False
+    rh_user_org_id: int | None = None
+    timestamp = timezone.now().isoformat()
+    modelName: str = field(validator=validators.instance_of(str), converter=str, default="")
+    problem: str = field(validator=validators.instance_of(str), converter=str, default="")
+    exception: bool = False
+    request: RequestPayload = RequestPayload()
+    _user: User | None = None
+
+    def set_user(self, user):
+        self._user = user
+        self.rh_user_has_seat = user.rh_user_has_seat
+        self.rh_user_org_id = user.org_id
+        self.groups = list(user.groups.values_list("name", flat=True))
+
+    def set_request(self, request):
+        self.set_user(request.user)
+        self.request = RequestPayload(path=request.path, method=request.method)
+
+    def as_dict(self):
+        # NOTE: The allowed fields should be moved in the event class itslef
+        def my_filter(a, v):
+            return a.name not in ["_user", "event_name"]
+
+        return asdict(self, filter=my_filter, recurse=True)
+
+
+@define
+class OneClickTrialStartedEvent(Schema1Event):
+    event_name: str = "oneClickTrialStarted"
+    plans: list[PlanEntry] = Factory(list)
+
+    def set_user(self, user):
+        super().set_user(user)
+        for up in user.userplan_set.all():
+            self.plans.append(
+                PlanEntry(
+                    accept_marketing=up.accept_marketing,
+                    created_at=up.created_at,
+                    expired_at=up.expired_at,
+                    is_active=up.is_active,
+                    name=up.plan.name,
+                    plan_id=up.plan.id,
+                )
+            )

--- a/ansible_ai_connect/ai/api/telemetry/test_schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/test_schema1.py
@@ -1,0 +1,72 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timedelta
+from unittest import TestCase, mock
+
+from .schema1 import OneClickTrialStartedEvent, Schema1Event
+
+
+class TestSchema1Event(TestCase):
+    def test_set_user(self):
+        m_user = mock.Mock()
+        m_user.rh_user_has_seat = True
+        m_user.org_id = 123
+        m_user.groups.values_list.return_value = ["mecano"]
+        event1 = Schema1Event()
+        event1.set_user(m_user)
+        self.assertEqual(event1.rh_user_has_seat, True)
+        self.assertEqual(event1.rh_user_org_id, 123)
+        self.assertEqual(event1.groups, ["mecano"])
+
+    def test_set_request(self):
+        m_request = mock.Mock()
+        m_request.user.groups.values_list.return_value = []
+        m_request.path = "/trial"
+        m_request.method = "POST"
+        event1 = Schema1Event()
+        event1.set_request(m_request)
+        self.assertEqual(event1.request.path, "/trial")
+        self.assertEqual(event1.request.method, "POST")
+
+    def test_as_dict(self):
+        event1 = Schema1Event()
+        as_dict = event1.as_dict()
+
+        self.assertEqual(as_dict.get("event_name"), None)
+        self.assertFalse(as_dict.get("exception"), False)
+
+
+class TestOneClickTrialStartedEvent(TestCase):
+    def test_new_trial(self):
+        event1 = OneClickTrialStartedEvent()
+        self.assertEqual(event1.event_name, "oneClickTrialStarted")
+
+    def test_new_trial_record_plan(self):
+        m_plan = mock.Mock()
+        m_plan.plan.name = "Some plan"
+        m_plan.plan.id = 12
+        m_plan.created_at = str(datetime.now())
+        m_plan.expired_at = str(datetime.now() + timedelta(days=30))
+        m_plan.is_expired = False
+        m_user = mock.Mock()
+        m_user.groups.values_list.return_value = []
+        m_user.userplan_set.all.return_value = [m_plan]
+        event1 = OneClickTrialStartedEvent()
+        event1.set_user(m_user)
+        self.assertTrue(isinstance(event1.plans, list))
+        self.assertEqual(len(event1.plans), 1)
+        self.assertEqual(event1.plans[0].name, "Some plan")
+        self.assertTrue(event1.plans[0].created_at.startswith("20"))
+        self.assertEqual(event1.plans[0].plan_id, 12)

--- a/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
@@ -337,4 +337,16 @@ ALLOW_LIST = {
         "timestamp": None,
         "value": None,
     },
+    "oneClickTrialStarted": {
+        "exception": None,
+        "groups": None,
+        "hostname": None,
+        "imageTags": None,
+        "modelName": None,
+        "plans": None,
+        "problem": None,
+        "request": None,
+        "rh_user_has_seat": None,
+        "rh_user_org_id": None,
+    },
 }


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-27313>

## Description

Send a `newTrial` event when the user accepts the Trial period.

## Testing

- Add a `print()` at the top of `ansible_ai_connect.ai.api.utils.segment.base_send_segment_event` to trace the payload we will send, or do something more elegant.
- Enable the Trial with `ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=True`
- Enable the Schema1 event transmission with `SEGMENT_WRITE_KEY=whatever`
- Use an OIDC/RHSSO account with an AAP subscript but without any IBM api key
- Connect to the dashboard
- Accept the Trial period
- Check the logs

## Production deployment

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: