### PR TITLE
AAP-27466: CVE-2024-37891 ansible-lightspeed-container: urllib3: proxy-authorization request header is not stripped during cross-origin redirects [ansible_automation_platform-2.4]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   'slack-sdk~=3.31.0',
   'social-auth-app-django~=5.4.1',
   'social-auth-core[openidconnect]>=4.4.2',
-  'urllib3~=1.26.18',
+  'urllib3~=1.26.19',
   'uwsgi~=2.0.22',
   'uwsgi-readiness-check~=0.2.0',
   'django-allow-cidr',


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-27466

## Description
Update `urllib3` to (minimum of) `1.26.19`

`pyproject.toml` is used to build downstream AAP.

## Testing
N/A. Minor revision bump.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
