### PR TITLE
AAP-29990: User Trials Reports: Date argument handling. Add TimeZone information

### DIFF
--- a/ansible_ai_connect/users/reports/generators.py
+++ b/ansible_ai_connect/users/reports/generators.py
@@ -31,13 +31,15 @@ class BaseGenerator(ABC):
         created_before: Optional[datetime] = None,
     ):
         queryset = User.objects.all().exclude(organization__isnull=True)
+        queryset_args = {}
         if plan_id is not None:
-            queryset = queryset.filter(userplan__plan_id=plan_id)
+            queryset_args["userplan__plan_id"] = plan_id
         if created_after is not None:
-            queryset = queryset.filter(plans__created_at__gte=created_after)
+            queryset_args["userplan__created_at__gte"] = created_after
         if created_before is not None:
-            queryset = queryset.filter(plans__created_at__lte=created_before)
+            queryset_args["userplan__created_at__lte"] = created_before
 
+        queryset = queryset.filter(**queryset_args)
         serializer = UserResponseSerializer(queryset, many=True)
         users = serializer.data
         return users

--- a/ansible_ai_connect/users/reports/tests/test_generators.py
+++ b/ansible_ai_connect/users/reports/tests/test_generators.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from datetime import datetime, timezone
 
 from dateutil.relativedelta import relativedelta
 from django.test import override_settings
@@ -44,6 +45,7 @@ class BaseReportGeneratorTest:
         self.trial_plan, _ = Plan.objects.get_or_create(
             name="Trial of 10 days", expires_after="10 days"
         )
+        self.trial_plan.created_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
     def cleanup(self):
         self.trial_user.delete()
@@ -101,7 +103,7 @@ class BaseReportGeneratorTest:
     def test_get_report_filter_by_created_after_trail_date(self):
         self.add_plan_to_user()
         r = self.get_report_generator().generate(
-            created_after=self.trial_plan.created_at + relativedelta(days=1)
+            created_after=self.trial_user.userplan_set.first().created_at + relativedelta(days=1)
         )
         self.test.assertIn(self.get_report_header(), r)
         self.test.assertNotIn("Robert,Surcouf", r)
@@ -110,7 +112,7 @@ class BaseReportGeneratorTest:
     def test_get_report_filter_by_created_before(self):
         self.add_plan_to_user()
         r = self.get_report_generator().generate(
-            created_before=self.trial_plan.created_at + relativedelta(days=1)
+            created_before=self.trial_user.userplan_set.first().created_at + relativedelta(days=1)
         )
         self.test.assertIn(self.get_report_header(), r)
         self.test.assertIn("Robert,Surcouf", r)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-29990

## Description
Further to #1272 this PR adds timezone support.

## Testing
See below.

### Steps to test
1. Pull down the PR
2. Start `ansible-ai-connect-service`
3. Create a Trial Plan for a user (login with an appropriate account and accept trial terms)
4. Start a new Python Run/Debug configuration (in IntelliJ).
5. Set "Script path" to `<path-to->/ansible-ai-connect-service/ansible_ai_connect/manage.py`
6. Set "Parameters" to `generate_users_trials_reports --created-after=2024-08-01`
7. Run it.
8. Try with `--created-before` argument too.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
