### PR TITLE
AAP-31447: build the filename from the day before created_before

### DIFF
--- a/ansible_ai_connect/users/reports/postman.py
+++ b/ansible_ai_connect/users/reports/postman.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import List, Optional
 from urllib import parse
 
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.utils import timezone
 from oauth2client.service_account import ServiceAccountCredentials
@@ -223,7 +224,9 @@ class GoogleDrivePostman(BasePostman):
     def send_reports(self, reports: Reports):
         drive = self.get_drive()
         folder_id = self.get_folder_id(drive)
-        report_date = reports.created_before or timezone.now()
+        # We want the name of our daily report to match the date of the last day of the period.
+        # NOT the day when the report was created.
+        report_date = (reports.created_before or timezone.now()) - relativedelta(days=1)
 
         for report in reports.data:
             file_name = self.create_filename(report.title, report_date)

--- a/ansible_ai_connect/users/reports/tests/test_postman.py
+++ b/ansible_ai_connect/users/reports/tests/test_postman.py
@@ -17,6 +17,7 @@ from abc import abstractmethod
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+from dateutil.relativedelta import relativedelta
 from django.test import override_settings
 from django.utils import timezone
 from oauth2client.service_account import ServiceAccountCredentials
@@ -222,7 +223,7 @@ class GoogleDrivePostmanTest(WisdomServiceAPITestCaseBaseOIDC):
         self.assertEqual(g_auth.return_value.credentials, sa_credentials.return_value)
         g_drive.assert_called_once_with(g_auth.return_value)
 
-        file_name_prefix = created_before.strftime("%Y%m%d")
+        file_name_prefix = (created_before - relativedelta(days=1)).strftime("%Y%m%d")
         create_file = g_drive.return_value.CreateFile
         create_file.assert_called_once_with(
             {"parents": [{"id": "test-folder-id"}], "title": f"{file_name_prefix}_title.csv"}


### PR DESCRIPTION
Use the data BEFORE the `created_after` parameter to build the report file name.
