### PR TITLE
AAP-30426: Lightspeed API playbook generation and explanation to accept a new custom_prompt field

### DIFF
--- a/ansible_ai_connect/ai/api/model_client/base.py
+++ b/ansible_ai_connect/ai/api/model_client/base.py
@@ -63,13 +63,16 @@ class ModelMeshClient:
         self,
         request,
         text: str = "",
+        custom_prompt: str = "",
         create_outline: bool = False,
         outline: str = "",
         generation_id: str = "",
     ) -> tuple[str, str]:
         raise NotImplementedError
 
-    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
+    def explain_playbook(
+        self, request, content: str, custom_prompt: str = "", explanation_id: str = ""
+    ) -> str:
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_client/dummy_client.py
+++ b/ansible_ai_connect/ai/api/model_client/dummy_client.py
@@ -90,6 +90,7 @@ class DummyClient(ModelMeshClient):
         self,
         request,
         text: str = "",
+        custom_prompt: str = "",
         create_outline: bool = False,
         outline: str = "",
         generation_id: str = "",
@@ -98,5 +99,7 @@ class DummyClient(ModelMeshClient):
             return PLAYBOOK, OUTLINE
         return PLAYBOOK, ""
 
-    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
+    def explain_playbook(
+        self, request, content: str, custom_prompt: str = "", explanation_id: str = ""
+    ) -> str:
         return EXPLANATION

--- a/ansible_ai_connect/ai/api/model_client/langchain.py
+++ b/ansible_ai_connect/ai/api/model_client/langchain.py
@@ -14,6 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 import re
 from textwrap import dedent
 from typing import Any, Dict
@@ -35,6 +36,8 @@ SYSTEM_MESSAGE_TEMPLATE = (
     "Do not explain your response. Do not include the prompt in your response."
 )
 HUMAN_MESSAGE_TEMPLATE = "{prompt}"
+
+logger = logging.getLogger(__name__)
 
 
 def unwrap_playbook_answer(message: str | BaseMessage) -> tuple[str, str]:
@@ -124,6 +127,7 @@ class LangChainClient(ModelMeshClient):
         self,
         request,
         text: str = "",
+        custom_prompt: str = "",
         create_outline: bool = False,
         outline: str = "",
         generation_id: str = "",
@@ -150,6 +154,9 @@ class LangChainClient(ModelMeshClient):
         This is what the playbook should do: {text}
         This is a break down of the expected Playbook: {outline}
         """
+
+        if custom_prompt:
+            logger.info("custom_prompt is not supported for generate_playbook and will be ignored.")
 
         system_template = (
             SYSTEM_MESSAGE_TEMPLATE_WITH_OUTLINE if create_outline else SYSTEM_MESSAGE_TEMPLATE
@@ -183,7 +190,9 @@ class LangChainClient(ModelMeshClient):
 
         return playbook, outline
 
-    def explain_playbook(self, request, content, explanation_id: str = "") -> str:
+    def explain_playbook(
+        self, request, content: str, custom_prompt: str = "", explanation_id: str = ""
+    ) -> str:
         SYSTEM_MESSAGE_TEMPLATE = """
         You're an Ansible expert.
         You format your output with Markdown.
