### PR TITLE
tests: move user creation function/class at the root level

### DIFF
--- a/ansible_ai_connect/ai/tests/test_feature_flags.py
+++ b/ansible_ai_connect/ai/tests/test_feature_flags.py
@@ -20,7 +20,7 @@ from django.test import override_settings
 from ldclient.config import Config
 
 import ansible_ai_connect.ai.feature_flags as feature_flags
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
 
 
 class TestFeatureFlags(WisdomServiceAPITestCaseBaseOIDC):

--- a/ansible_ai_connect/main/tests/test_console_views.py
+++ b/ansible_ai_connect/main/tests/test_console_views.py
@@ -25,8 +25,8 @@ from ansible_ai_connect.ai.api.permissions import (
     IsOrganisationAdministrator,
     IsOrganisationLightspeedSubscriber,
 )
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 from ansible_ai_connect.organizations.models import Organization
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
 
 
 class TestConsoleView(WisdomServiceAPITestCaseBaseOIDC):

--- a/ansible_ai_connect/main/tests/test_middleware.py
+++ b/ansible_ai_connect/main/tests/test_middleware.py
@@ -27,8 +27,8 @@ from segment import analytics
 from ansible_ai_connect.ai.api.tests.test_views import (
     MockedMeshClient,
     WisdomAppsBackendMocking,
-    WisdomServiceAPITestCaseBaseOIDC,
 )
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
 
 
 def dummy_redact_seated_users_data(event, allow_list):

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -27,23 +27,13 @@ from rest_framework.test import APITransactionTestCase
 
 from ansible_ai_connect.main.settings.base import SOCIAL_AUTH_OIDC_KEY
 from ansible_ai_connect.main.views import LoginView
+from ansible_ai_connect.test_utils import create_user_with_provider
 from ansible_ai_connect.users.constants import (
     USER_SOCIAL_AUTH_PROVIDER_AAP,
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
 from ansible_ai_connect.users.models import Plan
-from ansible_ai_connect.users.tests.test_users import create_user
-
-
-def create_user_with_provider(**kwargs):
-    kwargs.setdefault("username", "test_user_name")
-    kwargs.setdefault("password", "test_passwords")
-    kwargs.setdefault("provider", USER_SOCIAL_AUTH_PROVIDER_OIDC)
-    kwargs.setdefault("external_username", "anexternalusername")
-    return create_user(
-        **kwargs,
-    )
 
 
 class LogoutTest(TestCase):

--- a/ansible_ai_connect/users/tests/test_throttling.py
+++ b/ansible_ai_connect/users/tests/test_throttling.py
@@ -14,8 +14,8 @@
 
 from django.conf import settings
 
-from ansible_ai_connect.ai.api.tests.test_views import WisdomServiceAPITestCaseBaseOIDC
 from ansible_ai_connect.ai.api.views import Completions, Feedback
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
 
 from ..throttling import GroupSpecificThrottle
 

--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -21,17 +21,16 @@ import boto3
 from django.conf import settings
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from rest_framework.test import APITransactionTestCase
 
 import ansible_ai_connect.users.models
-from ansible_ai_connect.ai.api.tests.test_views import APITransactionTestCase
 from ansible_ai_connect.main.tests.test_views import create_user_with_provider
-from ansible_ai_connect.test_utils import WisdomAppsBackendMocking
+from ansible_ai_connect.test_utils import WisdomAppsBackendMocking, create_user
 from ansible_ai_connect.users.constants import (
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
 )
 from ansible_ai_connect.users.models import Plan
-from ansible_ai_connect.users.tests.test_users import create_user
 
 
 def bypass_init(*args, **kwargs):


### PR DESCRIPTION
Move:
- create_user
- WisdomServiceAPITestCaseBase
- WisdomServiceAPITestCaseBaseOIDC

At the root level in `ansible_ai_connect.test_utils` to simplify the reusablity.
