### PR TITLE
AAP-25344: AAP 2.5 Gateway SSO for Lightspeed

### DIFF
--- a/ansible_ai_connect/users/auth.py
+++ b/ansible_ai_connect/users/auth.py
@@ -52,7 +52,7 @@ class AAPOAuth2(BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
-        url = f"{settings.AAP_API_URL}/v2/me/"
+        url = self.get_me_endpoint(settings.AAP_API_URL)
         resp_data = self.get_json(url, headers={"Authorization": f"bearer {access_token}"})
         return resp_data.get("results")[0]
 
@@ -67,9 +67,23 @@ class AAPOAuth2(BaseOAuth2):
         return data
 
     def user_has_valid_license(self, access_token):
-        url = f"{settings.AAP_API_URL}/v2/config/"
+        url = self.get_config_endpoint(settings.AAP_API_URL)
         data = self.get_json(url, headers={"Authorization": f"bearer {access_token}"})
         return not data["license_info"]["date_expired"] if "license_info" in data else False
+
+    def get_me_endpoint(self, api_url):
+        """Creates me link to the AAP API depending on the Auth platform"""
+
+        # AAP Controller has /api at the end for API link, AAP Gateway doesn't
+        url = api_url.rstrip("/")
+        return f"{url}/v2/me/" if url.endswith("/api") else f"{url}/api/gateway/v1/me/"
+
+    def get_config_endpoint(self, api_url):
+        """Creates config link to the AAP API depending on the Auth platform"""
+
+        # AAP Controller has /api at the end for API link, AAP Gateway doesn't
+        url = api_url.rstrip("/")
+        return f"{url}/v2/config/" if url.endswith("/api") else f"{url}/api/controller/v2/config/"
 
 
 class RHSSOAuthentication(authentication.BaseAuthentication):

--- a/ansible_ai_connect/users/tests/test_auth.py
+++ b/ansible_ai_connect/users/tests/test_auth.py
@@ -68,7 +68,8 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
             }
         ),
     )
-    def test_date_expired_checked_and_is_true_during_auth(self):
+    @patch("django.conf.settings.AAP_API_URL")
+    def test_date_expired_checked_and_is_true_during_auth(self, AAP_API_URL):
         self.authentication = AAPOAuth2()
         user = MagicMock()
         response = {"is_system_auditor": True, "is_superuser": True}
@@ -87,7 +88,8 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
             }
         ),
     )
-    def test_date_expired_checked_and_is_false_during_auth(self):
+    @patch("django.conf.settings.AAP_API_URL")
+    def test_date_expired_checked_and_is_false_during_auth(self, AAP_API_URL):
         self.authentication = AAPOAuth2()
         user = MagicMock()
         response = {"is_system_auditor": False, "is_superuser": False}
@@ -102,7 +104,8 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
         extra_data=MagicMock(return_value={"test": "data"}),
         get_json=MagicMock(return_value={}),
     )
-    def test_missing_values(self):
+    @patch("django.conf.settings.AAP_API_URL")
+    def test_missing_values(self, AAP_API_URL):
         self.authentication = AAPOAuth2()
         user = MagicMock()
         response = {}
@@ -111,6 +114,50 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
         self.assertFalse(data["aap_licensed"])
         self.assertFalse(data["aap_system_auditor"])
         self.assertFalse(data["aap_superuser"])
+
+    def test_get_me_endpoint_controller(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test/api"
+        self.assertEqual(
+            "http://controller.test/api/v2/me/", authentication.get_me_endpoint(api_url)
+        )
+
+    def test_get_me_endpoint_controller_ended(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test/api/"
+        self.assertEqual(
+            "http://controller.test/api/v2/me/", authentication.get_me_endpoint(api_url)
+        )
+
+    def test_get_me_endpoint_gateway(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test"
+        self.assertEqual(
+            "http://controller.test/api/gateway/v1/me/", authentication.get_me_endpoint(api_url)
+        )
+
+    def test_get_config_endpoint_controller(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test/api"
+        self.assertEqual(
+            "http://controller.test/api/v2/config/", authentication.get_config_endpoint(api_url)
+        )
+
+    def test_get_config_endpoint_gateway(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test"
+        self.assertEqual(
+            "http://controller.test/api/controller/v2/config/",
+            authentication.get_config_endpoint(api_url),
+        )
+
+    def test_get_config_endpoint_gateway_ended(self):
+        authentication = AAPOAuth2()
+        api_url = "http://controller.test/"
+        self.assertEqual(
+            "http://controller.test/api/controller/v2/config/",
+            authentication.get_config_endpoint(api_url),
+        )
 
 
 class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-25344>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Fixed links for AAP 2.5 Gateway API. Now it supports both AAP Controller and AAP Gateway.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Ran in on-prem mode
3. Configure AAP 2.5 Gateway
4. Log in into Lightspeed using AAP Gateway
5. Configure AAP 2.4/2.5 Controller
6. Log in into Lightspeed using AAP Controller

### Scenarios tested
Described above (used AAP 2.5 Gateway and Controller)

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own