### PR TITLE
trial: properly wrap in a <div/> the expiration message

### DIFF
--- a/ansible_ai_connect/users/templates/users/trial.html
+++ b/ansible_ai_connect/users/templates/users/trial.html
@@ -65,7 +65,9 @@
               -->
 
               {% elif has_expired_plan %}
-              Your trial period has expired
+              <div class="ls_message_body">
+              <p>Your trial period has expired</p>
+              </div>
               {% else  %}
               <form action={% url 'trial' %} method="post">{% csrf_token %}
 


### PR DESCRIPTION
Use a dedicated `<div />` to hold the "Your trial period has expired" message.
