### PR TITLE
AAP-26787: API: add a endpoint to list the users

### DIFF
--- a/ansible_ai_connect/main/urls.py
+++ b/ansible_ai_connect/main/urls.py
@@ -58,6 +58,7 @@ from ansible_ai_connect.users.views import (
     TrialTermsOfService,
     TrialView,
     UnauthorizedView,
+    UserViewSet,
 )
 
 WISDOM_API_VERSION = "v0"
@@ -70,6 +71,12 @@ urlpatterns = [
     # Adding a trailing slash breaks our metric collection in all sorts of ways.
     path("metrics", MetricsView.as_view(), name="prometheus-metrics"),
     path("admin/", admin.site.urls),
+    path(f"api/{WISDOM_API_VERSION}/users", UserViewSet.as_view({"get": "list"}), name="user_list"),
+    path(
+        f"api/{WISDOM_API_VERSION}/users/<pk>",
+        UserViewSet.as_view({"get": "retrieve"}),
+        name="user_retrieve",
+    ),
     path(f"api/{WISDOM_API_VERSION}/ai/", include("ansible_ai_connect.ai.api.urls")),
     path(f"api/{WISDOM_API_VERSION}/me/", CurrentUserView.as_view(), name="me"),
     path(

--- a/ansible_ai_connect/organizations/models.py
+++ b/ansible_ai_connect/organizations/models.py
@@ -35,6 +35,12 @@ class Organization(models.Model):
     id = models.IntegerField(primary_key=True)
     telemetry_opt_out = models.BooleanField(default=False, db_column="telemetry_opt_out")
 
+    @property  # NOTE: The info dict is already cache in the seat_checker
+    def name(self):
+        seat_checker = apps.get_app_config("ai").get_seat_checker()
+        organization_info = seat_checker.get_organization(self.id)
+        return organization_info.get("name")
+
     @property
     def has_telemetry_opt_out(self):
         # For saas deployment mode, telemetry is opted-in by default (telemetry_opt_out=False)

--- a/ansible_ai_connect/organizations/serializers.py
+++ b/ansible_ai_connect/organizations/serializers.py
@@ -1,0 +1,24 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rest_framework import serializers
+
+from ansible_ai_connect.organizations.models import Organization
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Organization
+        fields = ["id", "name", "has_api_key", "has_telemetry_opt_out"]

--- a/ansible_ai_connect/users/authz_checker.py
+++ b/ansible_ai_connect/users/authz_checker.py
@@ -103,6 +103,12 @@ authz_ams_rh_org_has_subscription_cache_hit_counter = Counter(
     namespace=NAMESPACE,
 )
 
+authz_ams_account_cache_hit_counter = Counter(
+    "authz_ams_account_cache_hit_counter",
+    "Counter of the number of times the AMS 'account' cache is hit.",
+    namespace=NAMESPACE,
+)
+
 
 class BaseCheck:
     @abstractmethod
@@ -196,7 +202,7 @@ class Token:
         return self.access_token
 
 
-class CIAMCheck(BaseCheck):
+class CIAMCheck(BaseCheck):  # TODO: To be removed
     def __init__(self, client_id, client_secret, sso_server, api_server):
         self._session = requests.Session()
         self._token = Token(client_id, client_secret, sso_server)
@@ -211,6 +217,7 @@ class CIAMCheck(BaseCheck):
         r.raise_for_status()
 
 
+# NOTE: we should probably rename the class to reflect it's current purpose
 class AMSCheck(BaseCheck):
     # An AMS Organization ID that should never match anything
     ERROR_AMS_ORG_UNDEFINED = "__undefined__"
@@ -239,13 +246,13 @@ class AMSCheck(BaseCheck):
     def update_bearer_token(self):
         self._session.headers.update({"Authorization": f"Bearer {self._token.get()}"})
 
-    def get_ams_org(self, rh_org_id: int) -> str:
+    def get_organization(self, rh_org_id: int) -> dict[str, str]:
         if not rh_org_id:
             logger.error(f"Unexpected value for rh_org_id: {rh_org_id}.")
-            return AMSCheck.ERROR_AMS_ORG_UNDEFINED
+            return {}
 
         # Check cache
-        cache_key = f"rh_org_{rh_org_id}"
+        cache_key = f"rh_organization_info_{rh_org_id}"
         cached_result = cache.get(cache_key)
         if cached_result is not None:
             authz_ams_org_cache_hit_counter.inc(exemplar={"organization_id": str(rh_org_id)})
@@ -288,9 +295,9 @@ class AMSCheck(BaseCheck):
         try:
             if len(data["items"]) == 0:
                 logger.info(f"An AMS Organization could not be found. " f"rh_org_id: {rh_org_id}.")
-                return AMSCheck.ERROR_AMS_ORG_UNDEFINED
+                return {}
 
-            result = data["items"][0]["id"]
+            result = data["items"][0]
             cache.set(cache_key, result, settings.AMS_ORG_CACHE_TIMEOUT_SEC)
             return result
         except (IndexError, KeyError, ValueError):
@@ -299,6 +306,81 @@ class AMSCheck(BaseCheck):
                 f"rh_org_id: {rh_org_id}, data={data}."
             )
             raise AMSCheck.AMSError
+
+    def get_account(self, rh_org_id: int, username: str) -> dict[str, str]:
+        if not rh_org_id:
+            logger.error(f"Unexpected value for rh_org_id: {rh_org_id}.")
+            return {}
+
+        # Check cache
+        cache_key = f"rh_account_info_{rh_org_id}_{username}"
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            authz_ams_account_cache_hit_counter.inc(
+                exemplar={"organization_id": str(rh_org_id), "username": str(username)}
+            )
+            return cached_result
+
+        params = {"search": f"organization.external_id = '{rh_org_id}' and username = '{username}'"}
+        self.update_bearer_token()
+
+        try:
+
+            @backoff.on_exception(
+                backoff.expo,
+                Exception,
+                max_tries=self.retries + 1,
+                giveup=fatal_exception,
+                on_backoff=self.on_backoff,
+            )
+            @authz_ams_get_organization_hist.time()
+            def get_request():
+                return self._session.get(
+                    self._api_server + "/api/accounts_mgmt/v1/accounts",
+                    params=params,
+                    timeout=self.timeout,
+                )
+
+            r = get_request()
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+            logger.error(self.ERROR_AMS_CONNECTION_TIMEOUT + f" rh_org_id: {rh_org_id}.")
+            raise AMSCheck.AMSError()
+
+        if r.status_code != HTTPStatus.OK:
+            logger.error(
+                f"Unexpected error code ({r.status_code}) returned by AMS backend (account). "
+                f"rh_org_id: {rh_org_id}."
+            )
+            raise AMSCheck.AMSError()
+
+        data = r.json()
+
+        try:
+            if len(data["items"]) == 0:
+                logger.info(
+                    f"An AMS Account could not be found. "
+                    f"rh_org_id: {rh_org_id}."
+                    f"username: {username}."
+                )
+                return {}
+
+            result = data["items"][0]
+            cache.set(cache_key, result, settings.AMS_ORG_CACHE_TIMEOUT_SEC)
+            return result
+        except (IndexError, KeyError, ValueError):
+            logger.exception(
+                f"Unexpected answer from AMS backend (account). "
+                f"rh_org_id: {rh_org_id}, data={data}."
+            )
+            raise AMSCheck.AMSError
+
+    def get_ams_org(self, rh_org_id: int) -> str:
+        """Return the AMS ID for a Red Hat org id"""
+        org_info = self.get_organization(rh_org_id)
+        if "id" in org_info:
+            return self.get_organization(rh_org_id)["id"]
+        else:
+            return AMSCheck.ERROR_AMS_ORG_UNDEFINED
 
     def self_test(self):
         self.update_bearer_token()
@@ -446,3 +528,23 @@ class DummyCheck(BaseCheck):
             int(i) for i in settings.AUTHZ_DUMMY_ORGS_WITH_SUBSCRIPTION.split(",") if i
         ]
         return organization_id in orgs_with_subscription
