### PR TITLE
AAP-29990: User Trials Reports: Date argument handling

### DIFF
--- a/ansible_ai_connect/users/management/commands/generate_users_trials_reports.py
+++ b/ansible_ai_connect/users/management/commands/generate_users_trials_reports.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from argparse import ArgumentTypeError
 from datetime import datetime
 from typing import Optional, cast
 
@@ -48,18 +49,26 @@ class Command(BaseCommand):
         generator = UserMarketingReportGenerator()
         return generator.generate(plan_id, created_after, created_before)
 
+    @staticmethod
+    def iso_datetime_type(arg_datetime: str):
+        try:
+            return datetime.fromisoformat(arg_datetime)
+        except ValueError:
+            msg = f"Given datetime '{arg_datetime}' is invalid. Expected ISO-8601 format."
+            raise ArgumentTypeError(msg)
+
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", action="store_true", help="Do nothing", default=False)
         parser.add_argument("--plan-id", help="Trail plan_id", type=int)
         parser.add_argument(
             "--created-after",
-            help="UTC formatted datetime after which trials were accepted.",
-            type=datetime,
+            help="ISO-8601 formatted datetime after which trials were accepted.",
+            type=Command.iso_datetime_type,
         )
         parser.add_argument(
             "--created-before",
-            help="UTC formatted datetime before which trials were accepted.",
-            type=datetime,
+            help="ISO-8601 formatted datetime before which trials were accepted.",
+            type=Command.iso_datetime_type,
         )
         parser.add_argument(
             "--auto-range",


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-29990

## Description
This PR fixes the handling of date arguments.

## Testing
See below.

### Steps to test
1. Pull down the PR
2. Start `ansible-ai-connect-service`
3. Create a Trial Plan for a user (login with an appropriate account and accept trial terms)
4. Start a new Python Run/Debug configuration (in IntelliJ).
5. Set "Script path" to `<path-to->/ansible-ai-connect-service/ansible_ai_connect/manage.py`
6. Set "Parameters" to `generate_users_trials_reports --created-after=2024-08-01`
7. Run it.
8. Try with `--created-before` argument too.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
