### PR TITLE
requirements: upgrade to Django==4.2.16

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -85,7 +85,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.15
+django==4.2.16
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -85,7 +85,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.15
+django==4.2.16
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -20,10 +20,8 @@ boto3==1.26.84
 # pin black on 24.3.0 to address PYSEC-2024-48.
 black==24.3.0
 certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
-# UPDATED MANUALLY: waiting for parent package to be updated
 cryptography==43.0.1
-# pin Django on 4.2.11 to address PYSEC-2024-47.
-Django==4.2.15
+Django==4.2.16
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
This to address the following CVE:

- CVE-2024-45230
- CVE-2024-45231

See: https://docs.djangoproject.com/en/5.1/releases/4.2.16/
