### PR TITLE
No longer need for extension version checks around telemetry.

### DIFF
--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/deserialise.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/deserialise.py
@@ -39,11 +39,6 @@ class DeserializeStage(PipelineElement):
         try:
             request_serializer.is_valid(raise_exception=True)
             request._request._suggestion_id = str(request_serializer.validated_data["suggestionId"])
-            request._request._ansible_extension_version = str(
-                request_serializer.validated_data.get("metadata", {}).get(
-                    "ansibleExtensionVersion", None
-                )
-            )
             context.metadata = request_serializer.validated_data.get("metadata", {})
             prompt = request_serializer.validated_data.get("prompt")
         except Exception as exc:

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -37,26 +37,13 @@ from .fields import (
 )
 
 
-class Metadata(serializers.Serializer):
-    class Meta:
-        fields = ["ansibleExtensionVersion"]
-
-    ansibleExtensionVersion = serializers.RegexField(
-        r"v?\d+\.\d+\.\d+",
-        required=False,
-        label="Ansible vscode/vscodium extension version",
-        help_text="User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH",
-    )
-
-
-class CompletionMetadata(Metadata):
+class CompletionMetadata(serializers.Serializer):
     class Meta:
         fields = [
             "documentUri",
             "activityId",
             "ansibleFileType",
             "additionalContext",
-            "ansibleExtensionVersion",
         ]
 
     documentUri = AnonymizedCharField(required=False)
@@ -92,7 +79,7 @@ class CompletionMetadata(Metadata):
         ),
     ]
 )
-class CompletionRequestSerializer(Metadata):
+class CompletionRequestSerializer(serializers.Serializer):
 
     prompt = AnonymizedPromptCharField(
         trim_whitespace=False,
@@ -329,11 +316,10 @@ class PlaybookExplanationFeedback(serializers.Serializer):
         ),
     ]
 )
-class FeedbackRequestSerializer(Metadata):
+class FeedbackRequestSerializer(serializers.Serializer):
 
     inlineSuggestion = InlineSuggestionFeedback(required=False)
     issueFeedback = IssueFeedback(required=False)
-    metadata = Metadata(required=False)
     model = serializers.CharField(required=False)
     playbookExplanationFeedback = PlaybookExplanationFeedback(required=False)
     playbookGenerationFeedback = PlaybookGenerationFeedback(required=False)
@@ -352,7 +338,7 @@ class FeedbackRequestSerializer(Metadata):
             raise serializers.ValidationError("invalid feedback type for user")
 
 
-class ExplanationRequestSerializer(Metadata):
+class ExplanationRequestSerializer(serializers.Serializer):
 
     content = AnonymizedCharField(
         required=True,
@@ -374,7 +360,6 @@ class ExplanationRequestSerializer(Metadata):
         ),
     )
     model = serializers.CharField(required=False, allow_blank=True)
-    metadata = Metadata(required=False)
 
     def validate(self, data):
         data = super().validate(data)
@@ -409,7 +394,6 @@ class GenerationRequestSerializer(serializers.Serializer):
             "wizardId",
             "createOutline",
             "customPrompt",
-            "ansibleExtensionVersion",
             "outline",
         ]
 
@@ -452,8 +436,6 @@ class GenerationRequestSerializer(serializers.Serializer):
     )
     model = serializers.CharField(required=False, allow_blank=True)
 
-    metadata = Metadata(required=False)
-
     def validate(self, data):
         data = super().validate(data)
 
@@ -484,7 +466,7 @@ class GenerationResponseSerializer(serializers.Serializer):
     outline = serializers.CharField()
 
 
-class ContentMatchRequestSerializer(Metadata):
+class ContentMatchRequestSerializer(serializers.Serializer):
     suggestions = serializers.ListField(child=AnonymizedCharField(trim_whitespace=False))
     suggestionId = serializers.UUIDField(
         format="hex_verbose",
@@ -496,7 +478,6 @@ class ContentMatchRequestSerializer(Metadata):
         ),
     )
     model = serializers.CharField(required=False, allow_blank=True)
