### PR TITLE
container: refresh browserslist

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -62,7 +62,7 @@ COPY ansible_ai_connect_admin_portal/package.json /tmp/ansible_ai_connect_admin_
 COPY ansible_ai_connect_admin_portal/package-lock.json /tmp/ansible_ai_connect_admin_portal/package-lock.json
 COPY ansible_ai_connect_admin_portal/tsconfig.json /tmp/ansible_ai_connect_admin_portal/tsconfig.json
 RUN npm --prefix /tmp/ansible_ai_connect_admin_portal ci
-RUN npm --prefix /tmp/ansible_ai_connect_admin_portal run build
+RUN npx update-browserslist-db@latest && npm --prefix /tmp/ansible_ai_connect_admin_portal run build
 
 # Copy configuration files
 COPY tools/scripts/launch-wisdom.sh /usr/bin/launch-wisdom.sh


### PR DESCRIPTION
Call `npx update-browserslist-db@latest` to avoid a failure later during the `npm run build` if the browser DB is outdated.

```
[1/2] STEP 33/47: RUN npm --prefix /tmp/ansible_ai_connect_admin_portal run build

> admin-portal@0.1.0 build
> node scripts/build.js

Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```
