### PR TITLE
AAP-27339: Handle HAP detected in playbook gen and explanation

### DIFF
--- a/ansible_ai_connect/ai/api/exceptions.py
+++ b/ansible_ai_connect/ai/api/exceptions.py
@@ -135,6 +135,11 @@ class WcaCloudflareRejectionException(WisdomBadRequest):
     default_detail = "Cloudflare rejected the request. Please contact your administrator."
 
 
+class WcaHAPFilterRejectionException(WisdomBadRequest):
+    default_code = "error__wca_hap_filter_rejection"
+    default_detail = "WCA Hate, Abuse, and Profanity filter rejected the request."
+
+
 class WcaUserTrialExpiredException(WisdomAccessDenied):
     default_code = "permission_denied__user_trial_expired"
     default_detail = "User trial expired. Please contact your administrator."

--- a/ansible_ai_connect/ai/api/model_client/exceptions.py
+++ b/ansible_ai_connect/ai/api/model_client/exceptions.py
@@ -83,6 +83,11 @@ class WcaCloudflareRejection(WcaException):
 
 
 @dataclass
+class WcaHAPFilterRejection(WcaException):
+    """WCA Hate, Abuse, and Profanity filter rejection."""
+
+
+@dataclass
 class WcaUserTrialExpired(WcaException):
     """WCA notifies that user's trial has expired."""
 

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
@@ -31,6 +31,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaBadRequestException,
     WcaCloudflareRejectionException,
     WcaEmptyResponseException,
+    WcaHAPFilterRejectionException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
@@ -44,6 +45,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaBadRequest,
     WcaCloudflareRejection,
     WcaEmptyResponse,
+    WcaHAPFilterRejection,
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
@@ -155,6 +157,14 @@ class InferenceStage(PipelineElement):
             exception = e
             logger.exception(f"Cloudflare rejected the request for {payload.suggestionId}")
             raise WcaCloudflareRejectionException(cause=e)
+
+        except WcaHAPFilterRejection as e:
+            exception = e
+            logger.exception(
+                f"WCA Hate, Abuse, and Profanity filter rejected "
+                f"the request for suggestion {suggestion_id}"
+            )
+            raise WcaHAPFilterRejectionException(cause=e)
 
         except WcaUserTrialExpired as e:
             exception = e

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -40,6 +40,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaBadRequestException,
     WcaCloudflareRejectionException,
     WcaEmptyResponseException,
+    WcaHAPFilterRejectionException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
@@ -52,6 +53,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaBadRequest,
     WcaCloudflareRejection,
     WcaEmptyResponse,
+    WcaHAPFilterRejection,
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
@@ -713,6 +715,14 @@ class Explanation(APIView):
             )
             raise WcaCloudflareRejectionException(cause=e)
 
+        except WcaHAPFilterRejection as e:
+            exception = e
+            logger.exception(
+                f"WCA Hate, Abuse, and Profanity filter rejected "
+                f"the request for playbook explanation {explanation_id}"
+            )
+            raise WcaHAPFilterRejectionException(cause=e)
+
         except WcaUserTrialExpired as e:
             exception = e
             logger.exception(
@@ -892,6 +902,14 @@ class Generation(APIView):
                 f"Cloudflare rejected the request for playbook generation {generation_id}"
             )
             raise WcaCloudflareRejectionException(cause=e)
+
+        except WcaHAPFilterRejection as e:
+            exception = e
+            logger.exception(
+                f"WCA Hate, Abuse, and Profanity filter rejected "
+                f"the request for playbook generation {generation_id}"
+            )
+            raise WcaHAPFilterRejectionException(cause=e)
 
         except WcaUserTrialExpired as e:
             exception = e


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-27339

## Description
Add support for WCA HAP rejections to completions, playbook generation and playbook explanation.

## Testing

### Steps to test
1. Pull down the PR
2. Run the service locally
3. Point VSCode at it.
4. Enable Playbook generation.
5. Type something naughty.

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

VSCode changes: https://github.com/ansible/vscode-ansible/pull/1432