### PR TITLE
A UUID value cannot be in JSON

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -3481,6 +3481,9 @@ class TestChatView(WisdomServiceAPITestCaseBase):
             def json(self):
                 return self.json_data
 
+        # Make sure that the given json data is serializable
+        json.dumps(kwargs["json"])
+
         json_response = {
             "response": "AAP 2.5 introduces an updated, unified UI.",
             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -1079,7 +1079,7 @@ class Chat(APIView):
                 "provider": settings.CHATBOT_DEFAULT_PROVIDER,
             }
             if "conversation_id" in request_serializer.validated_data:
-                data["conversation_id"] = request_serializer.validated_data["conversation_id"]
+                data["conversation_id"] = str(request_serializer.validated_data["conversation_id"])
             response = requests.post(settings.CHATBOT_URL + "/v1/query", headers=headers, json=data)
 
             if response.status_code == 200:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-32365>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
This is a bug found in #1334.  Before assigning `conversation_id` in a JSON, the value (a UUID) needs to be converted into a string.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
A modification to a subroutine used in Chat API unit tests is provided. Manual tests were also performed using the chatbot PoC.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
