### PR TITLE
AAP-32403: Lightspeed: Playbook generation: Handle "warnings" in response

### DIFF
--- a/ansible_ai_connect/ai/api/model_client/base.py
+++ b/ansible_ai_connect/ai/api/model_client/base.py
@@ -68,7 +68,7 @@ class ModelMeshClient:
         outline: str = "",
         generation_id: str = "",
         model_id: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list]:
         raise NotImplementedError
 
     def explain_playbook(

--- a/ansible_ai_connect/ai/api/model_client/dummy_client.py
+++ b/ansible_ai_connect/ai/api/model_client/dummy_client.py
@@ -95,10 +95,10 @@ class DummyClient(ModelMeshClient):
         outline: str = "",
         generation_id: str = "",
         model_id: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list]:
         if create_outline:
-            return PLAYBOOK, OUTLINE
-        return PLAYBOOK, ""
+            return PLAYBOOK, OUTLINE, []
+        return PLAYBOOK, "", []
 
     def explain_playbook(
         self,

--- a/ansible_ai_connect/ai/api/model_client/langchain.py
+++ b/ansible_ai_connect/ai/api/model_client/langchain.py
@@ -132,7 +132,7 @@ class LangChainClient(ModelMeshClient):
         outline: str = "",
         generation_id: str = "",
         model_id: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list]:
         SYSTEM_MESSAGE_TEMPLATE = """
         You are an Ansible expert.
         Your role is to help Ansible developers write playbooks.
@@ -189,7 +189,7 @@ class LangChainClient(ModelMeshClient):
         if not create_outline:
             outline = ""
 
-        return playbook, outline
+        return playbook, outline, []
 
     def explain_playbook(
         self,

--- a/ansible_ai_connect/ai/api/model_client/tests/test_dummy_client.py
+++ b/ansible_ai_connect/ai/api/model_client/tests/test_dummy_client.py
@@ -58,21 +58,25 @@ class TestDummyClient(SimpleTestCase):
 
     def test_generate_playbook(self):
         client = DummyClient(inference_url="https://ibm.com")
-        playbook, outline = client.generate_playbook(None, text="foo", create_outline=False)
+        playbook, outline, warnings = client.generate_playbook(
+            None, text="foo", create_outline=False
+        )
         self.assertTrue(isinstance(playbook, str))
         self.assertTrue(isinstance(outline, str))
         self.assertEqual(outline, "")
 
     def test_generate_playbook_with_outline(self):
         client = DummyClient(inference_url="https://ibm.com")
-        playbook, outline = client.generate_playbook(None, text="foo", create_outline=True)
+        playbook, outline, warnings = client.generate_playbook(
+            None, text="foo", create_outline=True
+        )
         self.assertTrue(isinstance(playbook, str))
         self.assertTrue(isinstance(outline, str))
         self.assertTrue(outline)
 
     def test_generate_playbook_with_model_id(self):
         client = DummyClient(inference_url="https://ibm.com")
-        playbook, outline = client.generate_playbook(
+        playbook, outline, warnings = client.generate_playbook(
             None, text="foo", create_outline=True, model_id="mymodel"
         )
         self.assertTrue(isinstance(playbook, str))

--- a/ansible_ai_connect/ai/api/model_client/tests/test_langchain.py
+++ b/ansible_ai_connect/ai/api/model_client/tests/test_langchain.py
@@ -122,7 +122,7 @@ class TestLangChainClient(WisdomServiceLogAwareTestCase):
         self.my_client.get_chat_model = fake_get_chat_mode
 
     def test_generate_playbook(self):
-        playbook, outline = self.my_client.generate_playbook(
+        playbook, outline, warnings = self.my_client.generate_playbook(
             request=Mock(),
             text="foo",
         )
@@ -130,7 +130,7 @@ class TestLangChainClient(WisdomServiceLogAwareTestCase):
         self.assertEqual(outline, "")
 
     def test_generate_playbook_with_outline(self):
-        playbook, outline = self.my_client.generate_playbook(
+        playbook, outline, warnings = self.my_client.generate_playbook(
             request=Mock(), text="foo", create_outline=True
         )
         self.assertEqual(playbook, "my_playbook")
@@ -142,7 +142,7 @@ class TestLangChainClient(WisdomServiceLogAwareTestCase):
                 logger="ansible_ai_connect.ai.api.model_client.langchain", level="INFO"
             ) as log,
         ):
-            playbook, outline = self.my_client.generate_playbook(
+            playbook, outline, warnings = self.my_client.generate_playbook(
                 request=Mock(),
                 text="foo",
                 create_outline=True,

--- a/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/tests/test_wca_client.py
@@ -335,7 +335,7 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
     @assert_call_count_metrics(metric=wca_codegen_playbook_hist)
     def test_playbook_gen(self):
         request = Mock()
-        playbook, outline = self.wca_client.generate_playbook(
+        playbook, outline, warnings = self.wca_client.generate_playbook(
             request, text="Install Wordpress", create_outline=True
         )
         self.assertEqual(playbook, "Oh!")
@@ -521,7 +521,7 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
         fake_linter = Mock()
         fake_linter.run_linter.return_value = "I'm super fake!"
         self.mock_ansible_lint_caller_with(fake_linter)
-        playbook, outline = self.wca_client.generate_playbook(
+        playbook, outline, warnings = self.wca_client.generate_playbook(
             request=Mock(), text="Install Wordpress", create_outline=True
         )
         self.assertEqual(playbook, "I'm super fake!")
@@ -531,7 +531,7 @@ class TestWCAClientExpGen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
     @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
     def test_playbook_gen_when_is_not_initialized(self):
         self.mock_ansible_lint_caller_with(None)
-        playbook, outline = self.wca_client.generate_playbook(
+        playbook, outline, warnings = self.wca_client.generate_playbook(
             request=Mock(), text="Install Wordpress", create_outline=True
         )
         # Ensure nothing was done

--- a/ansible_ai_connect/ai/api/model_client/wca_client.py
+++ b/ansible_ai_connect/ai/api/model_client/wca_client.py
@@ -582,7 +582,7 @@ class WCAClient(BaseWCAClient):
         outline: str = "",
         generation_id: str = "",
         model_id: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list]:
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
         model_id = self.get_model_id(request.user, organization_id, model_id)
@@ -633,6 +633,7 @@ class WCAClient(BaseWCAClient):
 
         playbook = response["playbook"]
         outline = response["outline"]
+        warnings = response["warnings"] if "warnings" in response else []
 
         from ansible_ai_connect.ai.apps import AiConfig
 
@@ -640,7 +641,7 @@ class WCAClient(BaseWCAClient):
         if ansible_lint_caller := ai_config.get_ansible_lint_caller():
             playbook = ansible_lint_caller.run_linter(playbook)
 
-        return playbook, outline
+        return playbook, outline, warnings
 
     def explain_playbook(
         self,
@@ -779,7 +780,7 @@ class WCAOnPremClient(BaseWCAClient):
         outline: str = "",
         generation_id: str = "",
         model_id: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, list]:
         raise FeatureNotAvailable
 
     def explain_playbook(

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -472,6 +472,12 @@ class GenerationRequestSerializer(serializers.Serializer):
         return data
 
 
+class GenerationWarningResponseSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    message = serializers.CharField()
+    details = serializers.CharField(required=False)
+
+
 class GenerationResponseSerializer(serializers.Serializer):
     playbook = serializers.CharField()
     format = serializers.CharField()
@@ -482,6 +488,7 @@ class GenerationResponseSerializer(serializers.Serializer):
         help_text=("A UUID that identifies the particular summary data is being requested for."),
     )
     outline = serializers.CharField()
+    warnings = serializers.ListField(child=GenerationWarningResponseSerializer(), required=False)
 
 
 class ContentMatchRequestSerializer(Metadata):

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -857,7 +857,7 @@ class Generation(APIView):
 
             llm = apps.get_app_config("ai").model_mesh_client
             start_time = time.time()
-            playbook, outline = llm.generate_playbook(
+            playbook, outline, warnings = llm.generate_playbook(
                 request, text, custom_prompt, create_outline, outline, generation_id, model_id
             )
             duration = round((time.time() - start_time) * 1000, 2)
@@ -874,6 +874,7 @@ class Generation(APIView):
             answer = {
                 "playbook": anonymized_playbook,
                 "outline": anonymized_outline,
+                "warnings": warnings,
                 "format": "plaintext",
                 "generationId": generation_id,
             }

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -812,10 +812,26 @@ components:
             requested for.
         outline:
           type: string
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenerationWarningResponse'
       required:
       - format
       - outline
       - playbook
+    GenerationWarningResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        message:
+          type: string
+        details:
+          type: string
+      required:
+      - id
+      - message
     InlineSuggestionFeedback:
       type: object
       properties:


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-32403

## Description
Ensure `warnings` returned from WCA are included in the API response payload.

## Testing

### Steps to test
1. Pull down the PR
2. Unit tests

### Scenarios tested
Unit tests.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