+
+    def get_organization(self, organization_id: int) -> dict[str, str]:
+        return {
+            "created_at": "2019-02-11T06:30:13.094967Z",
+            "ebs_account_id": str(organization_id * 2),
+            "external_id": str(organization_id),
+            "href": "/api/accounts_mgmt/v1/organizations/Somethinghere",
+            "id": "Somethinghere",
+            "kind": "Organization",
+            "name": f"My great organization {organization_id}",
+            "updated_at": "2024-08-08T19:54:15.145316Z",
+        }
+
+    def get_account(self, organization_id: int, username: str) -> dict[str, str]:
+        return {
+            "email": f"{username}@my-great-domain.us",
+            "first_name": "Robert",
+            "last_name": "Surcouf",
+            "username": username,
+        }

--- a/ansible_ai_connect/users/models.py
+++ b/ansible_ai_connect/users/models.py
@@ -68,8 +68,19 @@ class User(ExportModelOperationsMixin("user"), AbstractUser):
     rh_employee = models.BooleanField(default=False)
     external_username = models.CharField(default="", null=False)
 
+    def ams(self) -> dict[str, str]:
+        if not self.organization:
+            return {}
+        seat_checker = apps.get_app_config("ai").get_seat_checker()
+        account_info = seat_checker.get_account(self.organization.id, self.external_username)
+        return {
+            k: v
+            for k, v in account_info.items()
+            if k in ["created_at", "email", "first_name", "last_name", "updated_at"]
+        }
+
     @property
