### PR TITLE
AAP-26787: Extract information about the recent new Lightspeed Trial subscription

### DIFF
--- a/ansible_ai_connect/main/exception_handler.py
+++ b/ansible_ai_connect/main/exception_handler.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
@@ -19,6 +20,10 @@ from rest_framework.views import exception_handler
 def exception_handler_with_error_type(exc, context):
     # Call the default exception handler first
     response = exception_handler(exc, context)
+
+    # All exceptions are returned as JSON
+    context["request"].accepted_media_type = "application/json"
+    context["request"].accepted_renderer = JSONRenderer()
 
     if isinstance(response, Response):
         # Add error type if specified.

--- a/ansible_ai_connect/main/urls.py
+++ b/ansible_ai_connect/main/urls.py
@@ -60,6 +60,10 @@ from ansible_ai_connect.users.views import (
     UnauthorizedView,
     UserViewSet,
 )
+from ansible_ai_connect.users.views_reports import (
+    UserMarketingReportView,
+    UserTrialsReportView,
+)
 
 WISDOM_API_VERSION = "v0"
 
@@ -76,6 +80,16 @@ urlpatterns = [
         f"api/{WISDOM_API_VERSION}/users/<pk>",
         UserViewSet.as_view({"get": "retrieve"}),
         name="user_retrieve",
+    ),
+    path(
+        f"api/{WISDOM_API_VERSION}/users/trials/",
+        UserTrialsReportView.as_view(),
+        name="user_trials",
+    ),
+    path(
+        f"api/{WISDOM_API_VERSION}/users/marketing/",
+        UserMarketingReportView.as_view(),
+        name="user_marketing",
     ),
     path(f"api/{WISDOM_API_VERSION}/ai/", include("ansible_ai_connect.ai.api.urls")),
     path(f"api/{WISDOM_API_VERSION}/me/", CurrentUserView.as_view(), name="me"),

