### PR TITLE
AAP-33632: ModelPipelines: Implement invoke(..) method

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/bam/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/bam/pipelines.py
@@ -29,6 +29,10 @@ from ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines import (
     LangchainPlaybookExplanationPipeline,
     LangchainPlaybookGenerationPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ContentMatchParameters,
+    ContentMatchResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,9 +105,6 @@ class BAMCompletionsPipeline(LangchainCompletionsPipeline):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
@@ -121,10 +122,7 @@ class BAMContentMatchPipeline(LangchainContentMatchPipeline):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def codematch(self, request, model_input, model_id):
+    def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -141,9 +139,6 @@ class BAMPlaybookGenerationPipeline(LangchainPlaybookGenerationPipeline):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
     def get_chat_model(self, model_id):
         return ChatBAM(
             api_key=settings.ANSIBLE_AI_MODEL_MESH_API_KEY,
@@ -157,9 +152,6 @@ class BAMPlaybookExplanationPipeline(LangchainPlaybookExplanationPipeline):
 
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
-
-    def invoke(self):
-        raise NotImplementedError
 
     def get_chat_model(self, model_id):
         return ChatBAM(

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -16,17 +16,24 @@ import json
 import logging
 import secrets
 import time
-from typing import Any, Dict
 
 import requests
 from django.conf import settings
 
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    CompletionsParameters,
+    CompletionsResponse,
+    ContentMatchParameters,
+    ContentMatchResponse,
     MetaData,
     ModelPipelineCompletions,
     ModelPipelineContentMatch,
     ModelPipelinePlaybookExplanation,
     ModelPipelinePlaybookGeneration,
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -87,10 +94,7 @@ class DummyCompletionsPipeline(DummyMetaData, ModelPipelineCompletions):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def invoke(self, params: CompletionsParameters) -> CompletionsResponse:
         logger.debug("!!!! settings.ANSIBLE_AI_MODEL_MESH_API_TYPE == 'dummy' !!!!")
         logger.debug("!!!! Mocking Model response !!!!")
         if settings.DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER:
@@ -111,10 +115,7 @@ class DummyContentMatchPipeline(DummyMetaData, ModelPipelineContentMatch):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def codematch(self, request, model_input, model_id):
+    def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
 
@@ -123,19 +124,8 @@ class DummyPlaybookGenerationPipeline(DummyMetaData, ModelPipelinePlaybookGenera
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def generate_playbook(
-        self,
-        request,
-        text: str = "",
-        custom_prompt: str = "",
-        create_outline: bool = False,
-        outline: str = "",
-        generation_id: str = "",
-        model_id: str = "",
-    ) -> tuple[str, str, list]:
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
+        create_outline = params.create_outline
         if create_outline:
             return PLAYBOOK, OUTLINE, []
         return PLAYBOOK, "", []
@@ -146,15 +136,5 @@ class DummyPlaybookExplanationPipeline(DummyMetaData, ModelPipelinePlaybookExpla
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def explain_playbook(
-        self,
-        request,
-        content: str,
-        custom_prompt: str = "",
-        explanation_id: str = "",
-        model_id: str = "",
-    ) -> str:
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         return EXPLANATION

--- a/ansible_ai_connect/ai/api/model_pipelines/grpc/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/grpc/pipelines.py
@@ -27,11 +27,19 @@ from ansible_ai_connect.ai.api.model_pipelines.grpc.grpc_pb import (
     wisdomextservice_pb2_grpc,
 )
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    CompletionsParameters,
+    CompletionsResponse,
+    ContentMatchParameters,
+    ContentMatchResponse,
     MetaData,
     ModelPipelineCompletions,
     ModelPipelineContentMatch,
     ModelPipelinePlaybookExplanation,
     ModelPipelinePlaybookGeneration,
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
 )
 from ansible_ai_connect.healthcheck.backends import (
     ERROR_MESSAGE,
@@ -61,8 +69,37 @@ class GrpcCompletionsPipeline(GrpcMetaData, ModelPipelineCompletions):
         super().__init__(inference_url=inference_url)
         self._inference_stub = self.get_inference_stub()
 
-    def invoke(self):
-        raise NotImplementedError
+    def invoke(self, params: CompletionsParameters) -> CompletionsResponse:
+        request = params.request
+        model_id = params.model_id
+        model_input = params.model_input
+        model_id = self.get_model_id(request.user, None, model_id)
+        logger.debug(f"Input prompt: {model_input}")
+        prompt = model_input.get("instances", [{}])[0].get("prompt", "")
+        context = model_input.get("instances", [{}])[0].get("context", "")
+        logger.debug(f"Input prompt: {prompt}")
+        logger.debug(f"Input context: {context}")
+
+        try:
+            task_count = len(get_task_names_from_prompt(prompt))
+            response = self._inference_stub.AnsiblePredict(
+                request=ansiblerequest_pb2.AnsibleRequest(  # type: ignore
+                    prompt=prompt, context=context
+                ),
+                metadata=[("mm-vmodel-id", model_id)],
+                timeout=self.timeout(task_count),
+            )
+
+            logger.debug(f"inference response: {response}")
+            logger.debug(f"inference response: {response.text}")
+            result: Dict[str, Any] = {"predictions": [response.text], "model_id": model_id}
+            return result
+        except grpc.RpcError as exc:
+            if exc.code() == grpc.StatusCode.DEADLINE_EXCEEDED:  # type: ignore
+                raise ModelTimeoutError
+            else:
+                logger.error(f"gRPC client error: {exc.details()}")  # type: ignore
+                raise
 
     def get_inference_stub(self) -> wisdomextservice_pb2_grpc.WisdomExtServiceStub:
         logger.debug("Inference URL: " + self._inference_url)
@@ -94,35 +131,6 @@ class GrpcCompletionsPipeline(GrpcMetaData, ModelPipelineCompletions):
             )
         return summary
 
-    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
-        model_id = self.get_model_id(request.user, None, model_id)
-        logger.debug(f"Input prompt: {model_input}")
-        prompt = model_input.get("instances", [{}])[0].get("prompt", "")
-        context = model_input.get("instances", [{}])[0].get("context", "")
-        logger.debug(f"Input prompt: {prompt}")
-        logger.debug(f"Input context: {context}")
-
-        try:
-            task_count = len(get_task_names_from_prompt(prompt))
-            response = self._inference_stub.AnsiblePredict(
-                request=ansiblerequest_pb2.AnsibleRequest(  # type: ignore
-                    prompt=prompt, context=context
-                ),
-                metadata=[("mm-vmodel-id", model_id)],
-                timeout=self.timeout(task_count),
-            )
-
-            logger.debug(f"inference response: {response}")
-            logger.debug(f"inference response: {response.text}")
-            result: Dict[str, Any] = {"predictions": [response.text], "model_id": model_id}
-            return result
-        except grpc.RpcError as exc:
-            if exc.code() == grpc.StatusCode.DEADLINE_EXCEEDED:  # type: ignore
-                raise ModelTimeoutError
-            else:
-                logger.error(f"gRPC client error: {exc.details()}")  # type: ignore
-                raise
-
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
@@ -132,10 +140,7 @@ class GrpcContentMatchPipeline(GrpcMetaData, ModelPipelineContentMatch):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def codematch(self, request, model_input, model_id):
+    def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
 
@@ -144,19 +149,7 @@ class GrpcPlaybookGenerationPipeline(GrpcMetaData, ModelPipelinePlaybookGenerati
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def generate_playbook(
-        self,
-        request,
-        text: str = "",
-        custom_prompt: str = "",
-        create_outline: bool = False,
-        outline: str = "",
-        generation_id: str = "",
-        model_id: str = "",
-    ) -> tuple[str, str, list]:
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
         raise NotImplementedError
 
 
@@ -165,15 +158,5 @@ class GrpcPlaybookExplanationPipeline(GrpcMetaData, ModelPipelinePlaybookExplana
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def explain_playbook(
-        self,
-        request,
-        content: str,
-        custom_prompt: str = "",
-        explanation_id: str = "",
-        model_id: str = "",
-    ) -> str:
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -23,6 +23,10 @@ from ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines import (
     LangchainPlaybookExplanationPipeline,
     LangchainPlaybookGenerationPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ContentMatchParameters,
+    ContentMatchResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +41,6 @@ class OllamaCompletionsPipeline(LangchainCompletionsPipeline):
 
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
-
-    def invoke(self):
-        raise NotImplementedError
 
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
@@ -56,10 +57,7 @@ class OllamaContentMatchPipeline(LangchainContentMatchPipeline):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def codematch(self, request, model_input, model_id):
+    def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -74,9 +72,6 @@ class OllamaPlaybookGenerationPipeline(LangchainPlaybookGenerationPipeline):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
     def get_chat_model(self, model_id):
         return Ollama(
             base_url=self._inference_url,
@@ -88,9 +83,6 @@ class OllamaPlaybookExplanationPipeline(LangchainPlaybookExplanationPipeline):
 
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
-
-    def invoke(self):
-        raise NotImplementedError
 
     def get_chat_model(self, model_id):
         return Ollama(

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_bam_client.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_bam_client.py
@@ -22,6 +22,7 @@ from responses import matchers
 from ansible_ai_connect.ai.api.model_pipelines.bam.pipelines import (
     BAMCompletionsPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import CompletionsParameters
 
 
 class TestBam(TestCase):
@@ -90,5 +91,7 @@ class TestBam(TestCase):
             },
         )
 
-        response = model_client.infer(request=Mock(), model_input=self.model_input, model_id=model)
+        response = model_client.invoke(
+            CompletionsParameters.init(request=Mock(), model_input=self.model_input, model_id=model)
+        )
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_langchain.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_langchain.py
@@ -15,6 +15,10 @@ from ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines import (
     unwrap_playbook_answer,
     unwrap_task_answer,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    PlaybookExplanationParameters,
+    PlaybookGenerationParameters,
+)
 from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 
 logger = logging.getLogger(__name__)
@@ -125,16 +129,18 @@ class TestLangChainPlaybookGenerationPipeline(WisdomServiceLogAwareTestCase):
         self.my_client.get_chat_model = fake_get_chat_mode
 
     def test_generate_playbook(self):
-        playbook, outline, warnings = self.my_client.generate_playbook(
-            request=Mock(),
-            text="foo",
+        playbook, outline, warnings = self.my_client.invoke(
+            PlaybookGenerationParameters.init(
+                request=Mock(),
+                text="foo",
+            )
         )
         self.assertEqual(playbook, "my_playbook")
         self.assertEqual(outline, "")
 
     def test_generate_playbook_with_outline(self):
-        playbook, outline, warnings = self.my_client.generate_playbook(
-            request=Mock(), text="foo", create_outline=True
+        playbook, outline, warnings = self.my_client.invoke(
+            PlaybookGenerationParameters.init(request=Mock(), text="foo", create_outline=True)
         )
         self.assertEqual(playbook, "my_playbook")
         self.assertEqual(outline, "my outline")
@@ -145,11 +151,13 @@ class TestLangChainPlaybookGenerationPipeline(WisdomServiceLogAwareTestCase):
                 logger="ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines", level="INFO"
             ) as log,
         ):
-            playbook, outline, warnings = self.my_client.generate_playbook(
-                request=Mock(),
-                text="foo",
-                create_outline=True,
-                custom_prompt="You are an Ansible expert.",
+            playbook, outline, warnings = self.my_client.invoke(
+                PlaybookGenerationParameters.init(
+                    request=Mock(),
+                    text="foo",
+                    create_outline=True,
+                    custom_prompt="You are an Ansible expert.",
+                )
             )
             self.assertInLog(
                 "custom_prompt is not supported for generate_playbook and will be ignored.", log
@@ -169,7 +177,9 @@ class TestLangChainPlaybookExplanationPipeline(WisdomServiceLogAwareTestCase):
         self.my_client.get_chat_model = fake_get_chat_mode
 
     def test_explain_playbook(self):
-        explanation = self.my_client.explain_playbook(request=Mock(), content="foo")
+        explanation = self.my_client.invoke(
+            PlaybookExplanationParameters.init(request=Mock(), content="foo")
+        )
         self.assertTrue(explanation)
 
     def test_explain_playbook_with_custom_prompt(self):
@@ -178,8 +188,10 @@ class TestLangChainPlaybookExplanationPipeline(WisdomServiceLogAwareTestCase):
                 logger="ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines", level="INFO"
             ) as log,
         ):
-            explanation = self.my_client.explain_playbook(
-                request=Mock(), content="foo", custom_prompt="You are an Ansible expert."
+            explanation = self.my_client.invoke(
+                PlaybookExplanationParameters.init(
+                    request=Mock(), content="foo", custom_prompt="You are an Ansible expert."
+                )
             )
             self.assertInLog(
                 "custom_prompt is not supported for explain_playbook and will be ignored.", log
@@ -188,8 +200,10 @@ class TestLangChainPlaybookExplanationPipeline(WisdomServiceLogAwareTestCase):
 
     def test_explain_playbook_with_model_id(self):
         with (self.assertLogs(logger=logger, level="DEBUG") as log,):
-            explanation = self.my_client.explain_playbook(
-                request=Mock(), content="foo", model_id="mymodel"
+            explanation = self.my_client.invoke(
+                PlaybookExplanationParameters.init(
+                    request=Mock(), content="foo", model_id="mymodel"
+                )
             )
             self.assertInLog("get_chat_mode: model_id=mymodel", log)
             self.assertTrue(explanation)

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_llamacpp_client.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_llamacpp_client.py
@@ -24,6 +24,7 @@ from ansible_ai_connect.ai.api.model_pipelines.exceptions import ModelTimeoutErr
 from ansible_ai_connect.ai.api.model_pipelines.llamacpp.pipelines import (
     LlamaCppCompletionsPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import CompletionsParameters
 
 
 class TestLlamaCPPClient(TestCase):
@@ -68,7 +69,9 @@ class TestLlamaCPPClient(TestCase):
             },
         )
 
-        response = model_client.infer(request=Mock(), model_input=self.model_input)
+        response = model_client.invoke(
+            CompletionsParameters.init(request=Mock(), model_input=self.model_input)
+        )
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))
 
     @responses.activate
@@ -95,7 +98,9 @@ class TestLlamaCPPClient(TestCase):
             },
         )
 
-        response = model_client.infer(request=Mock(), model_input=self.model_input, model_id=model)
+        response = model_client.invoke(
+            CompletionsParameters.init(request=Mock(), model_input=self.model_input, model_id=model)
+        )
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_MODEL_ID="test")
@@ -104,4 +109,6 @@ class TestLlamaCPPClient(TestCase):
         model_client = LlamaCppCompletionsPipeline(inference_url=self.inference_url)
         model_client.session.post = Mock(side_effect=ReadTimeout())
         with self.assertRaises(ModelTimeoutError):
-            model_client.infer(request=Mock(), model_input=self.model_input)
+            model_client.invoke(
+                CompletionsParameters.init(request=Mock(), model_input=self.model_input)
+            )

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_ollama_client.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_ollama_client.py
@@ -21,6 +21,7 @@ from django.test import TestCase
 from ansible_ai_connect.ai.api.model_pipelines.ollama.pipelines import (
     OllamaCompletionsPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import CompletionsParameters
 
 
 class TestOllama(TestCase):
@@ -48,5 +49,9 @@ class TestOllama(TestCase):
 
         m_ollama.return_value = final
         model_client = OllamaCompletionsPipeline("http://localhost")
-        response = model_client.infer(request=Mock(), model_input=self.model_input, model_id="test")
+        response = model_client.invoke(
+            CompletionsParameters.init(
+                request=Mock(), model_input=self.model_input, model_id="test"
+            )
+        )
         self.assertEqual(json.dumps(self.expected_response), json.dumps(response))

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
@@ -14,16 +14,24 @@
 
 import logging
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ansible_ai_connect.ai.api.model_pipelines.exceptions import WcaTokenFailure
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    CompletionsParameters,
+    CompletionsResponse,
+    ContentMatchParameters,
+    ContentMatchResponse,
     MetaData,
     ModelPipeline,
     ModelPipelineCompletions,
     ModelPipelineContentMatch,
     ModelPipelinePlaybookExplanation,
     ModelPipelinePlaybookGeneration,
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
 )
 
 if TYPE_CHECKING:
@@ -43,7 +51,7 @@ class WCADummyMetaData(MetaData):
         self,
         user: User,
         organization_id: Optional[int] = None,
-        requested_model_id: str = "",
+        requested_model_id: Optional[str] = None,
     ) -> str:
         return requested_model_id or ""
 
@@ -64,10 +72,7 @@ class WCADummyCompletionsPipeline(WCADummyPipeline, ModelPipelineCompletions):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def infer(self, request, model_input, model_id="", suggestion_id=None) -> Dict[str, Any]:
+    def invoke(self, params: CompletionsParameters) -> CompletionsResponse:
         return {
             "model_id": "mocked_wca_client",
             "predictions": ["      ansible.builtin.apt:\n        name: apache2"],
@@ -82,10 +87,7 @@ class WCADummyContentMatchPipeline(WCADummyPipeline, ModelPipelineContentMatch):
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def codematch(self, request, model_input, model_id):
+    def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
 
@@ -94,19 +96,7 @@ class WCADummyPlaybookGenerationPipeline(WCADummyPipeline, ModelPipelinePlaybook
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def generate_playbook(
-        self,
-        request,
-        text: str = "",
-        custom_prompt: str = "",
-        create_outline: bool = False,
-        outline: str = "",
-        generation_id: str = "",
-        model_id: str = "",
-    ) -> tuple[str, str, list]:
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
         raise NotImplementedError
 
 
@@ -115,15 +105,5 @@ class WCADummyPlaybookExplanationPipeline(WCADummyPipeline, ModelPipelinePlayboo
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
-    def explain_playbook(
-        self,
-        request,
-        content: str,
-        custom_prompt: str = "",
-        explanation_id: str = "",
-        model_id: str = "",
-    ) -> str:
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -25,6 +25,12 @@ from ansible_ai_connect.ai.api.model_pipelines.exceptions import (
     WcaModelIdNotFound,
     WcaUsernameNotFound,
 )
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
+)
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     WCA_REQUEST_ID_HEADER,
     WCABaseCompletionsPipeline,
@@ -63,7 +69,7 @@ class WCAOnPremMetaData(WCABaseMetaData):
         self,
         user,
         organization_id: Optional[int] = None,
-        requested_model_id: str = "",
+        requested_model_id: Optional[str] = None,
     ) -> str:
         if requested_model_id:
             # requested_model_id defined: let them use what they ask for
@@ -109,9 +115,6 @@ class WCAOnPremCompletionsPipeline(WCAOnPremPipeline, WCABaseCompletionsPipeline
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
-
     def self_test(self) -> HealthCheckSummary:
         wca_api_key = settings.ANSIBLE_WCA_HEALTHCHECK_API_KEY
         wca_model_id = settings.ANSIBLE_WCA_HEALTHCHECK_MODEL_ID
@@ -146,9 +149,6 @@ class WCAOnPremContentMatchPipeline(WCAOnPremPipeline, WCABaseContentMatchPipeli
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
         return self._get_base_headers(api_key)
 
-    def invoke(self):
-        raise NotImplementedError
-
     def self_test(self):
         raise NotImplementedError
 
@@ -158,23 +158,11 @@ class WCAOnPremPlaybookGenerationPipeline(WCAOnPremPipeline, WCABasePlaybookGene
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
+        raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError
-
-    def generate_playbook(
-        self,
-        request,
-        text: str = "",
-        custom_prompt: str = "",
-        create_outline: bool = False,
-        outline: str = "",
-        generation_id: str = "",
-        model_id: str = "",
-    ) -> tuple[str, str, list]:
-        raise FeatureNotAvailable
 
 
 class WCAOnPremPlaybookExplanationPipeline(WCAOnPremPipeline, WCABasePlaybookExplanationPipeline):
@@ -182,18 +170,8 @@ class WCAOnPremPlaybookExplanationPipeline(WCAOnPremPipeline, WCABasePlaybookExp
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
-    def invoke(self):
-        raise NotImplementedError
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
+        raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError
-
-    def explain_playbook(
-        self,
-        request,
-        content: str,
-        custom_prompt: str = "",
-        explanation_id: str = "",
-        model_id: str = "",
-    ) -> str:
-        raise FeatureNotAvailable

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
@@ -55,7 +55,10 @@ from ansible_ai_connect.ai.api.model_pipelines.exceptions import (
     WcaRequestIdCorrelationFailure,
     WcaUserTrialExpired,
 )
-from ansible_ai_connect.ai.api.model_pipelines.pipelines import ModelPipelineCompletions
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    CompletionsParameters,
+    ModelPipelineCompletions,
+)
 from ansible_ai_connect.ai.api.pipelines.common import PipelineElement
 from ansible_ai_connect.ai.api.pipelines.completion_context import CompletionContext
 from ansible_ai_connect.ai.api.utils.segment import send_segment_event
@@ -105,8 +108,13 @@ class InferenceStage(PipelineElement):
         event_name = None
         start_time = time.time()
         try:
-            predictions = model_mesh_client.infer(
-                request, data, model_id=model_id, suggestion_id=suggestion_id
+            predictions = model_mesh_client.invoke(
+                CompletionsParameters.init(
+                    request=request,
+                    model_input=data,
+                    model_id=model_id,
+                    suggestion_id=suggestion_id,
+                )
             )
             model_id = predictions.get("model_id", model_id)
         except ModelTimeoutError as e:

--- a/ansible_ai_connect/ai/api/tests/test_api_timeout.py
+++ b/ansible_ai_connect/ai/api/tests/test_api_timeout.py
@@ -31,7 +31,9 @@ from ansible_ai_connect.ai.api.model_pipelines.http.pipelines import (
     HttpCompletionsPipeline,
     HttpMetaData,
 )
-from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_saas import WCASaaSPipeline
+from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_saas import (
+    WCASaaSCompletionsPipeline,
+)
 
 from .test_views import WisdomServiceAPITestCaseBase
 
@@ -75,17 +77,17 @@ class TestApiTimeout(WisdomServiceAPITestCaseBase):
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=None)
     def test_timeout_settings_is_none_wca(self):
-        model_client = WCASaaSPipeline(inference_url="http://example.com/")
+        model_client = WCASaaSCompletionsPipeline(inference_url="http://example.com/")
         self.assertIsNone(model_client.timeout(1))
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=123)
     def test_timeout_settings_is_not_none_wca(self):
-        model_client = WCASaaSPipeline(inference_url="http://example.com/")
+        model_client = WCASaaSCompletionsPipeline(inference_url="http://example.com/")
         self.assertEqual(123, model_client.timeout(1))
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_API_TIMEOUT=123)
     def test_timeout_settings_is_not_none_wca_multitask(self):
-        model_client = WCASaaSPipeline(inference_url="http://example.com/")
+        model_client = WCASaaSCompletionsPipeline(inference_url="http://example.com/")
         self.assertEqual(123 * 2, model_client.timeout(2))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)

--- a/ansible_ai_connect/main/tests/test_middleware.py
+++ b/ansible_ai_connect/main/tests/test_middleware.py
@@ -25,7 +25,7 @@ from django.urls import reverse
 from segment import analytics
 
 from ansible_ai_connect.ai.api.tests.test_views import (
-    MockedMeshClient,
+    MockedPipelineCompletions,
     WisdomAppsBackendMocking,
 )
 from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
@@ -81,7 +81,7 @@ class TestMiddleware(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBaseOIDC)
         with patch.object(
             apps.get_app_config("ai"),
             "get_model_pipeline",
-            Mock(return_value=MockedMeshClient(self, expected, response_data)),
+            Mock(return_value=MockedPipelineCompletions(self, expected, response_data)),
         ):
             with self.assertLogs(logger="root", level="DEBUG") as log:
                 r = self.client.post(reverse("completions"), payload, format="json")
@@ -201,7 +201,7 @@ class TestMiddleware(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBaseOIDC)
             with patch.object(
                 apps.get_app_config("ai"),
                 "get_model_pipeline",
-                Mock(return_value=MockedMeshClient(self, payload, response_data)),
+                Mock(return_value=MockedPipelineCompletions(self, payload, response_data)),
             ):
                 with self.assertLogs(logger="root", level="DEBUG") as log:
                     r = self.client.post(reverse("completions"), payload, format="json")
@@ -247,7 +247,7 @@ class TestMiddleware(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBaseOIDC)
             with patch.object(
                 apps.get_app_config("ai"),
                 "get_model_pipeline",
-                Mock(return_value=MockedMeshClient(self, payload, response_data)),
+                Mock(return_value=MockedPipelineCompletions(self, payload, response_data)),
             ):
                 with self.assertLogs(logger="root", level="DEBUG") as log:
                     r = self.client.post(reverse("completions"), payload, format="json")
@@ -316,7 +316,7 @@ class TestMiddleware(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBaseOIDC)
         with patch.object(
             apps.get_app_config("ai"),
             "get_model_pipeline",
-            Mock(return_value=MockedMeshClient(self, payload, response_data)),
+            Mock(return_value=MockedPipelineCompletions(self, payload, response_data)),
         ):
             with self.assertLogs(logger="root", level="DEBUG") as log:
                 self.client.post(reverse("completions"), payload, format="json")


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-33632

## Description
Refactoring away of explicit `infer(..)`, `codematch(..)`, `generate_playbook(..)` and `explain_playbook(..)` methods.

A single `invoke(..)` method exists on a given _pipeline_. The parameters for each _feature_ differ.

## Testing
N/A Refactoring exercise.

### Steps to test
1. Pull down the PR
2. Run Wisdom Service locally
3. Connect with VSCode
4. Check things stil work

### Scenarios tested
As above

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
