### PR TITLE
PR to upgrade node from 20.x to 21.x

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '20.x'
+        node-version: '21.x'
         cache: 'npm'
         cache-dependency-path: ./ansible_ai_connect_admin_portal/package-lock.json
 
@@ -111,7 +111,7 @@ jobs:
     - name: Use Node.js (chatbot)
       uses: actions/setup-node@v3
       with:
-        node-version: '20.x'
+        node-version: '21.x'
         cache: 'npm'
         cache-dependency-path: ./ansible_ai_connect_chatbot/package-lock.json
 

--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '21.x'
           cache: 'npm'
           cache-dependency-path: ${{env.WORKING_DIRECTORY}}/package-lock.json
 

--- a/.github/workflows/npm_audit_chatbot.yml
+++ b/.github/workflows/npm_audit_chatbot.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '21.x'
           cache: 'npm'
           cache-dependency-path: ${{env.WORKING_DIRECTORY}}/package-lock.json
 

--- a/.github/workflows/ui_compile.yml
+++ b/.github/workflows/ui_compile.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '21.x'
           cache: 'npm'
           cache-dependency-path: ${{env.WORKING_DIRECTORY}}/package-lock.json
 

--- a/.github/workflows/ui_compile_chatbot.yml
+++ b/.github/workflows/ui_compile_chatbot.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '21.x'
           cache: 'npm'
           cache-dependency-path: ${{env.WORKING_DIRECTORY}}/package-lock.json
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: related to https://issues.redhat.com/browse/AAP-31381
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
PR to update node version to 21.x from existing 20.x. This is to fix the CVE around serialize-javascript, please ref the https://github.com/ansible/ansible-ai-connect-service/pull/1353#issuecomment-2429222264

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Install node 21.x in your machine
3. Run `npm install`, and the [CI failure](https://github.com/ansible/ansible-ai-connect-service/actions/runs/11459341065/job/31883616193?pr=1353#step:4:22) observed here should not be observable with the upgraded node.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
NA

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