-    def org_id(self):
+    def org_id(self) -> int | None:
         if self.groups.filter(name="Commercial").exists():
             return FAUX_COMMERCIAL_USER_ORG_ID
         if self.organization and self.organization.id:

--- a/ansible_ai_connect/users/permissions.py
+++ b/ansible_ai_connect/users/permissions.py
@@ -1,0 +1,26 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import copy
+
+import rest_framework.permissions
+
+
+class DjangoModelPermissionsWithGET(rest_framework.permissions.DjangoModelPermissions):
+
+    def __init__(self):
+        self.perms_map = copy.deepcopy(
+            self.perms_map
+        )  # you need deepcopy when you inherit a dictionary type
+        self.perms_map["GET"] = ["%(app_label)s.view_%(model_name)s"]

--- a/ansible_ai_connect/users/serializers.py
+++ b/ansible_ai_connect/users/serializers.py
@@ -16,6 +16,23 @@ from textwrap import dedent
 from django.conf import settings
 from rest_framework import serializers
 
+from ansible_ai_connect.organizations.serializers import OrganizationSerializer
+from ansible_ai_connect.users.models import Plan, UserPlan
+
+
+class PlanSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Plan
+        fields = ["id", "name"]
+
+
+class UserPlanSerializer(serializers.ModelSerializer):
+    plan = PlanSerializer()
+
+    class Meta:
+        model = UserPlan
+        fields = ["created_at", "expired_at", "accept_marketing", "plan"]
+
 
 class UserResponseSerializer(serializers.Serializer):
     # Implemented as a vanilla Serializer as ModelSerializer is driven by the Model definition.
@@ -26,7 +43,10 @@ class UserResponseSerializer(serializers.Serializer):
     rh_user_is_org_admin = serializers.BooleanField(required=False)
     external_username = serializers.CharField(required=False)
     username = serializers.CharField(required=True, max_length=150)
+    ams = serializers.DictField(required=False)
     org_telemetry_opt_out = serializers.BooleanField(required=False)
