### PR TITLE
AAP-31593: One click Trial - schema2 telemetry enablement.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
     name: isort (python)
 - repo: https://github.com/ambv/black
-  rev: 24.3.0
+  rev: 24.8.0
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]
     language_version: python3
     require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
     language_version: python3
@@ -23,13 +23,13 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     args: [--config=.flake8]
     language_version: python3
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
+  rev: v3.17.0
   hooks:
   - id: pyupgrade
     language_version: python3

--- a/ansible_ai_connect/ai/api/telemetry/schema2.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema2.py
@@ -24,6 +24,7 @@ class AnalyticsTelemetryEvents(Enum):
     RECOMMENDATION_ACTION = "Recommendation Action"
     PRODUCT_FEEDBACK = "Product Feedback"
     PLAYBOOK_GENERATION_ACTION = "Playbook Generation Action"
+    ONECLICK_TRIAL_STARTED = "OneClickTrial Started"
 
 
 @frozen
@@ -79,6 +80,24 @@ class AnalyticsProductFeedback:
     )
     rh_user_org_id: int = field(validator=validators.instance_of(int), converter=int, default=0)
     model_name: str = field(default="")
+    timestamp: str = field(
+        default=Factory(lambda self: timezone.now().isoformat(), takes_self=True)
+    )
+
+
+@frozen
+class OneClickTrialPlan:
+    created_at: str = field(validator=validators.instance_of(str), converter=str)
+    expired_at: str = field(validator=validators.instance_of(str), converter=str)
+    is_active: bool
+    name: str = field(validator=validators.instance_of(str), converter=str)
+    id: int = field(validator=validators.instance_of(int))
+
+
+@frozen
+class OneClickTrialStarted:
+    plans: list[OneClickTrialPlan]
+    rh_user_org_id: int = field(validator=validators.instance_of(int), converter=int)
     timestamp: str = field(
         default=Factory(lambda self: timezone.now().isoformat(), takes_self=True)
     )

--- a/ansible_ai_connect/ai/api/telemetry/schema2_utils.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema2_utils.py
@@ -1,0 +1,53 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from ansible_ai_connect.ai.api.telemetry.schema2 import (
+    AnalyticsTelemetryEvents,
+    OneClickTrialPlan,
+    OneClickTrialStarted,
+)
+from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
+    send_segment_analytics_event,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def oneclick_trial_event_send(user):
+    send_segment_analytics_event(
+        AnalyticsTelemetryEvents.ONECLICK_TRIAL_STARTED,
+        lambda: _oneclick_trial_event_build(user),
+        user,
+    )
+
+
+def _oneclick_trial_event_build(user):
+    if not user.organization:
+        logger.error("Only users within an org are allowed to send trial events.")
+        raise ValueError("No user organization specified. Cannot send OneClickTrialStarted.")
+    return OneClickTrialStarted(
+        plans=[
+            OneClickTrialPlan(
+                created_at=plan.created_at,
+                expired_at=plan.expired_at,
+                is_active=plan.is_active,
+                name=plan.plan.name,
+                id=plan.plan.id,
+            )
+            for plan in user.userplan_set.all()
+        ],
+        rh_user_org_id=user.organization.id,
+    )

