### PR TITLE
removing redirect to trial when admin

### DIFF
--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -286,6 +286,15 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         self.assertEqual(r.status_code, 302)
         self.assertEqual(r.url, "/trial/")
 
+    def test_redirect_when_admin(self):
+        user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
+        self.client.force_login(user)
+        user.rh_user_is_org_admin = True
+        user.save()
+        r = self.client.get(reverse("home"))
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn("Start a [90] days free trial", str(r.content))
+
     def test_accept_trial_terms(self):
         user = create_user_with_provider(provider=USER_SOCIAL_AUTH_PROVIDER_OIDC)
         self.client.force_login(user)

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -69,6 +69,7 @@ class HomeView(TemplateView):
             and self.request.user.is_oidc_user
             and self.request.user.rh_org_has_subscription
             and not self.org_has_api_key
+            and not self.request.user.rh_user_is_org_admin
         ):
             return HttpResponseRedirect(reverse("trial"))
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-27650

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Admins should not be redirected to the trial page

## Production deployment

- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