+    userplan_set = UserPlanSerializer(many=True)
+    organization = OrganizationSerializer(required=False)
 
 
 class MarkdownUserResponseSerializer(serializers.Serializer):

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
+from rest_framework import viewsets
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -34,8 +35,9 @@ from ansible_ai_connect.ai.api.aws.exceptions import (
 from ansible_ai_connect.ai.api.telemetry import schema1
 from ansible_ai_connect.ai.api.utils.segment import send_schema1_event
 from ansible_ai_connect.main.cache.cache_per_user import cache_per_user
-from ansible_ai_connect.users.models import Plan
+from ansible_ai_connect.users.models import Plan, User
 
+from .permissions import DjangoModelPermissionsWithGET
 from .serializers import MarkdownUserResponseSerializer, UserResponseSerializer
 
 ME_USER_CACHE_TIMEOUT_SEC = settings.ME_USER_CACHE_TIMEOUT_SEC
@@ -120,6 +122,12 @@ class CurrentUserView(RetrieveAPIView):
         )
 
         return Response(user_data)
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    permission_classes = [DjangoModelPermissionsWithGET]
+    queryset = User.objects.all()
+    serializer_class = UserResponseSerializer
 
 
 class MarkdownCurrentUserView(RetrieveAPIView):

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -325,6 +325,48 @@ paths:
           description: Request was throttled
         '500':
           description: Internal service error
+  /api/v0/users:
+    get:
+      operationId: users_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      tags:
+      - users
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedUserResponseList'
+          description: ''
+  /api/v0/users/{id}:
+    get:
+      operationId: users_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user.
+        required: true
+      tags:
+      - users
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+          description: ''
   /api/v0/wca/apikey/:
     get:
       operationId: wca_api_key_get
@@ -856,6 +898,62 @@ components:
           title: Ansible vscode/vscodium extension version
           description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
           pattern: v?\d+\.\d+\.\d+
+    Organization:
+      type: object
+      properties:
+        id:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        name:
+          type: string
+          readOnly: true
+        has_api_key:
+          type: boolean
+          readOnly: true
+        has_telemetry_opt_out:
+          type: string
+          readOnly: true
+      required:
+      - has_api_key
+      - has_telemetry_opt_out
+      - id
+      - name
+    PaginatedUserResponseList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserResponse'
+    Plan:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 80
+      required:
+      - id
+      - name
     PlaybookExplanationFeedback:
       type: object
       properties:
@@ -972,6 +1070,24 @@ components:
       description: |-
         * `bug-report` - Bug Report
         * `feature-request` - Feature Request
+    UserPlan:
+      type: object
+      properties:
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        expired_at:
+          type: string
+          format: date-time
+          nullable: true
+        accept_marketing:
+          type: boolean
+        plan:
+          $ref: '#/components/schemas/Plan'
+      required:
+      - created_at
+      - plan
     UserResponse:
       type: object
       properties:
@@ -988,12 +1104,22 @@ components:
         username:
           type: string
           maxLength: 150
+        ams:
+          type: object
+          additionalProperties: {}
         org_telemetry_opt_out:
           type: boolean
+        userplan_set:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserPlan'
+        organization:
+          $ref: '#/components/schemas/Organization'
       required:
       - rh_org_has_subscription
       - rh_user_has_seat
       - username
+      - userplan_set
     WcaKeyRequest:
       type: object
       properties:


### PR DESCRIPTION
Expose a new end-points to list (`/api/v0/users`) and retrieve user information (`/api/v0/users/<PK>`) (e.g `/api/v0/users/1`).

To be able to access the end-point, the user needs to be part of a group with the following permissions:
- `view_user`
-  `view_userplan`
- `view_organization`

This explains how to prepare your user:

```python
from django.contrib.auth import get_user_model
from django.contrib.auth.models import Group, Permission
User = get_user_model()
me = User.objects.get(username="gleboude1@redhat.com")

from django.contrib.auth.models import Permission
wisdom_view_users, _ = Group.objects.get_or_create(name="wisdom_view_users")
wisdom_view_users.permissions.add(Permission.objects.get(codename='view_user'))
wisdom_view_users.permissions.add(Permission.objects.get(codename='view_userplan'))
wisdom_view_users.permissions.add(Permission.objects.get(codename='view_organization'))
me.groups.add(wisdom_view_users)
```

![image](https://github.com/user-attachments/assets/afb18fd3-a306-43bc-8e19-3b5dff8401c5)
