### PR TITLE
[DRAFT] AAP-TBE-model-id-validation: Consider WCA 204's as a valid model_id

### DIFF
--- a/ansible_ai_connect/ai/api/wca/tests/test_model_id_views.py
+++ b/ansible_ai_connect/ai/api/wca/tests/test_model_id_views.py
@@ -28,6 +28,7 @@ import ansible_ai_connect.ai.apps
 from ansible_ai_connect.ai.api.aws.exceptions import WcaSecretManagerError
 from ansible_ai_connect.ai.api.aws.wca_secret_manager import AWSSecretManager, Suffixes
 from ansible_ai_connect.ai.api.model_client.exceptions import (
+    WcaEmptyResponse,
     WcaInvalidModelId,
     WcaUserTrialExpired,
 )
@@ -276,6 +277,47 @@ class TestWCAModelIdView(
             self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
             self.assert_segment_log(log, "modelIdSet", "ValidationError")
 
+    @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
+    def test_set_model_id_empty_response(self, *args):
+        self.user.organization = Organization.objects.get_or_create(id=123)[0]
+        mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
+        mock_wca_client = apps.get_app_config("ai").model_mesh_client
+        self.client.force_authenticate(user=self.user)
+
+        # Set ModelId
+        mock_secret_manager.get_secret.return_value = {"SecretString": "someAPIKey"}
+        mock_wca_client.infer_from_parameters = Mock(side_effect=WcaEmptyResponse)
+        with self.assertLogs(logger="ansible_ai_connect.users.signals", level="DEBUG") as signals:
+            with self.assertLogs(logger="root", level="DEBUG") as log:
+                r = self.client.post(
+                    reverse("wca_model_id"),
+                    data='{ "model_id": "secret_model_id" }',
+                    content_type="application/json",
+                )
+
+                self.assertEqual(r.status_code, HTTPStatus.NO_CONTENT)
+                mock_secret_manager.save_secret.assert_called_with(
+                    123, Suffixes.MODEL_ID, "secret_model_id"
+                )
+                self.assert_segment_log(log, "modelIdSet", None)
+
+            # Check audit entry
+            self.assertInLog(
+                f"User: '{self.user}' set WCA Model Id for "
+                f"Organisation '{self.user.organization.id}'",
+                signals,
+            )
+
+        # Check ModelId was stored
+        mock_secret_manager.get_secret.return_value = {
+            "SecretString": "secret_model_id",
+            "CreatedDate": timezone.now().isoformat(),
+        }
+        r = self.client.get(reverse("wca_model_id"))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertEqual(r.data["model_id"], "secret_model_id")
+        mock_secret_manager.get_secret.assert_called_with(123, Suffixes.MODEL_ID)
+
 
 @patch.object(IsOrganisationAdministrator, "has_permission", return_value=True)
 @patch.object(IsOrganisationLightspeedSubscriber, "has_permission", return_value=False)
@@ -475,3 +517,15 @@ class TestWCAModelIdValidatorView(
             self.assertEqual(r.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
             self.assertInLog("Exception", log)
             self.assert_segment_log(log, "modelIdValidate", "Exception")
+
+    @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
+    def test_validate_error_model_id_empty_response(self, *args):
+        self.user.organization = Organization.objects.get_or_create(id=123)[0]
+        mock_wca_client = apps.get_app_config("ai").model_mesh_client
+        self.client.force_authenticate(user=self.user)
+        mock_wca_client.infer_from_parameters = Mock(side_effect=WcaEmptyResponse)
+
+        with self.assertLogs(logger="root", level="DEBUG") as log:
+            r = self.client.get(reverse("wca_model_id_validator"))
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            self.assert_segment_log(log, "modelIdValidate", None)


### PR DESCRIPTION
**=== DRAFT ===**

Jira Issue: https://issues.redhat.com/browse/AAP-27482

## Description
Currently HTTP204's from WCA are mapped to HTTP503 in validation of the `model_id`. However in these scenarios the `model_id` was found (otherwise we get other exceptions) it just returned an empty response for the `prompt` we [use](https://github.com/ansible/ansible-ai-connect-service/blob/main/ansible_ai_connect/ai/api/wca/model_id_views.py#L213-L215) to validate `model_id`'s.

## Testing
This is difficult to test for real; as it needs a model on WCA that, whilst valid, returns HTTP204 for the validation prompt.

### Steps to test
1. Pull down the PR
2. Unit tests only.

## Production deployment
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

@jameswnl would like to discuss this at the scrum meeting.