### PR TITLE
AAP-27482: Lightspeed admin portal saving custom model-ID return 503

### DIFF
--- a/ansible_ai_connect/ai/api/wca/model_id_views.py
+++ b/ansible_ai_connect/ai/api/wca/model_id_views.py
@@ -37,6 +37,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaUserTrialExpiredException,
 )
 from ansible_ai_connect.ai.api.model_client.exceptions import (
+    WcaEmptyResponse,
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
@@ -220,6 +221,7 @@ def do_validated_operation(request, api_key_provider, model_id_provider, on_succ
     event = None
     start_time = time.time()
     model_id = UNKNOWN_MODEL_ID
+    organization = None
     try:
         # An OrgId must be present
         # See https://issues.redhat.com/browse/AAP-16009
@@ -232,6 +234,16 @@ def do_validated_operation(request, api_key_provider, model_id_provider, on_succ
 
         validate(api_key, model_id)
 
+        return on_success(organization.id, model_id)
+
+    except WcaEmptyResponse:
+        # An empty response does not mean the model_id is invalid.
+        # More specific exceptions represent an invalid or missing model_id.
+        # organization is guaranteed to be non-None here.
+        logger.info(
+            "WCA returned an empty response validating "
+            f"model_id '{model_id}' for organisation '{organization.id}'."
+        )
         return on_success(organization.id, model_id)
 
     except (WcaInvalidModelId, WcaModelIdNotFound, WcaTokenFailure) as e:


### PR DESCRIPTION
**=== REPLACES #1221 WITH CORRECT BRANCH NAME ===**

Jira Issue: https://issues.redhat.com/browse/AAP-27482

## Description
Currently HTTP204's from WCA are mapped to HTTP503 in validation of the `model_id`. However in these scenarios the `model_id` was found (otherwise we get other exceptions) it just returned an empty response for the `prompt` we [use](https://github.com/ansible/ansible-ai-connect-service/blob/main/ansible_ai_connect/ai/api/wca/model_id_views.py#L213-L215) to validate `model_id`'s.

## Testing
This is difficult to test for real; as it needs a model on WCA that, whilst valid, returns HTTP204 for the validation prompt.

### Steps to test
1. Pull down the PR
2. Unit tests only.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
