### PR TITLE
Upgrade jsonpickle to 3.3.0

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -183,8 +183,10 @@ joblib==1.4.0
     # via ansible-risk-insight
 jsonpatch==1.33
     # via langchain-core
-jsonpickle==3.0.4
-    # via ansible-risk-insight
+jsonpickle==3.3.0
+    # via
+    #   -r requirements.in
+    #   ansible-risk-insight
 jsonpointer==2.4
     # via jsonpatch
 jsonschema==4.21.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -183,8 +183,10 @@ joblib==1.4.0
     # via ansible-risk-insight
 jsonpatch==1.33
     # via langchain-core
-jsonpickle==3.0.4
-    # via ansible-risk-insight
+jsonpickle==3.3.0
+    # via
+    #   -r requirements.in
+    #   ansible-risk-insight
 jsonpointer==2.4
     # via jsonpatch
 jsonschema==4.21.1

--- a/requirements.in
+++ b/requirements.in
@@ -44,6 +44,9 @@ jwcrypto==1.5.6
 # pin jinja2 on 3.1.4 to address GHSA-h75v-3vvj-5mfj
 # remove this once ansible-core or torch are updated
 jinja2==3.1.4
+# pin jsonpickle on 3.3.0 to address SNYK-PYTHON-JSONPICKLE-8136229
+# remove this once ansible-risk-insight is updated
+jsonpickle==3.3.0
 langchain==0.2.11
 langchain-community==0.2.10
 launchdarkly-server-sdk==8.3.0


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Issues to fix by upgrading dependencies:

  Upgrade jsonpickle@3.0.4 to jsonpickle@3.3.0 to fix
  ✗ Arbitrary Code Execution (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JSONPICKLE-8136229] in jsonpickle@3.0.4
    introduced by jsonpickle@3.0.4 and 1 other path(s)
```