--- a/ansible_ai_connect/main/urls.py
+++ b/ansible_ai_connect/main/urls.py
@@ -58,7 +58,6 @@ from ansible_ai_connect.users.views import (
     TrialTermsOfService,
     TrialView,
     UnauthorizedView,
-    UserViewSet,
 )
 from ansible_ai_connect.users.views_reports import (
     UserMarketingReportView,
@@ -75,19 +74,13 @@ urlpatterns = [
     # Adding a trailing slash breaks our metric collection in all sorts of ways.
     path("metrics", MetricsView.as_view(), name="prometheus-metrics"),
     path("admin/", admin.site.urls),
-    path(f"api/{WISDOM_API_VERSION}/users", UserViewSet.as_view({"get": "list"}), name="user_list"),
     path(
-        f"api/{WISDOM_API_VERSION}/users/<pk>",
-        UserViewSet.as_view({"get": "retrieve"}),
-        name="user_retrieve",
-    ),
-    path(
-        f"api/{WISDOM_API_VERSION}/users/trials/",
+        f"api/{WISDOM_API_VERSION}/users/trials",
         UserTrialsReportView.as_view(),
         name="user_trials",
     ),
     path(
-        f"api/{WISDOM_API_VERSION}/users/marketing/",
+        f"api/{WISDOM_API_VERSION}/users/marketing",
         UserMarketingReportView.as_view(),
         name="user_marketing",
     ),

--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -19,18 +19,13 @@ from unittest.mock import ANY, Mock, patch
 
 import boto3
 from django.conf import settings
-from django.contrib.auth.models import Group, Permission
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from rest_framework.test import APITransactionTestCase
 
 import ansible_ai_connect.users.models
 from ansible_ai_connect.main.tests.test_views import create_user_with_provider
-from ansible_ai_connect.test_utils import (
-    WisdomAppsBackendMocking,
-    WisdomServiceAPITestCaseBaseOIDC,
-    create_user,
-)
+from ansible_ai_connect.test_utils import WisdomAppsBackendMocking, create_user
 from ansible_ai_connect.users.constants import (
     USER_SOCIAL_AUTH_PROVIDER_GITHUB,
     USER_SOCIAL_AUTH_PROVIDER_OIDC,
@@ -492,26 +487,3 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         self.assertEqual(r.status_code, 200)  # No redirect
         r = self.client.get(reverse("trial"))
         self.assertEqual(r.status_code, 403)
-
-
-class TestUserViewSet(WisdomServiceAPITestCaseBaseOIDC):
-
-    def setUp(self):
-        super().setUp()
-        self.client = Client()
-        self.client.force_login(self.user)
-        self.group, _ = Group.objects.get_or_create(name="wisdom_view_users")
-        for i in ["view_user", "view_userplan", "view_organization"]:
-            self.group.permissions.add(Permission.objects.get(codename=i))
-
-    def test_get_list_with_no_permission(self):
-        r = self.client.get(reverse("user_list"))
-        self.assertEqual(r.status_code, 403)
-        print(r.content)
-
-    def test_get_list_with_permissions(self):
-        self.user.groups.add(self.group)
-        r = self.client.get(reverse("user_list"))
-        self.assertEqual(r.status_code, 200)
-        result = r.json()
-        self.assertGreater(len(result["results"]), 0)

--- a/ansible_ai_connect/users/tests/test_views_reports.py
+++ b/ansible_ai_connect/users/tests/test_views_reports.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dateutil.relativedelta import relativedelta
+from django.contrib.auth.models import Group, Permission
+from django.test import Client, override_settings
+from django.urls import reverse
+
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+from ansible_ai_connect.users.models import Plan
+
+
+class BaseReportViewTest:
+
+    def initialise(self, test: WisdomServiceAPITestCaseBaseOIDC):
+        self.test = test
+        self.client = Client()
+        self.client.force_login(test.user)
+        self.group, _ = Group.objects.get_or_create(name="wisdom_view_users")
+        for i in ["view_user", "view_userplan", "view_organization"]:
+            self.group.permissions.add(Permission.objects.get(codename=i))
+
+        self.trial_plan, _ = Plan.objects.get_or_create(
+            name="Trial of 10 days", expires_after="10 days"
+        )
+
+    def get_report_header(self) -> str:
+        pass
+
+    def get_report_url_alias(self) -> str:
+        pass
+
+    def add_plan_to_user(self):
+        self.test.user.plans.add(self.trial_plan)
+
+    def test_get_report_with_no_permission(self):
+        r = self.client.get(reverse(self.get_report_url_alias()))
+        self.test.assertEqual(r.status_code, 403)
+        self.test.assertEqual(r.accepted_media_type, "application/json")
+
+    def test_get_report_response(self):
+        self.test.user.groups.add(self.group)
+        r = self.client.get(reverse(self.get_report_url_alias()))
+        self.test.assertEqual(r.status_code, 200)
+        self.test.assertEqual(r.accepted_media_type, "text/csv")
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+
+    def test_get_report_with_no_plans(self):
+        self.test.user.groups.add(self.group)
+        r = self.client.get(reverse(self.get_report_url_alias()))
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertFalse("Trial of 10 days" in str(r.content))
+
+    def test_get_report_with_plans(self):
+        self.test.user.groups.add(self.group)
+        self.add_plan_to_user()
+        r = self.client.get(reverse(self.get_report_url_alias()))
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertTrue("Trial of 10 days" in str(r.content))
+
+    def test_get_report_filter_by_existing_plan_id(self):
+        self.test.user.groups.add(self.group)
+        self.add_plan_to_user()
+        r = self.client.get(
+            reverse(self.get_report_url_alias()) + "?plan_id=" + str(self.trial_plan.id)
+        )
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertTrue("Trial of 10 days" in str(r.content))
+
+    def test_get_report_filter_by_non_existing_plan_id(self):
+        self.test.user.groups.add(self.group)
+        self.add_plan_to_user()
+        r = self.client.get(reverse(self.get_report_url_alias()) + "?plan_id=999")
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertFalse("Trial of 10 days" in str(r.content))
+
+    def test_get_report_filter_by_created_after(self):
+        self.test.user.groups.add(self.group)
+        self.add_plan_to_user()
+        r = self.client.get(
+            reverse(self.get_report_url_alias())
+            + "?created_after="
+            + (self.trial_plan.created_at + relativedelta(days=-1)).strftime("%Y-%m-%d")
+        )
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertTrue("Trial of 10 days" in str(r.content))
+
+    def test_get_report_filter_by_created_before(self):
+        self.test.user.groups.add(self.group)
+        self.add_plan_to_user()
+        r = self.client.get(
+            reverse(self.get_report_url_alias())
+            + "?created_before="
+            + (self.trial_plan.created_at + relativedelta(days=1)).strftime("%Y-%m-%d")
+        )
+        self.test.assertTrue(self.get_report_header() in str(r.content))
+        self.test.assertTrue("Trial of 10 days" in str(r.content))
+
+
+@override_settings(AUTHZ_BACKEND_TYPE="dummy")
+class TestUserTrialsReportView(WisdomServiceAPITestCaseBaseOIDC, BaseReportViewTest):
+
+    def setUp(self):
+        super().setUp()
+        super().initialise(self)
+
+    def get_report_header(self) -> str:
+        return "First name,Last name,Organization name,Plan name,Trial started"
+
+    def get_report_url_alias(self) -> str:
+        return "user_trials"
+
+
+@override_settings(AUTHZ_BACKEND_TYPE="dummy")
+class TestUserMarketingReportView(WisdomServiceAPITestCaseBaseOIDC, BaseReportViewTest):
+
+    def setUp(self):
+        super().setUp()
+        super().initialise(self)
+
+    def get_report_header(self) -> str:
+        return "First name,Last name,Email,Plan name,Trial started"
+
+    def get_report_url_alias(self) -> str:
+        return "user_marketing"
+
+    def add_plan_to_user(self):
+        super().add_plan_to_user()
+        up = self.user.userplan_set.first()
+        up.accept_marketing = True
+        up.save()

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -23,7 +23,6 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
-from rest_framework import viewsets
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -35,9 +34,8 @@ from ansible_ai_connect.ai.api.aws.exceptions import (
 from ansible_ai_connect.ai.api.telemetry import schema1
 from ansible_ai_connect.ai.api.utils.segment import send_schema1_event
 from ansible_ai_connect.main.cache.cache_per_user import cache_per_user
-from ansible_ai_connect.users.models import Plan, User
+from ansible_ai_connect.users.models import Plan
 
-from .permissions import DjangoModelPermissionsWithGET
 from .serializers import MarkdownUserResponseSerializer, UserResponseSerializer
 
 ME_USER_CACHE_TIMEOUT_SEC = settings.ME_USER_CACHE_TIMEOUT_SEC
@@ -122,12 +120,6 @@ class CurrentUserView(RetrieveAPIView):
         )
 
         return Response(user_data)
-
-
-class UserViewSet(viewsets.ModelViewSet):
-    permission_classes = [DjangoModelPermissionsWithGET]
-    queryset = User.objects.all()
-    serializer_class = UserResponseSerializer
 
 
 class MarkdownCurrentUserView(RetrieveAPIView):

--- a/ansible_ai_connect/users/views_reports.py
+++ b/ansible_ai_connect/users/views_reports.py
@@ -113,7 +113,7 @@ class UserTrialsReportView(BaseReportView):
                     },
                 },
             },
