### PR TITLE
Containerfile: call npx update-browserslist-db during the build

### DIFF
--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -61,6 +61,7 @@ COPY ansible_ai_connect_admin_portal/src /tmp/ansible_ai_connect_admin_portal/sr
 COPY ansible_ai_connect_admin_portal/package.json /tmp/ansible_ai_connect_admin_portal/package.json
 COPY ansible_ai_connect_admin_portal/package-lock.json /tmp/ansible_ai_connect_admin_portal/package-lock.json
 COPY ansible_ai_connect_admin_portal/tsconfig.json /tmp/ansible_ai_connect_admin_portal/tsconfig.json
+RUN cd /tmp/ansible_ai_connect_admin_portal && npx update-browserslist-db@latest
 RUN npm --prefix /tmp/ansible_ai_connect_admin_portal ci
 RUN npm --prefix /tmp/ansible_ai_connect_admin_portal run build
 


### PR DESCRIPTION
Call `npx update-browserslist-db@latest` during the container build. This
to address the following error:

```
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```
