### PR TITLE
Add note to remind us to keep pyproject.toml synchronized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ our dependencies involved. Due to differences in architecture and
 version of Python between developers' machines, we do not recommend
 running the pip-compile commands directly.
 
+### Use of `pyproject.toml`
+
+`pyproject.toml` contains the dependencies used by downstream builds. Changes to any of the top level dependencies in `requirements.in` must there also be reflected in `pyproject.toml` too. See [PEP-518](https://peps.python.org/pep-0518/) for details.
 
 # Using the VS Code extension
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,14 @@
+# ======================================================================
+# If any top level dependency is added, updated or deleted be
+# sure to check pyproject.toml too. pyproject.toml is the *only*
+# dependencies file used by downstream and hence *must* be synchronized.
+# It is also recommended that dependencies in pyproject.toml use the '~=' version qualifier.
+#
+# See the following for details:
+# - https://peps.python.org/pep-0518
+# - https://peps.python.org/pep-0631
+# - https://peps.python.org/pep-0508
+# ======================================================================
 ansible-anonymizer==1.5.0
 ansible-risk-insight==0.2.7
 ansible-lint==24.2.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Add a note reminding us to keep `pyproject.toml` synchronised with `requirements.in`

## Testing
n/a

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
