### PR TITLE
Upgrade cyrptography to 42.0.8

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -65,7 +65,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via black
-cryptography==42.0.6
+cryptography==42.0.8
     # via
     #   -r requirements.in
     #   ansible-core

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -65,7 +65,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via black
-cryptography==42.0.6
+cryptography==42.0.8
     # via
     #   -r requirements.in
     #   ansible-core

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ boto3==1.26.84
 black==24.3.0
 certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 # UPDATED MANUALLY: waiting for parent package to be updated
-cryptography==42.0.6
+cryptography==42.0.8
 # pin Django on 4.2.11 to address PYSEC-2024-47.
 Django==4.2.15
 django-deprecate-fields==0.1.1


### PR DESCRIPTION
This PR does not need a corresponding Jira item. -->

## Description
```
Issues to fix by upgrading dependencies:

  Upgrade cryptography@42.0.6 to cryptography@42.0.8 to fix
  ✗ Uncontrolled Resource Consumption [Low Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6913422] in cryptography@42.0.6
    introduced by cryptography@42.0.6 and 10 other path(s)
```