### PR TITLE
pip-compile: do a sequential run

### DIFF
--- a/tools/docker-compose/pip-compile.yaml
+++ b/tools/docker-compose/pip-compile.yaml
@@ -17,3 +17,5 @@ services:
       - $PWD:/var/www/wisdom:Z
     command:
       - /var/www/wisdom/tools/scripts/pip-compile.sh
+    depends_on:
+      - pip-compile-x86_64


### PR DESCRIPTION
Avoid triggering the two builds at the same time. This leads to a race condition
during the build on my local set-up.