-    metadata = Metadata(required=False)
 
     def validate(self, data):
         data = super().validate(data)

--- a/ansible_ai_connect/ai/api/tests/test_serializers.py
+++ b/ansible_ai_connect/ai/api/tests/test_serializers.py
@@ -239,28 +239,6 @@ class FeedbackRequestSerializerTest(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_invalid_ansible_extension_version_on_inline_suggestion(self):
-        org = Mock(telemetry_opt_out=False)
-        user = Mock(rh_user_has_seat=True, organization=org)
-        request = Mock(user=user)
-        serializer = FeedbackRequestSerializer(
-            context={"request": request},
-            data={
-                "inlineSuggestion": {
-                    "userActionTime": 5155,
-                    "action": "0",
-                    "suggestionId": "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
-                },
-                "metadata": {
-                    "ansibleExtensionVersion": "foo",
-                },
-            },
-        )
-
-        # feedback request raises exception when ansibleExtensionVersion is not valid version
-        with self.assertRaises(serializers.ValidationError):
-            serializer.is_valid(raise_exception=True)
-
     def test_commercial_user_not_opted_out_passes_on_inlineSuggestion(self):
         org = Mock(has_telemetry_opt_out=False)
 

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -2410,7 +2410,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         state: present
 """,
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger="root", level="DEBUG") as log:
@@ -2437,7 +2436,6 @@ This playbook emails admin@redhat.com with a list of passwords.
             state: present
     """,
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
             "model": model,
         }
         self.client.force_authenticate(user=self.user)
