### PR TITLE
AAP-30180: trial report, get email/name from RHSSO

### DIFF
--- a/ansible_ai_connect/users/management/commands/migrate_email_name_from_ams.py
+++ b/ansible_ai_connect/users/management/commands/migrate_email_name_from_ams.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Initialize the email and names field from the AMS"
+
+    def handle(self, *args, **options):
+        cpt = 0
+        for user in User.objects.all():
+            if user.first_name:
+                continue
+            ams_data = user.ams()
+            if not ams_data:
+                continue
+            user.given_name = ams_data.get("first_name")
+            user.family_name = ams_data.get("last_name")
+            user.email = ams_data.get("email")
+            user.save()
+            cpt += 1
+
+        self.stdout.write(f"{cpt} users migrated.")

--- a/ansible_ai_connect/users/management/commands/tests/test_migrate_email_name_from_ams.py
+++ b/ansible_ai_connect/users/management/commands/tests/test_migrate_email_name_from_ams.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import override_settings
+
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+
+User = get_user_model()
+
+
+@override_settings(AUTHZ_BACKEND_TYPE="dummy")
+class TestMigrate(WisdomServiceAPITestCaseBaseOIDC):
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "migrate_email_name_from_ams",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_migrate(self):
+        original = (self.user.email, self.user.given_name, self.user.family_name)
+
+        out = self.call_command()
+        self.assertIn("1 users migrated", out)
+        self.user = User.objects.get(id=self.user.id)
+        self.assertNotEqual(
+            original, (self.user.email, self.user.given_name, self.user.family_name)
+        )
+        self.assertEqual(self.user.given_name, "Robert")

--- a/ansible_ai_connect/users/reports/generators.py
+++ b/ansible_ai_connect/users/reports/generators.py
@@ -73,12 +73,11 @@ class UserTrialsReportGenerator(BaseGenerator):
             ["First name", "Last name", "Organization name", "Plan name", "Trial started"]
         )
         for user in users:
-            ams = user.get("ams")
             organization = user.get("organization")
             for plan in user.get("userplan_set"):
                 row_data = [
-                    ams.get("first_name"),
-                    ams.get("last_name"),
+                    user.get("given_name"),
+                    user.get("family_name"),
                     organization.get("name"),
                     plan.get("plan").get("name"),
                     plan.get("created_at"),
@@ -105,13 +104,12 @@ class UserMarketingReportGenerator(BaseGenerator):
         writer = csv.writer(output)
         writer.writerow(["First name", "Last name", "Email", "Plan name", "Trial started"])
         for user in users:
-            ams = user.get("ams")
             for plan in user.get("userplan_set"):
                 if plan.get("accept_marketing"):
                     row_data = [
-                        ams.get("first_name"),
-                        ams.get("last_name"),
-                        ams.get("email"),
+                        user.get("given_name"),
+                        user.get("family_name"),
+                        user.get("email"),
                         plan.get("plan").get("name"),
                         plan.get("created_at"),
                     ]

--- a/ansible_ai_connect/users/reports/tests/test_generators.py
+++ b/ansible_ai_connect/users/reports/tests/test_generators.py
@@ -37,6 +37,8 @@ class BaseReportGeneratorTest:
         # A User that has a trial plan
         # DummyCheck/AUTHZ_BACKEND_TYPE=dummy sets the User's name to "Robert Surcouf"
         self.trial_user = create_user_with_provider(
+            given_name="Robert",
+            family_name="Surcouf",
             username="trial_user",
             email="trial_user@somewhere.com",
             provider=USER_SOCIAL_AUTH_PROVIDER_OIDC,

--- a/ansible_ai_connect/users/serializers.py
+++ b/ansible_ai_connect/users/serializers.py
@@ -38,15 +38,17 @@ class UserResponseSerializer(serializers.Serializer):
     # Implemented as a vanilla Serializer as ModelSerializer is driven by the Model definition.
     # Field 'org_telemetry_opt_out' is an extension to the CurrentUserView response dependent
     # upon whether the Telemetry Opt In/Out feature has been enabled.
+    email = serializers.CharField(required=False)
+    external_username = serializers.CharField(required=False)
+    family_name = serializers.CharField(required=False)
+    given_name = serializers.CharField(required=False)
+    org_telemetry_opt_out = serializers.BooleanField(required=False)
+    organization = OrganizationSerializer(required=False)
     rh_org_has_subscription = serializers.BooleanField(read_only=True)
     rh_user_has_seat = serializers.BooleanField(read_only=True)
     rh_user_is_org_admin = serializers.BooleanField(required=False)
-    external_username = serializers.CharField(required=False)
     username = serializers.CharField(required=True, max_length=150)
-    ams = serializers.DictField(required=False)
-    org_telemetry_opt_out = serializers.BooleanField(required=False)
     userplan_set = UserPlanSerializer(many=True)
-    organization = OrganizationSerializer(required=False)
 
 
 class MarkdownUserResponseSerializer(serializers.Serializer):

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1026,6 +1026,18 @@ components:
     UserResponse:
       type: object
       properties:
+        email:
+          type: string
+        external_username:
+          type: string
+        family_name:
+          type: string
+        given_name:
+          type: string
+        org_telemetry_opt_out:
+          type: boolean
+        organization:
+          $ref: '#/components/schemas/Organization'
         rh_org_has_subscription:
           type: boolean
           readOnly: true
@@ -1034,22 +1046,13 @@ components:
           readOnly: true
         rh_user_is_org_admin:
           type: boolean
-        external_username:
-          type: string
         username:
           type: string
           maxLength: 150
-        ams:
-          type: object
-          additionalProperties: {}
-        org_telemetry_opt_out:
-          type: boolean
         userplan_set:
           type: array
           items:
             $ref: '#/components/schemas/UserPlan'
-        organization:
-          $ref: '#/components/schemas/Organization'
       required:
       - rh_org_has_subscription
       - rh_user_has_seat


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-30180>

## Description

Initialize the RHSSO users's email/given_name/family_name from AMS.

### Scenarios tested

Run `wisdom-manage migrate_email_name_from_ams`.

## Production deployment

- :warning:  This code change requires the following considerations before going to production:
    We need to manually run `wisdom-manage migrate_email_name_from_ams` in the secondary environment first.