### PR TITLE
postman/slack: print the actual error message

### DIFF
--- a/ansible_ai_connect/users/reports/postman.py
+++ b/ansible_ai_connect/users/reports/postman.py
@@ -128,7 +128,7 @@ class SlackWebhookPostman(BasePostman):
             webhook = WebhookClient(self.webhook_url)
             response = webhook.send(text="fallback", blocks=BasePostman.make_message_body(reports))
             if response.status_code != 200:
-                logger.error(f"Failed to post reports. See response for details {response}.")
+                logger.error(f"Failed to post reports. See response for details: {response.body}")
                 raise ReportGenerationException("Failed to post reports.")
 
         except SlackApiError as e:


### PR DESCRIPTION
The message itself is actually in the `body` attribute.

See: https://slack.dev/python-slack-sdk/api-docs/slack_sdk/webhook/webhook_response.html#slack_sdk.webhook.webhook_response.WebhookResponse
