### PR TITLE
AAP-27719: Lightspeed on-prem using self-signed cert to connect to WCA-onprem failed

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -51,7 +51,7 @@ botocore==1.29.165
     #   s3transfer
 bracex==2.4
     # via wcmatch
-certifi==2024.7.4
+certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
     # via
     #   -r requirements.in
     #   launchdarkly-server-sdk

--- a/requirements-dev-aarch64.txt
+++ b/requirements-dev-aarch64.txt
@@ -8,7 +8,7 @@ black==24.3.0
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
-certifi==2024.7.4
+certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
     # via
     #   -r requirements-dev.in
     #   requests

--- a/requirements-dev-x86_64.txt
+++ b/requirements-dev-x86_64.txt
@@ -8,7 +8,7 @@ black==24.3.0
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
-certifi==2024.7.4
+certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
     # via
     #   -r requirements-dev.in
     #   requests

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,6 @@
 black==24.3.0
 coverage==7.2.1
-# pin certifi on 2024.7.4 to address CVE-2024-39689
-certifi==2024.7.4
+certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 flake8==6.0.0
 grpcio-tools==1.62.2
 # pin idna until responses -> requests is updated

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -51,7 +51,7 @@ botocore==1.29.165
     #   s3transfer
 bracex==2.4
     # via wcmatch
-certifi==2024.7.4
+certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
     # via
     #   -r requirements.in
     #   launchdarkly-server-sdk

--- a/requirements.in
+++ b/requirements.in
@@ -4,8 +4,7 @@ ansible-lint==24.2.2
 boto3==1.26.84
 # pin black on 24.3.0 to address PYSEC-2024-48.
 black==24.3.0
-# pin certifi on 2024.7.4 to address CVE-2024-39689
-certifi==2024.7.4
+certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==42.0.6
 # pin Django on 4.2.11 to address PYSEC-2024-47.

--- a/tools/scripts/pip-compile.sh
+++ b/tools/scripts/pip-compile.sh
@@ -2,6 +2,7 @@
 set -o errexit
 
 dnf install -y python3.11
+dnf -y install git
 
 /usr/bin/python3.11 -m venv /var/www/venv
 /var/www/venv/bin/python3.11 -m pip --no-cache-dir install pip-tools


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-27719

## Description
Use Red Hat fork of `certifi` that is hard coded to work with RHEL Certificate Authority store. The `ansible-ai-connect-service` container image is based on `registry.access.redhat.com/ubi9/ubi` which uses different CA store location to other OS's.

## Testing
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
