### PR TITLE
AAP-32524: Lightspeed: Playbook generation: Custom prompt must end with \n

### DIFF
--- a/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
@@ -342,6 +342,48 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
         self.assertEqual(outline, "Ahh!")
 
     @assert_call_count_metrics(metric=wca_codegen_playbook_hist)
+    def test_playbook_gen_custom_prompt(self):
+        request = Mock()
+        self.wca_client.generate_playbook(
+            request,
+            text="Install Wordpress",
+            custom_prompt="You are an Ansible expert",
+            create_outline=True,
+        )
+        self.wca_client.session.post.assert_called_once_with(
+            "http://example.com//v1/wca/codegen/ansible/playbook",
+            headers=ANY,
+            json={
+                "model_id": "a-random-model",
+                "text": "Install Wordpress",
+                "create_outline": True,
+                "custom_prompt": "You are an Ansible expert\n",
+            },
+            verify=ANY,
+        )
+
+    @assert_call_count_metrics(metric=wca_codegen_playbook_hist)
+    def test_playbook_gen_custom_prompt_with_trailing_newline(self):
+        request = Mock()
+        self.wca_client.generate_playbook(
+            request,
+            text="Install Wordpress",
+            custom_prompt="You are an Ansible expert\n",
+            create_outline=True,
+        )
+        self.wca_client.session.post.assert_called_once_with(
+            "http://example.com//v1/wca/codegen/ansible/playbook",
+            headers=ANY,
+            json={
+                "model_id": "a-random-model",
+                "text": "Install Wordpress",
+                "create_outline": True,
+                "custom_prompt": "You are an Ansible expert\n",
+            },
+            verify=ANY,
+        )
+
+    @assert_call_count_metrics(metric=wca_codegen_playbook_hist)
     @assert_call_count_metrics(metric=wca_codegen_playbook_retry_counter)
     def test_playbook_gen_error(self):
         request = Mock()
@@ -385,6 +427,40 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
         request = Mock()
         explanation = self.wca_client.explain_playbook(request, content="Some playbook")
         self.assertEqual(explanation, "!Óh¡")
+
+    @assert_call_count_metrics(metric=wca_explain_playbook_hist)
+    def test_playbook_exp_custom_prompt(self):
+        request = Mock()
+        self.wca_client.explain_playbook(
+            request, content="Some playbook", custom_prompt="Explain this"
+        )
+        self.wca_client.session.post.assert_called_once_with(
+            "http://example.com//v1/wca/explain/ansible/playbook",
+            headers=ANY,
+            json={
+                "model_id": "a-random-model",
+                "playbook": "Some playbook",
+                "custom_prompt": "Explain this\n",
+            },
+            verify=ANY,
+        )
+
+    @assert_call_count_metrics(metric=wca_explain_playbook_hist)
+    def test_playbook_exp_custom_prompt_with_trailing_newline(self):
+        request = Mock()
+        self.wca_client.explain_playbook(
+            request, content="Some playbook", custom_prompt="Explain this\n"
+        )
+        self.wca_client.session.post.assert_called_once_with(
+            "http://example.com//v1/wca/explain/ansible/playbook",
+            headers=ANY,
+            json={
+                "model_id": "a-random-model",
+                "playbook": "Some playbook",
+                "custom_prompt": "Explain this\n",
+            },
+            verify=ANY,
+        )
 
     @assert_call_count_metrics(metric=wca_explain_playbook_hist)
     @assert_call_count_metrics(metric=wca_explain_playbook_retry_counter)

--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -596,6 +596,8 @@ class WCAClient(BaseWCAClient):
         if outline:
             data["outline"] = outline
         if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
             data["custom_prompt"] = custom_prompt
 
         @backoff.on_exception(
@@ -658,6 +660,8 @@ class WCAClient(BaseWCAClient):
             "playbook": content,
         }
         if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
             data["custom_prompt"] = custom_prompt
 
         @backoff.on_exception(


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-32524

## Description
This PR ensures `custom_prompts` end with a `\n` character.

## Testing

### Steps to test
1. Pull down the PR
2. Start `ansible-ai-connect-service`
3. Run the "special" VSCode extension, supporting "custom prompts".
4. Verify you receive "Playbook generation" responses.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