@@ -2453,7 +2451,6 @@ This playbook emails admin@redhat.com with a list of passwords.
     def test_with_pii(self):
         payload = {
             "content": "marc-anthony@bar.foo",
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.explain_playbook.return_value = "foo"
@@ -2482,7 +2479,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         state: present
 """,
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         with patch.object(
             apps.get_app_config("ai"),
@@ -2499,7 +2495,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         # No content specified
         payload = {
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         with patch.object(
             apps.get_app_config("ai"),
@@ -2526,7 +2521,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         body: Here are your passwords.
 """,
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
 
         with patch.object(
@@ -2556,7 +2550,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         state: present
 """,
             "explanationId": explanation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
 
         self.client.force_authenticate(user=self.user)
@@ -2569,7 +2562,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         payload = {
             "content": "marc-anthony@bar.foo",
             "customPrompt": "Please explain this {playbook}",
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.explain_playbook.return_value = "foo"
@@ -2589,7 +2581,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         payload = {
             "content": "marc-anthony@bar.foo",
             "customPrompt": "",
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.explain_playbook.return_value = "foo"
@@ -2611,7 +2602,6 @@ This playbook emails admin@redhat.com with a list of passwords.
         payload = {
             "content": "marc-anthony@bar.foo",
             "customPrompt": "Please explain this",
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.explain_playbook.return_value = "foo"
@@ -2650,7 +2640,6 @@ that are running Red Hat Enterprise Linux 9.
         state: present
 """,
         "explanationId": explanation_id,
-        "ansibleExtensionVersion": "24.4.0",
     }
 
     def stub_wca_client(
@@ -2901,7 +2890,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Install nginx on RHEL9",
             "generationId": generation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         self.client.force_authenticate(user=self.user)
         r = self.client.post(reverse("generations"), payload, format="json")
@@ -2917,7 +2905,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Install nginx on RHEL9",
             "generationId": generation_id,
-            "ansibleExtensionVersion": "24.4.0",
             "model": model,
         }
         self.client.force_authenticate(user=self.user)
@@ -2932,7 +2919,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Install nginx on RHEL9 jean-marc@redhat.com",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -2952,7 +2938,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Install nginx on RHEL9",
             "generationId": generation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         with patch.object(
             apps.get_app_config("ai"),
@@ -2967,7 +2952,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
     def test_bad_request(self):
         generation_id = str(uuid.uuid4())
         # No content specified
-        payload = {"generationId": generation_id, "ansibleExtensionVersion": "24.4.0"}
+        payload = {"generationId": generation_id}
         with patch.object(
             apps.get_app_config("ai"),
             "model_mesh_client",
@@ -2983,7 +2968,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Show me the money",
             "generationId": generation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
 
         with patch.object(
@@ -3006,7 +2990,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
         payload = {
             "text": "Install nginx on RHEL9",
             "generationId": generation_id,
-            "ansibleExtensionVersion": "24.4.0",
         }
         self.client.force_authenticate(user=self.user)
         with self.assertRaises(Exception):
@@ -3020,7 +3003,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             "customPrompt": "You are an Ansible expert. Explain {goal} with {outline}.",
             "outline": "Install nginx. Start nginx.",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -3048,7 +3030,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             "customPrompt": "",
             "outline": "Install nginx. Start nginx.",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -3074,7 +3055,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             "text": "Install nginx on RHEL9 jean-marc@redhat.com",
             "customPrompt": "You are an Ansible expert",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -3098,7 +3078,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             "customPrompt": "You are an Ansible expert. Explain {goal}.",
             "outline": "Install nginx. Start nginx.",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -3124,7 +3103,6 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
             "text": "Install nginx on RHEL9 jean-marc@redhat.com",
             "customPrompt": "You are an Ansible expert. Explain {goal}.",
             "generationId": str(uuid.uuid4()),
-            "ansibleExtensionVersion": "24.4.0",
         }
         mocked_client = Mock()
         mocked_client.generate_playbook.return_value = ("foo", "bar")
@@ -3164,7 +3142,6 @@ class TestGenerationViewWithWCA(WisdomAppsBackendMocking, WisdomServiceAPITestCa
     payload = {
         "text": "Install nginx on RHEL9",
         "generationId": generation_id,
-        "ansibleExtensionVersion": "24.4.0",
     }
 
     def stub_wca_client(

--- a/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
@@ -16,7 +16,6 @@ import logging
 
 from attr import asdict
 from django.conf import settings
-from packaging.version import InvalidVersion, Version
 from segment.analytics import Client
 
 from ansible_ai_connect.ai.api.utils.segment import (
@@ -42,31 +41,12 @@ max_retries = Client.DefaultConfig.max_retries
 segment_analytics_client = None
 
 
-def meets_min_ansible_extension_version(version) -> bool:
-    if not version:
-        return False
-    minVersion = Version(settings.ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION)
-    try:
-        userVersion = Version(version)
-    except InvalidVersion:
-        return False
-    return userVersion >= minVersion
-
-
-def send_segment_analytics_event(
-    event_enum, event_payload_supplier, user: User, ansibleExtensionVersion=None
-):
+def send_segment_analytics_event(event_enum, event_payload_supplier, user: User):
     if not settings.SEGMENT_ANALYTICS_WRITE_KEY:
         logger.info("Segment analytics write key not set, skipping event.")
         return
     if not user.rh_user_has_seat:
         logger.info("Skipping analytics telemetry event for users that has no seat.")
-        return
-
-    if meets_min_ansible_extension_version(ansibleExtensionVersion) is False:
-        logger.info(
-            f"Skipping analytics telemetry event, extension version: {ansibleExtensionVersion}"
-        )
         return
 
     organization: Organization = user.organization

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -231,9 +231,6 @@ class Feedback(APIView):
             "playbookGenerationAction"
         )
 
-        ansible_extension_version = validated_data.get("metadata", {}).get(
-            "ansibleExtensionVersion", None
-        )
         model_name = ""
         try:
             org_id = getattr(user, "org_id", None)
@@ -266,7 +263,6 @@ class Feedback(APIView):
                     rh_user_org_id=org_id,
                 ),
                 user,
-                ansible_extension_version,
             )
         if suggestion_quality_data:
             event = {
@@ -294,7 +290,6 @@ class Feedback(APIView):
                     model_name=model_name,
                 ),
                 user,
-                ansible_extension_version,
             )
         if issue_feedback_data:
             event = {
@@ -335,7 +330,6 @@ class Feedback(APIView):
                         wizard_id=str(playbook_generation_action_data.get("wizardId", "")),
                     ),
                     user,
-                    ansible_extension_version,
                 )
 
         feedback_events = [

--- a/ansible_ai_connect/main/middleware.py
+++ b/ansible_ai_connect/main/middleware.py
@@ -169,7 +169,6 @@ class SegmentMiddleware:
                             model_name=model_name,
                         ),
                         request.user,
-                        getattr(request, "_ansible_extension_version", None),
                     )
 
         # Clean up response.data for 204; should be empty to prevent

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -233,9 +233,6 @@ SOCIAL_AUTH_PIPELINE = (
 # Write key for sending analytics data to Segment. Note that each of Prod/Dev have a different key.
 SEGMENT_WRITE_KEY = os.environ.get("SEGMENT_WRITE_KEY")
 SEGMENT_ANALYTICS_WRITE_KEY = os.environ.get("SEGMENT_ANALYTICS_WRITE_KEY")
-ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION = os.environ.get(
-    "ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION", "v2.12.143"
-)
 
 OAUTH2_PROVIDER = {
     "SCOPES": {

--- a/ansible_ai_connect/main/tests/test_middleware.py
+++ b/ansible_ai_connect/main/tests/test_middleware.py
@@ -45,7 +45,7 @@ class TestMiddleware(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBaseOIDC)
     @override_settings(ENABLE_ARI_POSTPROCESS=True)
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
-    @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="DUMMY_KEY_ANALYTICS_VALUE")
+    @override_settings(SEGMENT_ANALYTICS_WRITE_KEY=None)
     @patch(
         "ansible_ai_connect.ai.api.utils.segment.redact_seated_users_data",
         dummy_redact_seated_users_data,

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -565,11 +565,6 @@ components:
     CompletionMetadata:
       type: object
       properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
         documentUri:
           type: string
         activityId:
@@ -590,11 +585,6 @@ components:
     CompletionRequest:
       type: object
       properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
         prompt:
           type: string
           description: Editor prompt.
@@ -659,11 +649,6 @@ components:
     ContentMatchRequest:
       type: object
       properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
         suggestions:
           type: array
           items:
@@ -692,11 +677,6 @@ components:
     ExplanationRequest:
       type: object
       properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
         content:
           type: string
           title: Playbook content
@@ -736,11 +716,6 @@ components:
     FeedbackRequest:
       type: object
       properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
         inlineSuggestion:
           $ref: '#/components/schemas/InlineSuggestionFeedback'
         issueFeedback:
@@ -861,14 +836,6 @@ components:
           readOnly: true
       required:
       - content
-    Metadata:
-      type: object
-      properties:
-        ansibleExtensionVersion:
-          type: string
-          title: Ansible vscode/vscodium extension version
-          description: User's installed Ansible extension version, in format vMAJOR.MINOR.PATCH
-          pattern: v?\d+\.\d+\.\d+
     Organization:
       type: object
       properties:


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-31593>

## Description

At this point, since the inclusion of AAP-31593, not all the requests (which end up on sending telemetry) are having a proper extension version field. Also several latest extensions already are suitable for using telemetry. This way, deleting the min. version check.

Related to https://github.com/ansible/ansible-wisdom-ops/pull/1039
 
### Scenarios tested
Locally against staging.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
Promote https://github.com/ansible/ansible-wisdom-ops/pull/1039 as well