-            403: OpenApiResponse(description="Unauthorized"),
+            403: OpenApiResponse(description="Forbidden"),
         },
         summary="Users trials report",
     )
@@ -177,7 +177,7 @@ class UserMarketingReportView(BaseReportView):
                     },
                 },
             },
-            403: OpenApiResponse(description="Unauthorized"),
+            403: OpenApiResponse(description="Forbidden"),
         },
         summary="Users marketing preferences report",
     )

--- a/ansible_ai_connect/users/views_reports.py
+++ b/ansible_ai_connect/users/views_reports.py
@@ -1,0 +1,185 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import csv
+import io
+
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    OpenApiTypes,
+    extend_schema,
+)
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.renderers import BaseRenderer
+from rest_framework.response import Response
+
+from ansible_ai_connect.users.models import User
+
+from .permissions import DjangoModelPermissionsWithGET
+from .serializers import UserResponseSerializer
+
+
+class BaseReportView(RetrieveAPIView):
+    permission_classes = [DjangoModelPermissionsWithGET]
+    pagination_class = None
+
+    def get_queryset(self):
+        queryset = User.objects.all().exclude(organization__isnull=True)
+        plan_id = self.request.query_params.get("plan_id")
+        created_after = self.request.query_params.get("created_after")
+        created_before = self.request.query_params.get("created_before")
+        if plan_id is not None:
+            queryset = queryset.filter(userplan__plan_id=plan_id)
+        if created_after is not None:
+            queryset = queryset.filter(plans__created_at__gte=created_after)
+        if created_before is not None:
+            queryset = queryset.filter(plans__created_at__lte=created_before)
+        return queryset
+
+    def get(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        serializer = UserResponseSerializer(queryset, many=True)
+        users = serializer.data
+        return Response(users)
+
+
+class UserTrialsReportView(BaseReportView):
+    """
+    Returns a CSV report of user trials.
+    """
+
+    class UserTrialsReportRenderer(BaseRenderer):
+        media_type = "text/csv"
+        format = "csv"
+
+        def render(self, data, accepted_media_type=None, renderer_context=None):
+            output = io.StringIO()
+            writer = csv.writer(output)
+            writer.writerow(
+                ["First name", "Last name", "Organization name", "Plan name", "Trial started"]
+            )
+            for user in data:
+                ams = user.get("ams")
+                organization = user.get("organization")
+                for plan in user.get("userplan_set"):
+                    row_data = [
+                        ams.get("first_name"),
+                        ams.get("last_name"),
+                        organization.get("name"),
+                        plan.get("plan").get("name"),
+                        plan.get("created_at"),
+                    ]
+                    writer.writerow(row_data)
+            return output.getvalue()
+
+    renderer_classes = [UserTrialsReportRenderer]
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("plan_id", OpenApiTypes.INT, OpenApiParameter.QUERY),
+            OpenApiParameter("created_after", OpenApiTypes.DATE, OpenApiParameter.QUERY),
+            OpenApiParameter("created_before", OpenApiTypes.DATE, OpenApiParameter.QUERY),
+        ],
+        responses={
+            (200, "text/csv"): {
+                "description": "OK",
+                "properties": {
+                    "First name": {
+                        "type": "string",
+                    },
+                    "Last name": {
+                        "type": "string",
+                    },
+                    "Organization name": {
+                        "type": "string",
+                    },
+                    "Plan name": {
+                        "type": "string",
+                    },
+                    "Trial started": {
+                        "type": "string",
+                    },
+                },
+            },
+            403: OpenApiResponse(description="Unauthorized"),
+        },
+        summary="Users trials report",
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+
+class UserMarketingReportView(BaseReportView):
+    """
+    Returns a CSV report of user marketing preferences.
+    """
+
+    class UserMarketingReportRenderer(BaseRenderer):
+        media_type = "text/csv"
+        format = "csv"
+
+        def render(self, data, accepted_media_type=None, renderer_context=None):
+            output = io.StringIO()
+            writer = csv.writer(output)
+            writer.writerow(["First name", "Last name", "Email", "Plan name", "Trial started"])
+            for user in data:
+                ams = user.get("ams")
+                for plan in user.get("userplan_set"):
+                    if plan.get("accept_marketing"):
+                        row_data = [
+                            ams.get("first_name"),
+                            ams.get("last_name"),
+                            ams.get("email"),
+                            plan.get("plan").get("name"),
+                            plan.get("created_at"),
+                        ]
+                        writer.writerow(row_data)
+            return output.getvalue()
+
+    renderer_classes = [UserMarketingReportRenderer]
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("plan_id", OpenApiTypes.INT, OpenApiParameter.QUERY),
+            OpenApiParameter("created_after", OpenApiTypes.DATE, OpenApiParameter.QUERY),
+            OpenApiParameter("created_before", OpenApiTypes.DATE, OpenApiParameter.QUERY),
+        ],
+        responses={
+            (200, "text/csv"): {
+                "description": "OK",
+                "properties": {
+                    "First name": {
+                        "type": "string",
+                    },
+                    "Last name": {
+                        "type": "string",
+                    },
+                    "Email": {
+                        "type": "string",
+                    },
+                    "Plan name": {
+                        "type": "string",
+                    },
+                    "Trial started": {
+                        "type": "string",
+                    },
+                },
+            },
+            403: OpenApiResponse(description="Unauthorized"),
+        },
+        summary="Users marketing preferences report",
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -325,49 +325,7 @@ paths:
           description: Request was throttled
         '500':
           description: Internal service error
