### PR TITLE
AAP-31593: schema2: drop the vscode-ansible extension check

### DIFF
--- a/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
+++ b/ansible_ai_connect/ai/api/utils/segment_analytics_telemetry.py
@@ -16,7 +16,6 @@ import logging
 
 from attr import asdict
 from django.conf import settings
-from packaging.version import InvalidVersion, Version
 from segment.analytics import Client
 
 from ansible_ai_connect.ai.api.utils.segment import (
@@ -42,17 +41,6 @@ max_retries = Client.DefaultConfig.max_retries
 segment_analytics_client = None
 
 
-def meets_min_ansible_extension_version(version) -> bool:
-    if not version:
-        return False
-    minVersion = Version(settings.ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION)
-    try:
-        userVersion = Version(version)
-    except InvalidVersion:
-        return False
-    return userVersion >= minVersion
-
-
 def send_segment_analytics_event(
     event_enum, event_payload_supplier, user: User, ansibleExtensionVersion=None
 ):
@@ -61,12 +49,6 @@ def send_segment_analytics_event(
         return
     if not user.rh_user_has_seat:
         logger.info("Skipping analytics telemetry event for users that has no seat.")
-        return
-
-    if meets_min_ansible_extension_version(ansibleExtensionVersion) is False:
-        logger.info(
-            f"Skipping analytics telemetry event, extension version: {ansibleExtensionVersion}"
-        )
         return
 
     organization: Organization = user.organization

--- a/ansible_ai_connect/ai/api/utils/tests/test_segment_analytics_telemetry.py
+++ b/ansible_ai_connect/ai/api/utils/tests/test_segment_analytics_telemetry.py
@@ -26,7 +26,6 @@ from ansible_ai_connect.ai.api.utils.analytics_telemetry_model import (
 )
 from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     get_segment_analytics_client,
-    meets_min_ansible_extension_version,
     send_segment_analytics_error_event,
     send_segment_analytics_event,
 )
@@ -78,15 +77,6 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
         self.assertEqual(client.sync_mode, False)
         self.assertEqual(client.timeout, 10)
 
-    @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
-    def test_meets_min_ansible_extension_version(self):
-        self.assertTrue(meets_min_ansible_extension_version("v3.1"))
-        self.assertTrue(meets_min_ansible_extension_version("v1.3.5"))
-        self.assertFalse(meets_min_ansible_extension_version("v0.1"))
-        self.assertFalse(meets_min_ansible_extension_version("foo"))
-        self.assertFalse(meets_min_ansible_extension_version(None))
-        self.assertFalse(meets_min_ansible_extension_version(""))
-
     @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.send_segment_event")
     def test_send_segment_analytics_error_value(self, send_segment_event):
         error = ValueError()
@@ -109,7 +99,6 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
 
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY="dummy_key")
-    @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, "LDClient")
     @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event(self, base_send_segment_event, LDClient):
@@ -129,7 +118,6 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
 
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY="dummy_key")
-    @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, "LDClient")
     @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.base_send_segment_event")
     def test_send_segment_analytics_event_requires_min_ansible_ext_version(
@@ -143,7 +131,6 @@ class TestSegmentAnalyticsTelemetry(WisdomServiceAPITestCaseBase):
 
     @override_settings(SEGMENT_ANALYTICS_WRITE_KEY="testWriteKey")
     @override_settings(LAUNCHDARKLY_SDK_KEY="dummy_key")
-    @override_settings(ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION="v1.0.0")
     @patch.object(feature_flags, "LDClient")
     @patch("ansible_ai_connect.ai.api.utils.segment_analytics_telemetry.send_segment_event")
     def test_send_segment_analytics_event_error_validation(self, send_segment_event, LDClient):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -233,9 +233,6 @@ SOCIAL_AUTH_PIPELINE = (
 # Write key for sending analytics data to Segment. Note that each of Prod/Dev have a different key.
 SEGMENT_WRITE_KEY = os.environ.get("SEGMENT_WRITE_KEY")
 SEGMENT_ANALYTICS_WRITE_KEY = os.environ.get("SEGMENT_ANALYTICS_WRITE_KEY")
-ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION = os.environ.get(
-    "ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION", "v2.12.143"
-)
 
 OAUTH2_PROVIDER = {
     "SCOPES": {


### PR DESCRIPTION
We don't need the check anymore.
