### PR TITLE
Upgrade aiohttp version.

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -4,8 +4,11 @@
 #
 #    pip-compile --output-file=requirements-aarch64.txt requirements.in
 #
-aiohttp==3.9.4
+aiohappyeyeballs==2.3.5
+    # via aiohttp
+aiohttp==3.10.2
     # via
+    #   -r requirements.in
     #   langchain
     #   langchain-community
 aiosignal==1.3.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -4,8 +4,11 @@
 #
 #    pip-compile --output-file=requirements-x86_64.txt requirements.in
 #
-aiohttp==3.9.4
+aiohappyeyeballs==2.3.5
+    # via aiohttp
+aiohttp==3.10.2
     # via
+    #   -r requirements.in
     #   langchain
     #   langchain-community
 aiosignal==1.3.1

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,10 @@
 ansible-anonymizer==1.5.0
 ansible-risk-insight==0.2.7
 ansible-lint==24.2.2
+# pin aiohttp on 3.10.2 to address SNYK-PYTHON-AIOHTTP-7675597
+# aiohttp is used by langchain and langchain-community that
+# specify a version ^3.8.3
+aiohttp==3.10.2
 boto3==1.26.84
 # pin black on 24.3.0 to address PYSEC-2024-48.
 black==24.3.0


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

https://github.com/ansible/ansible-ai-connect-service/actions/runs/10388714202/job/28764972767?pr=1255

https://security.snyk.io/vuln/SNYK-PYTHON-AIOHTTP-7675597

> Issues to fix by upgrading dependencies:
>
>  Upgrade aiohttp@3.9.4 to aiohttp@3.10.2 to fix
>  ✗ UNIX Symbolic Link (Symlink) Following (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-AIOHTTP-> 7675597] in aiohttp@3.9.4
>    introduced by aiohttp@3.9.4 and 3 other path(s)