### PR TITLE
AAP-30617: Introduce AACSAPIView to handle the generic aspect of the view

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -2896,7 +2896,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.NO_CONTENT,
             WcaBadRequestException,
-            "bad request for playbook explanation",
+            "WCA returned a bad request response.",
         )
 
     def test_missing_api_key(self):
@@ -2908,7 +2908,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.FORBIDDEN,
             WcaKeyNotFoundException,
-            "A WCA Api Key was expected but not found for playbook explanation",
+            "A WCA Api Key was expected but not found. Please contact your administrator.",
         )
 
     def test_missing_model_id(self):
@@ -2920,7 +2920,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.FORBIDDEN,
             WcaModelIdNotFoundException,
-            "A WCA Model ID was expected but not found for playbook explanation",
+            "A WCA Model ID was expected but not found. Please contact your administrator.",
         )
 
     def test_missing_default_model_id(self):
@@ -2932,7 +2932,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.FORBIDDEN,
             WcaNoDefaultModelIdException,
-            "A default WCA Model ID was expected but not found for playbook explanation",
+            "No default WCA Model ID was found.",
         )
 
     def test_request_id_correlation_failure(self):
@@ -2948,7 +2948,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.INTERNAL_SERVER_ERROR,
             WcaRequestIdCorrelationFailureException,
-            "WCA Request/Response ExplanationId correlation failed",
+            "WCA Request/Response Request Id correlation failed.",
         )
 
     def test_invalid_model_id(self):
@@ -2961,7 +2961,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.FORBIDDEN,
             WcaInvalidModelIdException,
-            "WCA Model ID is invalid for playbook explanation",
+            "WCA Model ID is invalid. Please contact your administrator.",
         )
 
     def test_empty_response(self):
@@ -2972,7 +2972,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.NO_CONTENT,
             WcaEmptyResponseException,
-            "WCA returned an empty response for playbook explanation",
+            "WCA returned an empty response.",
         )
 
     def test_cloudflare_rejection(self):
@@ -2981,7 +2981,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.BAD_REQUEST,
             WcaCloudflareRejectionException,
-            "Cloudflare rejected the request for playbook explanation",
+            "Cloudflare rejected the request. Please contact your administrator.",
         )
 
     def test_hap_filter(self):
@@ -2996,7 +2996,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.BAD_REQUEST,
             WcaHAPFilterRejectionException,
-            "WCA Hate, Abuse, and Profanity filter rejected the request for playbook explanation",
+            "WCA Hate, Abuse, and Profanity filter rejected the request.",
         )
 
     def test_user_trial_expired(self):
@@ -3008,7 +3008,7 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.FORBIDDEN,
             WcaUserTrialExpiredException,
-            "User trial expired, when requesting playbook explanation",
+            "User trial expired. Please contact your administrator.",
         )
 
     def test_wca_instance_deleted(self):
@@ -3025,7 +3025,8 @@ that are running Red Hat Enterprise Linux 9.
             model_client,
             HTTPStatus.IM_A_TEAPOT,
             WcaInstanceDeletedException,
-            "WCA Instance has been deleted when requesting playbook explanation",
+            "The WCA instance associated with the Model ID has been deleted."
+            "Please contact your administrator.",
         )
 
     def test_wca_request_with_model_id_given(self):


### PR DESCRIPTION
Introduce the `AACSAPIView` class to handle the generic parts of the view. For now, we use it only for the `Explanation` view and it will be extended to the other views later.

The class is in charge of:

- the Schema1 event creation and emission
- the exception handling
- the parameter handling (not in this PR, stay turned!)
