### PR TITLE
AAP-32268: Refactor ModelMeshClient into single responsibility. Fix casts. Add licenses.

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/bam/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/bam/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 from typing import Any, Callable, List, Optional, Union

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 import secrets

--- a/ansible_ai_connect/ai/api/model_pipelines/factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/factory.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 from typing import Optional, Type
 

--- a/ansible_ai_connect/ai/api/model_pipelines/grpc/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/grpc/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 from typing import Any, Dict
 

--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 from typing import Any, Dict

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 import re
 from textwrap import dedent

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 from typing import Any, Dict

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 
 from langchain.llms import Ollama

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Optional, TypeVar

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 import sys

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import logging
 from abc import ABCMeta
 from typing import TYPE_CHECKING, Any, Dict, Optional

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import base64
 import logging
 from abc import ABCMeta

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -1,3 +1,17 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import logging
 from abc import ABCMeta

--- a/ansible_ai_connect/ai/api/wca/api_key_views.py
+++ b/ansible_ai_connect/ai/api/wca/api_key_views.py
@@ -146,7 +146,7 @@ class WCAApiKeyView(RetrieveAPIView, CreateAPIView, DestroyAPIView):
 
             # Validate API Key
             _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-            model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+            model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
             model_meta_data.get_token(wca_key)
 
             # Store the validated API Key
@@ -295,7 +295,7 @@ class WCAApiKeyValidatorView(RetrieveAPIView):
 
             # Validate API Key
             _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-            model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+            model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
             secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
             api_key = secret_manager.get_secret(organization.id, Suffixes.API_KEY)
             if api_key is None:

--- a/ansible_ai_connect/ai/api/wca/tests/test_api_key_views.py
+++ b/ansible_ai_connect/ai/api/wca/tests/test_api_key_views.py
@@ -168,7 +168,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         self.user.rh_user_has_seat = has_seat
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -211,7 +211,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_set_key_with_invalid_value(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -240,7 +240,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         self.client.force_authenticate(user=self.user)
         mock_model_meta_data.get_token = Mock(return_value="token")
         mock_secret_manager.save_secret.side_effect = WcaSecretManagerError("Test")
@@ -258,7 +258,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_set_key_throws_http_exception(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         self.client.force_authenticate(user=self.user)
         mock_model_meta_data.get_token = Mock(side_effect=WcaTokenFailure())
         with self.assertLogs(logger="root", level="DEBUG") as log:
@@ -297,7 +297,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_delete_key(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -369,7 +369,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_delete_key_with_model_id_deletion_error(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -419,7 +419,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_delete_key_with_api_key_deletion_error(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -469,7 +469,7 @@ class TestWCAApiKeyView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
     def test_delete_key_with_no_model_id(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         self.client.force_authenticate(user=self.user)
 
@@ -596,7 +596,7 @@ class TestWCAApiKeyValidatorView(WisdomAppsBackendMocking, WisdomServiceAPITestC
         self.user.rh_user_has_seat = has_seat
         mock_secret_manager = apps.get_app_config("ai").get_wca_secret_manager()
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         self.client.force_authenticate(user=self.user)
 
         mock_model_meta_data.get_token = Mock(return_value="token")
@@ -623,7 +623,7 @@ class TestWCAApiKeyValidatorView(WisdomAppsBackendMocking, WisdomServiceAPITestC
     def test_validate_key_with_invalid_value(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         self.client.force_authenticate(user=self.user)
         mock_model_meta_data.get_token = Mock(
             side_effect=WcaTokenFailureApiKeyError("Something went wrong")
@@ -638,7 +638,7 @@ class TestWCAApiKeyValidatorView(WisdomAppsBackendMocking, WisdomServiceAPITestC
     def test_validate_key_throws_http_exception(self, *args):
         self.user.organization = Organization.objects.get_or_create(id=123)[0]
         _md = apps.get_app_config("ai").get_model_pipeline(MetaData)
-        mock_model_meta_data: WCASaaSMetaData = cast(_md, WCASaaSMetaData)
+        mock_model_meta_data: WCASaaSMetaData = cast(WCASaaSMetaData, _md)
         self.client.force_authenticate(user=self.user)
         mock_model_meta_data.get_token = Mock(side_effect=WcaTokenFailure("Something went wrong"))
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-32268

## Description
Following #1343 this PR fixes an issues with use of `cast(..)` and adds licences to new files.

The failure was spotted during execution of our [CI pipeline](https://github.com/ansible/ansible-wisdom-testing/actions/runs/11372520531/job/31637023512).

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
