### PR TITLE
Restore the log out button

### DIFF
--- a/ansible_ai_connect/users/templates/users/trial.html
+++ b/ansible_ai_connect/users/templates/users/trial.html
@@ -109,6 +109,12 @@
                     Start trial
                   </button>
                 </p>
+                <br/>
+                <p>
+                  <button class="pf-c-button pf-m-secondary" formaction="{% url 'logout' %}" type="submit">
+                    Log out
+                  </button>
+                </p>
               </form>
               {% endif %}
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-29473>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
[AAP-28829](https://issues.redhat.com/browse/AAP-28829) removed the log out button from the Trial page, but the change caused test failures because our login tests depends on the button. This PR is for restoring the log out button on the Trial page.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
Manually click the log out button to make sure it works.

### Steps to test
1. Pull down the PR
2. Run local service
3. Trigger One Click feature from VS Code extension
4. Click the log out button to ensure it works

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See above.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
