### PR TITLE
Omaciel/remove model selection from chatbot

### DIFF
--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -117,19 +117,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
             </Bullseye>
           </ChatbotHeaderTitle>
           <ChatbotHeaderActions>
-            <ChatbotHeaderSelectorDropdown
-              value={selectedModel}
-              onSelect={onSelectModel}
-            >
-              <DropdownList>
-                <DropdownItem value="Granite 8B" key="granite">
-                  Granite 8B
-                </DropdownItem>
-                <DropdownItem value="Llama 3.1" key="llama">
-                  Llama 3.1
-                </DropdownItem>
-              </DropdownList>
-            </ChatbotHeaderSelectorDropdown>
             <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
               <DropdownGroup label="Display mode">
                 <DropdownList>


### PR DESCRIPTION
This PR does not need a corresponding Jira item. 

## Description
Removed Model selection from Virtual Assistant's header section

## Testing
1. Pull down the PR
2. cd into `ansible_ai_connect_chatbot` directory
3. run `rpm install && npm start`
4. Open browser to http://localhost:3000/ and open the Virtual Assistant

<img width="499" alt="Screenshot 2024-09-20 at 09 14 36" src="https://github.com/user-attachments/assets/ffdc2661-0a85-4764-bb35-80f8bbd4659e">


### Scenarios tested
None

## Production deployment
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
- [x] This code is for internal usage only