### PR TITLE
using quay.io/jameswong/git instead of alpine/git

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -279,7 +279,7 @@ spec:
         - name: source
         steps:
         - name: get-commit-timestamp
-          image: alpine/git
+          image: quay.io/ansible/git
           script: |
             #!/bin/sh
             set -euo pipefail


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-29987

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

`alpine/git` is being used in our Konflux pipeline but docker rate limit once a while will block access and fail our pipeline. Now switching to a clone in quay.io

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
