### PR TITLE
AAP-29861: WCA: Handle 'HTTP404: Failed to get remaining capacity' response

### DIFF
--- a/ansible_ai_connect/ai/api/exceptions.py
+++ b/ansible_ai_connect/ai/api/exceptions.py
@@ -140,6 +140,15 @@ class WcaHAPFilterRejectionException(WisdomBadRequest):
     default_detail = "WCA Hate, Abuse, and Profanity filter rejected the request."
 
 
+class WcaInstanceDeletedException(BaseWisdomAPIException):
+    status_code = 418
+    default_code = "error__wca_instance_deleted"
+    default_detail = (
+        "The WCA instance associated with the Model ID has been deleted."
+        "Please contact your administrator."
+    )
+
+
 class WcaUserTrialExpiredException(WisdomAccessDenied):
     default_code = "permission_denied__user_trial_expired"
     default_detail = "User trial expired. Please contact your administrator."

--- a/ansible_ai_connect/ai/api/model_client/exceptions.py
+++ b/ansible_ai_connect/ai/api/model_client/exceptions.py
@@ -109,3 +109,8 @@ class WcaRequestIdCorrelationFailure(WcaException):
     def __init__(self, model_id, x_request_id: uuid.uuid4):
         super().__init__(model_id)
         self.x_request_id: uuid.uuid4 = x_request_id
+
+
+@dataclass
+class WcaInstanceDeleted(WcaException):
+    """WCA Instance associated with the Model ID has been deleted."""

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
@@ -32,6 +32,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaCloudflareRejectionException,
     WcaEmptyResponseException,
     WcaHAPFilterRejectionException,
+    WcaInstanceDeletedException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
@@ -46,6 +47,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaCloudflareRejection,
     WcaEmptyResponse,
     WcaHAPFilterRejection,
+    WcaInstanceDeleted,
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
@@ -178,6 +180,14 @@ class InferenceStage(PipelineElement):
             }
             event_name = "trialExpired"
             raise WcaUserTrialExpiredException(cause=e)
+
+        except WcaInstanceDeleted as e:
+            exception = e
+            logger.exception(
+                "WCA Instance has been deleted when requesting suggestion "
+                f"{payload.suggestionId} for model {e.model_id}"
+            )
+            raise WcaInstanceDeletedException(cause=e)
 
         except Exception as e:
             exception = e

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -41,6 +41,7 @@ from ansible_ai_connect.ai.api.exceptions import (
     WcaCloudflareRejectionException,
     WcaEmptyResponseException,
     WcaHAPFilterRejectionException,
+    WcaInstanceDeletedException,
     WcaInvalidModelIdException,
     WcaKeyNotFoundException,
     WcaModelIdNotFoundException,
@@ -54,6 +55,7 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaCloudflareRejection,
     WcaEmptyResponse,
     WcaHAPFilterRejection,
+    WcaInstanceDeleted,
     WcaInvalidModelId,
     WcaKeyNotFound,
     WcaModelIdNotFound,
@@ -545,6 +547,14 @@ class ContentMatches(GenericAPIView):
             }
             raise WcaUserTrialExpiredException(cause=e)
 
+        except WcaInstanceDeleted as e:
+            exception = e
+            logger.exception(
+                f"WCA Instance has been deleted when requesting suggestion {suggestion_id} "
+                f"for model {e.model_id}"
+            )
+            raise WcaInstanceDeletedException(cause=e)
+
         except Exception as e:
             exception = e
             logger.exception(f"Error requesting content matches for suggestion {suggestion_id}")
@@ -729,6 +739,14 @@ class Explanation(APIView):
                 f"User trial expired, when requesting playbook explanation {explanation_id}"
             )
             raise WcaUserTrialExpiredException(cause=e)
+
+        except WcaInstanceDeleted as e:
+            exception = e
+            logger.exception(
+                "WCA Instance has been deleted when requesting playbook explanation "
+                f"{explanation_id} for model {e.model_id}"
+            )
+            raise WcaInstanceDeletedException(cause=e)
 
         except Exception as exc:
             exception = exc
@@ -917,6 +935,14 @@ class Generation(APIView):
                 f"User trial expired, when requesting playbook generation {generation_id}"
             )
             raise WcaUserTrialExpiredException(cause=e)
+
+        except WcaInstanceDeleted as e:
+            exception = e
+            logger.exception(
+                "WCA Instance has been deleted when requesting playbook generation "
+                f"{generation_id} for model {e.model_id}"
+            )
+            raise WcaInstanceDeletedException(cause=e)
 
         except Exception as exc:
             exception = exc


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-29861

## Description
Handle WCA responses for when the WCA instance on which a model is associated has been deleted.

## Testing
Unit tests. There's nothing we can test interactively without mocking WCA's responses which is what the unit tests do.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
  - [PR for VSCode](https://github.com/ansible/vscode-ansible/pull/1519)