-  /api/v0/users:
-    get:
-      operationId: users_list
-      parameters:
-      - name: page
-        required: false
-        in: query
-        description: A page number within the paginated result set.
-        schema:
-          type: integer
-      tags:
-      - users
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedUserResponseList'
-          description: ''
-  /api/v0/users/{id}:
-    get:
-      operationId: users_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user.
-        required: true
-      tags:
-      - users
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserResponse'
-          description: ''
-  /api/v0/users/marketing/:
+  /api/v0/users/marketing:
     get:
       operationId: users_marketing_retrieve
       description: Returns a CSV report of user marketing preferences.
@@ -410,8 +368,8 @@ paths:
                     type: string
           description: ''
         '403':
-          description: Unauthorized
-  /api/v0/users/trials/:
+          description: Forbidden
+  /api/v0/users/trials:
     get:
       operationId: users_trials_retrieve
       description: Returns a CSV report of user trials.
@@ -454,7 +412,7 @@ paths:
                     type: string
           description: ''
         '403':
-          description: Unauthorized
+          description: Forbidden
   /api/v0/wca/apikey/:
     get:
       operationId: wca_api_key_get
@@ -1007,29 +965,6 @@ components:
       - has_telemetry_opt_out
       - id
       - name
-    PaginatedUserResponseList:
-      type: object
-      required:
-      - count
-      - results
-      properties:
-        count:
-          type: integer
-          example: 123
-        next:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?page=4
-        previous:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?page=2
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/UserResponse'
     Plan:
       type: object
       properties:

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -367,6 +367,94 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserResponse'
           description: ''
