### PR TITLE
don't pause trial if we disable ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL

### DIFF
--- a/ansible_ai_connect/ai/api/permissions.py
+++ b/ansible_ai_connect/ai/api/permissions.py
@@ -65,9 +65,7 @@ class BlockWCANotReadyButTrialAvailable(permissions.BasePermission):
             return CONTINUE
 
         # accept user with active Trial period
-        if settings.ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL and any(
-            up.is_active for up in request.user.userplan_set.all()
-        ):
+        if any(up.is_active for up in request.user.userplan_set.all()):
             return CONTINUE
 
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
@@ -95,9 +93,7 @@ class BlockUserWithoutSeatAndWCAReadyOrg(permissions.BasePermission):
             return CONTINUE
 
         # accept user with active Trial period
-        if settings.ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL and any(
-            up.is_active for up in request.user.userplan_set.all()
-        ):
+        if any(up.is_active for up in request.user.userplan_set.all()):
             return CONTINUE
 
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
@@ -123,9 +119,7 @@ class BlockUserWithSeatButWCANotReady(permissions.BasePermission):
             return CONTINUE
 
         # If the user has an active Trial, we continue
-        if settings.ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL and any(
-            up.is_active for up in request.user.userplan_set.all()
-        ):
+        if any(up.is_active for up in request.user.userplan_set.all()):
             return CONTINUE
 
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
@@ -148,9 +142,7 @@ class BlockUserWithoutSeat(permissions.BasePermission):
             return CONTINUE
 
         # If the user has an active Trial, we continue
-        if settings.ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL and any(
-            up.is_active for up in request.user.userplan_set.all()
-        ):
+        if any(up.is_active for up in request.user.userplan_set.all()):
             return CONTINUE
 
         return CONTINUE if user.rh_user_has_seat else BLOCK

--- a/ansible_ai_connect/ai/api/tests/test_permissions.py
+++ b/ansible_ai_connect/ai/api/tests/test_permissions.py
@@ -154,6 +154,12 @@ class TestBlockUserWithoutSeat(WisdomAppsBackendMocking):
         self.user.plans.add(demo_plan)
         self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
 
+    @override_settings(ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=False)
+    def test_ensure_trial_user_can_pass_through_despite_trial_disabled(self):
+        demo_plan, _ = Plan.objects.get_or_create(name="demo_90_days", expires_after="90 days")
+        self.user.plans.add(demo_plan)
+        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
+
 
 @override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
 @override_settings(WCA_SECRET_DUMMY_SECRETS="")
@@ -189,6 +195,12 @@ class TestBlockWCANotReadyButTrialAvailable(WisdomAppsBackendMocking):
         self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
 
     def test_ensure_trial_user_can_pass_through(self):
+        demo_plan, _ = Plan.objects.get_or_create(name="demo_90_days", expires_after="90 days")
+        self.user.plans.add(demo_plan)
+        self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)
+
+    @override_settings(ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=False)
+    def test_ensure_trial_user_can_pass_through_despite_trial_disabled(self):
         demo_plan, _ = Plan.objects.get_or_create(name="demo_90_days", expires_after="90 days")
         self.user.plans.add(demo_plan)
         self.assertEqual(self.p.has_permission(self.request, None), CONTINUE)


### PR DESCRIPTION
Once the Trials are started, we don't pause them if the `ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL`
value change.