--- a/ansible_ai_connect/ai/api/telemetry/tests/test_schema2.py
+++ b/ansible_ai_connect/ai/api/telemetry/tests/test_schema2.py
@@ -1,0 +1,84 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timedelta
+from unittest import TestCase, mock
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.telemetry.schema2 import AnalyticsTelemetryEvents
+from ansible_ai_connect.ai.api.telemetry.schema2_utils import (
+    _oneclick_trial_event_build,
+    oneclick_trial_event_send,
+)
+from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
+
+
+class TestSchema2OneClickTrial(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        TestSchema2OneClickTrial._set_defaults()
+
+    @staticmethod
+    def _set_defaults():
+        segment_analytics_telemetry.write_key = "testWriteKey"
+        segment_analytics_telemetry.send = False
+
+    def test_oneclick_trial_event_build(self):
+        m_user = TestSchema2OneClickTrial.create_trial_user_plan()
+        event = _oneclick_trial_event_build(m_user)
+        self.assertTrue(isinstance(event.plans, list))
+        self.assertEqual(len(event.plans), 1)
+        self.assertEqual(event.plans[0].name, "Some plan")
+        self.assertTrue(event.plans[0].created_at.startswith("20"))
+        self.assertEqual(event.plans[0].id, 12)
+        self.assertEqual(event.rh_user_org_id, 123)
+
+    def test_oneclick_trial_event_build_error_no_org(self):
+        m_user = TestSchema2OneClickTrial.create_trial_user_plan()
+        m_user.organization = None
+        with self.assertRaises(ValueError) as context:
+            _oneclick_trial_event_build(m_user)
+            self.assertTrue("This is broken" in str(context.exception))
+
+    @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
+    @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
+    def test_oneclick_trial_event_send(self, mock_send):
+        m_user = TestSchema2OneClickTrial.create_trial_user_plan()
+        oneclick_trial_event_send(m_user)
+        mock_send.assert_called_once()
+        self.assertEqual(
+            mock_send.call_args[0][1], AnalyticsTelemetryEvents.ONECLICK_TRIAL_STARTED.value
+        )
+        self.assertEqual(mock_send.call_args[0][2], m_user)
+
+    @staticmethod
+    def create_trial_user_plan():
+        m_plan = mock.Mock()
+        m_plan.plan.name = "Some plan"
+        m_plan.plan.id = 12
+        m_plan.created_at = str(datetime.now())
+        m_plan.expired_at = str(datetime.now() + timedelta(days=30))
+        m_plan.is_expired = False
+        m_user = mock.Mock()
+        m_org = mock.Mock()
+        m_org.id = 123
+        m_user.organization = m_org
+        m_user.organization.has_telemetry_opt_out = False
+        m_user.groups.values_list.return_value = []
+        m_user.userplan_set.all.return_value = [m_plan]
+        return m_user

--- a/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
@@ -43,8 +43,12 @@ segment_analytics_client = None
 
 
 def meets_min_ansible_extension_version(version) -> bool:
+    """
+    Checks if the extension version, if exists, checks if it satisfies a defined min. version value.
+    Requests outside the extension context, such as one-click trial, assume no version parameter.
+    """
     if not version:
-        return False
+        return True
     minVersion = Version(settings.ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION)
     try:
         userVersion = Version(version)

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -64,6 +64,15 @@ from ansible_ai_connect.ai.api.model_client.exceptions import (
     WcaUserTrialExpired,
 )
 from ansible_ai_connect.ai.api.pipelines.completions import CompletionsPipeline
+from ansible_ai_connect.ai.api.telemetry.schema2 import (
+    AnalyticsPlaybookGenerationWizard,
+    AnalyticsProductFeedback,
+    AnalyticsRecommendationAction,
+    AnalyticsTelemetryEvents,
+)
+from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
+    send_segment_analytics_event,
+)
 from ansible_ai_connect.users.models import User
 
 from ..feature_flags import FeatureFlags
@@ -93,14 +102,7 @@ from .serializers import (
     SentimentFeedback,
     SuggestionQualityFeedback,
 )
-from .utils.analytics_telemetry_model import (
-    AnalyticsPlaybookGenerationWizard,
-    AnalyticsProductFeedback,
-    AnalyticsRecommendationAction,
-    AnalyticsTelemetryEvents,
-)
 from .utils.segment import send_segment_event
-from .utils.segment_analytics_telemetry import send_segment_analytics_event
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_ai_connect/main/middleware.py
+++ b/ansible_ai_connect/main/middleware.py
@@ -25,12 +25,12 @@ from rest_framework.exceptions import ErrorDetail
 from segment import analytics
 from social_django.middleware import SocialAuthExceptionMiddleware
 
-from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
-from ansible_ai_connect.ai.api.utils.analytics_telemetry_model import (
+from ansible_ai_connect.ai.api.telemetry.schema2 import (
     AnalyticsRecommendationGenerated,
     AnalyticsRecommendationTask,
     AnalyticsTelemetryEvents,
 )
+from ansible_ai_connect.ai.api.utils import segment_analytics_telemetry
 from ansible_ai_connect.ai.api.utils.segment import send_segment_event
 from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     send_segment_analytics_event,

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -31,6 +31,7 @@ from ansible_ai_connect.ai.api.aws.exceptions import (
     WcaSecretManagerMissingCredentialsError,
 )
 from ansible_ai_connect.ai.api.telemetry import schema1
+from ansible_ai_connect.ai.api.telemetry import schema2_utils as schema2
 from ansible_ai_connect.ai.api.utils.segment import send_schema1_event
 from ansible_ai_connect.main.cache.cache_per_user import cache_per_user
 from ansible_ai_connect.users.constants import TRIAL_PLAN_NAME
@@ -227,6 +228,8 @@ class TrialView(TemplateView):
             event = schema1.OneClickTrialStartedEvent()
             event.set_request(request)
             send_schema1_event(event)
+
+            schema2.oneclick_trial_event_send(request.user)
 
         context = self.get_context_data(**kwargs)
         return render(request, self.template_name, context=context)


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-31593>

## Description
- Adding `OneClickTrialStarted` for `schema2`telemetry
- Refactoring some `schema2` stuff into `telemetry` package
- `OneClickTrialStarted` event definition => Given the actual use cases (see [AAP-31593](https://issues.redhat.com/browse/AAP-31593)), notice I don't send the `accept_marketing` field for `schema2`, as we already do for `schema1`, and I understand that's not for the use case of telesense team. Other fields' are preserved. Let me know if you think it should be preserved otherwise.

Thanks!

## Scenarios tested
Tested locally against our wisdom staging Segment's  account. Events are flowing.

### Steps to test
1. Pull down the PR
2. Run the service
3. Start a trial
4. Look at Segment, if the `OneClickTrialStarted` has been sent, as expected.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
