### PR TITLE
requirements: upgrade Django to 4.2.15

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -80,7 +80,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.14
+django==4.2.15
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -80,7 +80,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.14
+django==4.2.15
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf3
 # UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==42.0.6
 # pin Django on 4.2.11 to address PYSEC-2024-47.
-Django==4.2.14
+Django==4.2.15
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
This to address the following CVE:

- CVE-2024-41989
- CVE-2024-41990
- CVE-2024-41991
- CVE-2024-42005

release note: https://docs.djangoproject.com/en/5.0/releases/4.2.15/