+  /api/v0/users/marketing/:
+    get:
+      operationId: users_marketing_retrieve
+      description: Returns a CSV report of user marketing preferences.
+      summary: Users marketing preferences report
+      parameters:
+      - in: query
+        name: created_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: plan_id
+        schema:
+          type: integer
+      tags:
+      - users
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            text/csv:
+              schema:
+                description: OK
+                properties:
+                  First name:
+                    type: string
+                  Last name:
+                    type: string
+                  Email:
+                    type: string
+                  Plan name:
+                    type: string
+                  Trial started:
+                    type: string
+          description: ''
+        '403':
+          description: Unauthorized
+  /api/v0/users/trials/:
+    get:
+      operationId: users_trials_retrieve
+      description: Returns a CSV report of user trials.
+      summary: Users trials report
+      parameters:
+      - in: query
+        name: created_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: plan_id
+        schema:
+          type: integer
+      tags:
+      - users
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            text/csv:
+              schema:
+                description: OK
+                properties:
+                  First name:
+                    type: string
+                  Last name:
+                    type: string
+                  Organization name:
+                    type: string
+                  Plan name:
+                    type: string
+                  Trial started:
+                    type: string
+          description: ''
+        '403':
+          description: Unauthorized
   /api/v0/wca/apikey/:
     get:
       operationId: wca_api_key_get


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-26787

## Description
This PR adds two CSV reports to `ansible-ai-connect-service` relating to "One Click"/"Trial" work.

## Testing

### Steps to test
1. Pull down the PR
2. Ensure `ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL=True` 
3. Start `ansible-ai-connect-service` locally
4. Login with a User that belongs to an Organisation that does not have a WCA setup (e.g your normal RH login) 
5. You should be prompted to start a trial.
6. Setup a Django Group following the instructions [here](https://github.com/ansible/ansible-ai-connect-service/pull/1251).

This can also be achieved by accessing the Django Admin Console.
- Create a Group
- Add the following permissions to the Group:
  - `organizations | organization | Can view organization`
  - `users | user | Can view user`
  - `users | user plan | Can view user plan`
- Assign the Group to your User

7. Access the Swagger UI at http://localhost:8000/api/schema/swagger-ui/
8. Try the "Users marketing preferences report" report at `/api/v0/users/marketing`
9. Try the "Users trials report" report at `/api/v0/users/trials`

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