@@ -199,6 +208,9 @@ class LangChainClient(ModelMeshClient):
 
         {playbook}"
         """
+
+        if custom_prompt:
+            logger.info("custom_prompt is not supported for explain_playbook and will be ignored.")
 
         model_id = self.get_model_id(request.user, None, "")
         llm = self.get_chat_model(model_id)

--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -574,6 +574,7 @@ class WCAClient(BaseWCAClient):
         self,
         request,
         text: str = "",
+        custom_prompt: str = "",
         create_outline: bool = False,
         outline: str = "",
         generation_id: str = "",
@@ -590,6 +591,8 @@ class WCAClient(BaseWCAClient):
         }
         if outline:
             data["outline"] = outline
+        if custom_prompt:
+            data["custom_prompt"] = custom_prompt
 
         @backoff.on_exception(
             backoff.expo,
@@ -632,7 +635,9 @@ class WCAClient(BaseWCAClient):
 
         return playbook, outline
 
-    def explain_playbook(self, request, content: str, explanation_id: str = "") -> str:
+    def explain_playbook(
+        self, request, content: str, custom_prompt: str = "", explanation_id: str = ""
+    ) -> str:
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
         model_id = self.get_model_id(request.user, organization_id)
@@ -642,6 +647,8 @@ class WCAClient(BaseWCAClient):
             "model_id": model_id,
             "playbook": content,
         }
+        if custom_prompt:
+            data["custom_prompt"] = custom_prompt
 
         @backoff.on_exception(
             backoff.expo,
@@ -752,11 +759,14 @@ class WCAOnPremClient(BaseWCAClient):
         self,
         request,
         text: str = "",
+        custom_prompt: str = "",
         create_outline: bool = False,
         outline: str = "",
         generation_id: str = "",
     ) -> tuple[str, str]:
         raise FeatureNotAvailable
 
-    def explain_playbook(self, request, content: str, explanation_id: str = "") -> str:
+    def explain_playbook(
+        self, request, content: str, custom_prompt: str = "", explanation_id: str = ""
+    ) -> str:
         raise FeatureNotAvailable

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/pre_process.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/pre_process.py
@@ -136,12 +136,7 @@ def completion_validate_multitask_yaml(context: CompletionContext):
             task_errors.append(task_error)
 
     if len(task_errors) > 0:
-        raise PreprocessInvalidYamlException(
-            detail={
-                "code": PreprocessInvalidYamlException.default_code,
-                "message": task_errors,
-            }
-        )
+        raise PreprocessInvalidYamlException(detail=task_errors)
 
 
 class PreProcessStage(PipelineElement):

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/tests/test_pre_process.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/tests/test_pre_process.py
@@ -549,11 +549,7 @@ class CompletionPreProcessTest(TestCase):
             PreProcessStage().process(context)
 
         exception: PreprocessInvalidYamlException = e.exception
-        detail: dict = exception.detail
-        code = detail["code"]
-        messages = detail["message"]
-        self.assertEqual(PreprocessInvalidYamlException.default_code, code)
-        return messages
+        return exception.detail
 
     def call_completion_pre_process(self, payload, is_commercial_user, expected_context):
         context = CompletionPreProcessTest.mock_context(payload, is_commercial_user)

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -359,6 +359,13 @@ class ExplanationRequestSerializer(Metadata):
         label="Playbook content",
         help_text=("The playbook that needs to be explained."),
     )
+    customPrompt = serializers.CharField(
+        trim_whitespace=False,
+        required=False,
+        allow_blank=True,
+        label="Custom prompt",
+        help_text="Custom prompt passed to the LLM when explaining a playbook.",
+    )
     explanationId = serializers.UUIDField(
         format="hex_verbose",
         required=False,
@@ -368,6 +375,17 @@ class ExplanationRequestSerializer(Metadata):
         ),
     )
     metadata = Metadata(required=False)
+
+    def validate(self, data):
+        data = super().validate(data)
+
+        custom_prompt = data.get("customPrompt")
+        if custom_prompt and "{playbook}" not in custom_prompt:
+            raise serializers.ValidationError(
+                {"customPrompt": "'{playbook}' placeholder expected."}
+            )
+
+        return data
 
 
 class ExplanationResponseSerializer(serializers.Serializer):
@@ -390,6 +408,7 @@ class GenerationRequestSerializer(serializers.Serializer):
             "generationId",
             "wizardId",
             "createOutline",
+            "customPrompt",
             "ansibleExtensionVersion",
             "outline",
         ]
@@ -398,6 +417,13 @@ class GenerationRequestSerializer(serializers.Serializer):
         required=True,
         label="Description content",
         help_text=("The description that needs to be converted to a playbook."),
+    )
+    customPrompt = serializers.CharField(
+        trim_whitespace=False,
+        required=False,
+        allow_blank=True,
+        label="Custom prompt",
+        help_text="Custom prompt passed to the LLM when generating the text of a playbook.",
     )
     generationId = serializers.UUIDField(
         format="hex_verbose",
@@ -427,6 +453,23 @@ class GenerationRequestSerializer(serializers.Serializer):
     )
 
     metadata = Metadata(required=False)
+
+    def validate(self, data):
+        data = super().validate(data)
+
+        outline = data.get("outline")
+        custom_prompt = data.get("customPrompt")
+        if custom_prompt:
+            if "{goal}" not in custom_prompt:
+                raise serializers.ValidationError(
+                    {"customPrompt": "'{goal}' placeholder expected."}
+                )
+            if outline and "{outline}" not in custom_prompt:
+                raise serializers.ValidationError(
+                    {"customPrompt": "'{outline}' placeholder expected when 'outline' provided."}
+                )
+
+        return data
 
 
 class GenerationResponseSerializer(serializers.Serializer):

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -362,7 +362,6 @@ class ExplanationRequestSerializer(Metadata):
     customPrompt = serializers.CharField(
         trim_whitespace=False,
         required=False,
-        allow_blank=True,
         label="Custom prompt",
         help_text="Custom prompt passed to the LLM when explaining a playbook.",
     )
@@ -421,7 +420,6 @@ class GenerationRequestSerializer(serializers.Serializer):
     customPrompt = serializers.CharField(
         trim_whitespace=False,
         required=False,
-        allow_blank=True,
         label="Custom prompt",
         help_text="Custom prompt passed to the LLM when generating the text of a playbook.",
     )

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -651,10 +651,11 @@ class Explanation(APIView):
             request_serializer.is_valid(raise_exception=True)
             explanation_id = str(request_serializer.validated_data.get("explanationId", ""))
             playbook = request_serializer.validated_data.get("content")
+            custom_prompt = str(request_serializer.validated_data.get("customPrompt", ""))
 
             llm = apps.get_app_config("ai").model_mesh_client
             start_time = time.time()
-            explanation = llm.explain_playbook(request, playbook, explanation_id)
+            explanation = llm.explain_playbook(request, playbook, custom_prompt, explanation_id)
             duration = round((time.time() - start_time) * 1000, 2)
 
             # Anonymize response
@@ -840,12 +841,13 @@ class Generation(APIView):
             create_outline = request_serializer.validated_data["createOutline"]
             outline = str(request_serializer.validated_data.get("outline", ""))
             text = request_serializer.validated_data["text"]
+            custom_prompt = str(request_serializer.validated_data.get("customPrompt", ""))
             wizard_id = str(request_serializer.validated_data.get("wizardId", ""))
 
             llm = apps.get_app_config("ai").model_mesh_client
             start_time = time.time()
             playbook, outline = llm.generate_playbook(
-                request, text, create_outline, outline, generation_id
+                request, text, custom_prompt, create_outline, outline, generation_id
             )
             duration = round((time.time() - start_time) * 1000, 2)
 

--- a/ansible_ai_connect/main/exception_handler.py
+++ b/ansible_ai_connect/main/exception_handler.py
@@ -48,6 +48,13 @@ def exception_handler_with_error_type(exc, context):
 
         # Build complete response
         _data = response.data if response.data else {}
-        response.data = {**_full_details, **_model_id, **_data}
+        response.data = {
+            "code": _full_details["code"] if "code" in _full_details else exc.default_code,
+            "message": (
+                _full_details["message"] if "message" in _full_details else exc.default_detail
+            ),
+            "detail": _data,
+            **_model_id,
+        }
 
     return response

--- a/ansible_ai_connect/test_utils.py
+++ b/ansible_ai_connect/test_utils.py
@@ -108,7 +108,7 @@ class WisdomTestCase(TestCase):
             self.assertEqual(r["Content-Length"], "0")
             return
 
-        r_code = r.data.get("message").code
+        r_code = r.data.get("code")
         self.assertEqual(r_code, code)
         if message:
             r_message = r.data.get("message")

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -701,6 +701,10 @@ components:
           type: string
           title: Playbook content
           description: The playbook that needs to be explained.
+        customPrompt:
+          type: string
+          title: Custom prompt
+          description: Custom prompt passed to the LLM when explaining a playbook.
         explanationId:
           type: string
           format: uuid
@@ -760,6 +764,11 @@ components:
           type: string
           title: Description content
           description: The description that needs to be converted to a playbook.
+        customPrompt:
+          type: string
+          title: Custom prompt
+          description: Custom prompt passed to the LLM when generating the text of
+            a playbook.
         generationId:
           type: string
           format: uuid


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-30426

## Description
Support `customPrompt` JSON field for both Playbook Generation and Explanation.

**_Playbook Generation_**
- The backend expects `{goal}` or both `{goal}` and `{outline}` keywords to be present in the `custom_prompt`
- Depending on if Goal or both Goal and Outline are provided

**_Playbook Explanation_**
- The backend expects `{playbook}` keyword to be present in the `custom_prompt`

## Testing

### Steps to test
1. Pull down the PR
2. `make start-backends`
3. `make create-application`
4. Run server
5. Create User API token:
- Login into Lightspeed as somebody
- Login to `http://localhost:8000/admin` as Django admin
- Create an Access Token for the User you logged into Lightspeed as
6. Run **generation** tests:
- Valid "custom prompt"
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/generations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"text": "Install apache",
"customPrompt": "You are an Ansible Expert. Generate a playbook to do {goal}"
}'
``` 
Response should be OK.
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/generations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"text": "Install apache",
"outline": "1. Install apache",
"customPrompt": "You are an Ansible Expert. Generate a playbook to do {goal} along the lines of {outline}"
}'
``` 
Response should be OK.
- Invalid "custom prompt"
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/generations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"text": "Install apache",
"customPrompt": "You are an Ansible Expert. Generate a playbook to do something"
}'
``` 
Response should represent:
```
{"customPrompt":["'{goal}' placeholder expected."]}
```
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/generations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"text": "Install apache",
"outline": "1. Install apache",
"customPrompt": "You are an Ansible Expert. Generate a playbook to do {goal} along the lines of something"
}'
``` 
Response should represent:
```
{"customPrompt":["'{outline}' placeholder expected when 'outline' provided."]}
```
7. Run **explanation** tests:
- Valid "custom prompt"
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/explanations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"content": "---\n- name: Install apache\n  hosts: all\n  tasks:\n    - name: Install apache\n      ansible.builtin.package:\n        name: httpd\n        state: present\n    - name: Start apache\n      ansible.builtin.service:\n        name: httpd\n        state: started\n",
"customPrompt": "You are an Ansible Expert. Explain playbook {playbook}"
}'
``` 
Response should be OK.
- Invalid "custom prompt"
```
curl -X 'POST' \
'http://localhost:8000/api/v0/ai/explanations/' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer <access_token_created_above>' \
-d '{
"content": "---\n- name: Install apache\n  hosts: all\n  tasks:\n    - name: Install apache\n      ansible.builtin.package:\n        name: httpd\n        state: present\n    - name: Start apache\n      ansible.builtin.service:\n        name: httpd\n        state: started\n",
"customPrompt": "You are an Ansible Expert. Explain playbook something"
}'
```
Response should represent:
```
{"customPrompt":["'{playbook}' placeholder expected."]}
```

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

See https://github.com/ansible/vscode-ansible/pull/1545