### PR TITLE
Duplicated chatbot message box issue

### DIFF
--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -539,6 +539,7 @@ WCA_ENABLE_ARI_POSTPROCESS = os.getenv("WCA_ENABLE_ARI_POSTPROCESS", "False").lo
 CSP_DEFAULT_SRC = ("'self'", "data:")
 CSP_INCLUDE_NONCE_IN = ["script-src-elem"]
 CSP_CONNECT_SRC = "'self'"
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
 
 # Region for where the service is deployed. Used by the Health Check endpoint.
 DEPLOYED_REGION = os.getenv("DEPLOYED_REGION") or "unknown"

--- a/ansible_ai_connect/main/tests/test_urls.py
+++ b/ansible_ai_connect/main/tests/test_urls.py
@@ -43,7 +43,7 @@ class TestUrls(TestCase):
         client = Client()
         response = client.get("/")
         csp_headers = response.headers.get("Content-Security-Policy")
-        self.assertNotIn("style-src 'self' 'unsafe-inline'", csp_headers)
+        self.assertIn("style-src 'self' 'unsafe-inline'", csp_headers)
         self.assertIn("default-src 'self' data:", csp_headers)
         self.assertIn("connect-src 'self'", csp_headers)
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-34074>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

The styles applied to the chatbot message box are set by using inline styles.  When the chatbot is loaded from the STAGE server, the following warning message shows up in the development console:

> index-CXRSxDSp.js:55 Refused to apply inline style because it violates the following Content Security Policy directive: "default-src 'self' data:". Either the 'unsafe-inline' keyword, a hash ('sha256-lmsyJ3MLn/9zJPUSTRtlKyXRD2upigFYpVAUZs6+KS8='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'style-src' was not explicitly set, so 'default-src' is used as a fallback.


Actually the same message shows up when the chatbot is loaded from a local server. However, when it was loaded from a local server, the styles are applied and no issues are found on UI.

This warning message can be suppressed by specifying the following setting for Django CSP:

```
CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
```
The string 'unsafe-inline' looks scary, but according to [the reply on this Stackoverflow page](https://stackoverflow.com/questions/68459561/content-security-policy-blocks-angular-styles), it should be fine for `CSP_STYLE_SRC`.  It is the change contained in this PR.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the AI Connect service
3. Login through Red Hat SSO and open the chatbot page
4. Open Developer Console and make sure no warning message is found

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
See above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
