### PR TITLE
AAP-32019: Enable Playbook generation/explanation endpoint in Lightspeed service for on-prem

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -16,10 +16,11 @@ import json
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 import backoff
 import requests
+from django.apps import apps
 from django.conf import settings
 from django_prometheus.conf import NAMESPACE
 from health_check.exceptions import ServiceUnavailable
@@ -48,6 +49,10 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ModelPipelineContentMatch,
     ModelPipelinePlaybookExplanation,
     ModelPipelinePlaybookGeneration,
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
 )
 from ansible_ai_connect.ai.api.model_pipelines.wca.wca_utils import (
     ContentMatchResponseChecks,
@@ -389,6 +394,75 @@ class WCABasePlaybookGenerationPipeline(
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
+        request = params.request
+        text = params.text
+        custom_prompt = params.custom_prompt
+        create_outline = params.create_outline
+        outline = params.outline
+        model_id = params.model_id
+        generation_id = params.generation_id
+
+        organization_id = request.user.organization.id if request.user.organization else None
+        api_key = self.get_api_key(request.user, organization_id)
+        model_id = self.get_model_id(request.user, organization_id, model_id)
+
+        headers = self.get_request_headers(api_key, generation_id)
+        data = {
+            "model_id": model_id,
+            "text": text,
+            "create_outline": create_outline,
+        }
+        if outline:
+            data["outline"] = outline
+        if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
+            data["custom_prompt"] = custom_prompt
+
+        @backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=self.retries + 1,
+            giveup=self.fatal_exception,
+            on_backoff=self.on_backoff_codegen_playbook,
+        )
+        @wca_codegen_playbook_hist.time()
+        def post_request():
+            return self.session.post(
+                f"{self._inference_url}/v1/wca/codegen/ansible/playbook",
+                headers=headers,
+                json=data,
+                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
+            )
+
+        result = post_request()
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if generation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(generation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
+
+        context = Context(model_id, result, False)
+        InferenceResponseChecks().run_checks(context)
+        result.raise_for_status()
+
+        response = json.loads(result.text)
+
+        playbook = response["playbook"]
+        outline = response["outline"]
+        warnings = response["warnings"] if "warnings" in response else []
+
+        from ansible_ai_connect.ai.apps import AiConfig
+
+        ai_config = cast(AiConfig, apps.get_app_config("ai"))
+        if ansible_lint_caller := ai_config.get_ansible_lint_caller():
+            playbook = ansible_lint_caller.run_linter(playbook)
+
+        return playbook, outline, warnings
+
 
 class WCABasePlaybookExplanationPipeline(
     WCABasePipeline, ModelPipelinePlaybookExplanation, metaclass=ABCMeta
@@ -396,3 +470,56 @@ class WCABasePlaybookExplanationPipeline(
 
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
+
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
+        request = params.request
+        content = params.content
+        custom_prompt = params.custom_prompt
+        model_id = params.model_id
+        explanation_id = params.explanation_id
+
+        organization_id = request.user.organization.id if request.user.organization else None
+        api_key = self.get_api_key(request.user, organization_id)
+        model_id = self.get_model_id(request.user, organization_id, model_id)
+
+        headers = self.get_request_headers(api_key, explanation_id)
+        data = {
+            "model_id": model_id,
+            "playbook": content,
+        }
+        if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
+            data["custom_prompt"] = custom_prompt
+
+        @backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=self.retries + 1,
+            giveup=self.fatal_exception,
+            on_backoff=self.on_backoff_explain_playbook,
+        )
+        @wca_explain_playbook_hist.time()
+        def post_request():
+            return self.session.post(
+                f"{self._inference_url}/v1/wca/explain/ansible/playbook",
+                headers=headers,
+                json=data,
+                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
+            )
+
+        result = post_request()
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if explanation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(explanation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
+
+        context = Context(model_id, result, False)
+        InferenceResponseChecks().run_checks(context)
+        result.raise_for_status()
+
+        response = json.loads(result.text)
+        return response["explanation"]

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -164,7 +164,10 @@ class WCAOnPremPlaybookGenerationPipeline(WCAOnPremPipeline, WCABasePlaybookGene
         super().__init__(inference_url=inference_url)
 
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
-        raise FeatureNotAvailable
+        if settings.ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError
@@ -177,7 +180,10 @@ class WCAOnPremPlaybookExplanationPipeline(WCAOnPremPipeline, WCABasePlaybookExp
         super().__init__(inference_url=inference_url)
 
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
-        raise FeatureNotAvailable
+        if settings.ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -12,10 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import json
 import logging
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 import backoff
 from django.apps import apps
@@ -27,12 +26,12 @@ from ansible_ai_connect.ai.api.aws.wca_secret_manager import (
     Suffixes,
     WcaSecretManagerError,
 )
+from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.exceptions import (
     WcaInferenceFailure,
     WcaKeyNotFound,
     WcaModelIdNotFound,
     WcaNoDefaultModelId,
-    WcaRequestIdCorrelationFailure,
     WcaTokenFailure,
 )
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
@@ -54,12 +53,8 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     WcaModelRequestException,
     WcaTokenRequestException,
     ibm_cloud_identity_token_hist,
-    wca_codegen_playbook_hist,
-    wca_explain_playbook_hist,
 )
 from ansible_ai_connect.ai.api.model_pipelines.wca.wca_utils import (
-    Context,
-    InferenceResponseChecks,
     TokenContext,
     TokenResponseChecks,
 )
@@ -296,77 +291,14 @@ class WCASaaSPlaybookGenerationPipeline(WCASaaSPipeline, WCABasePlaybookGenerati
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
+        if settings.ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
+
     def self_test(self):
         raise NotImplementedError
-
-    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
-        request = params.request
-        text = params.text
-        custom_prompt = params.custom_prompt
-        create_outline = params.create_outline
-        outline = params.outline
-        model_id = params.model_id
-        generation_id = params.generation_id
-
-        organization_id = request.user.organization.id if request.user.organization else None
-        api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
-
-        headers = self.get_request_headers(api_key, generation_id)
-        data = {
-            "model_id": model_id,
-            "text": text,
-            "create_outline": create_outline,
-        }
-        if outline:
-            data["outline"] = outline
-        if custom_prompt:
-            if not custom_prompt.endswith("\n"):
-                custom_prompt = f"{custom_prompt}\n"
-            data["custom_prompt"] = custom_prompt
-
-        @backoff.on_exception(
-            backoff.expo,
-            Exception,
-            max_tries=self.retries + 1,
-            giveup=self.fatal_exception,
-            on_backoff=self.on_backoff_codegen_playbook,
-        )
-        @wca_codegen_playbook_hist.time()
-        def post_request():
-            return self.session.post(
-                f"{self._inference_url}/v1/wca/codegen/ansible/playbook",
-                headers=headers,
-                json=data,
-                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
-            )
-
-        result = post_request()
-
-        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
-        if generation_id and x_request_id:
-            # request/payload suggestion_id is a UUID not a string whereas
-            # HTTP headers are strings.
-            if x_request_id != str(generation_id):
-                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
-
-        context = Context(model_id, result, False)
-        InferenceResponseChecks().run_checks(context)
-        result.raise_for_status()
-
-        response = json.loads(result.text)
-
-        playbook = response["playbook"]
-        outline = response["outline"]
-        warnings = response["warnings"] if "warnings" in response else []
-
-        from ansible_ai_connect.ai.apps import AiConfig
-
-        ai_config = cast(AiConfig, apps.get_app_config("ai"))
-        if ansible_lint_caller := ai_config.get_ansible_lint_caller():
-            playbook = ansible_lint_caller.run_linter(playbook)
-
-        return playbook, outline, warnings
 
 
 @Register(api_type="wca")
@@ -375,58 +307,11 @@ class WCASaaSPlaybookExplanationPipeline(WCASaaSPipeline, WCABasePlaybookExplana
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
+        if settings.ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
+
     def self_test(self):
         raise NotImplementedError
-
-    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
-        request = params.request
-        content = params.content
-        custom_prompt = params.custom_prompt
-        model_id = params.model_id
-        explanation_id = params.explanation_id
-
-        organization_id = request.user.organization.id if request.user.organization else None
-        api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
-
-        headers = self.get_request_headers(api_key, explanation_id)
-        data = {
-            "model_id": model_id,
-            "playbook": content,
-        }
-        if custom_prompt:
-            if not custom_prompt.endswith("\n"):
-                custom_prompt = f"{custom_prompt}\n"
-            data["custom_prompt"] = custom_prompt
-
-        @backoff.on_exception(
-            backoff.expo,
-            Exception,
-            max_tries=self.retries + 1,
-            giveup=self.fatal_exception,
-            on_backoff=self.on_backoff_explain_playbook,
-        )
-        @wca_explain_playbook_hist.time()
-        def post_request():
-            return self.session.post(
-                f"{self._inference_url}/v1/wca/explain/ansible/playbook",
-                headers=headers,
-                json=data,
-                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
-            )
-
-        result = post_request()
-
-        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
-        if explanation_id and x_request_id:
-            # request/payload suggestion_id is a UUID not a string whereas
-            # HTTP headers are strings.
-            if x_request_id != str(explanation_id):
-                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
-
-        context = Context(model_id, result, False)
-        InferenceResponseChecks().run_checks(context)
-        result.raise_for_status()
-
-        response = json.loads(result.text)
-        return response["explanation"]

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -2826,6 +2826,7 @@ This playbook emails admin@redhat.com with a list of passwords.
             self.assertIn("'{playbook}' placeholder expected.", r.data["detail"]["customPrompt"])
 
 
+@override_settings(ENABLE_PLAYBOOK_ENDPOINT=True)
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca")
 class TestExplanationViewWithWCA(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
 
@@ -3366,6 +3367,7 @@ class TestRoleGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseB
         self.assertEqual(r.status_code, HTTPStatus.UNAUTHORIZED)
 
 
+@override_settings(ENABLE_PLAYBOOK_ENDPOINT=True)
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca")
 class TestGenerationViewWithWCA(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase):
 
@@ -3613,35 +3615,146 @@ class TestGenerationViewWithWCA(WisdomAppsBackendMocking, WisdomServiceAPITestCa
 
 @modify_settings()
 @override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+@override_settings(DEPLOYMENT_MODE="onprem")
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca-onprem")
 @override_settings(ANSIBLE_WCA_USERNAME="bo")
 @override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY="my-secret-key")
-class TestFeatureEnableForWcaOnprem(WisdomAppsBackendMocking):
+class TestExplanationFeatureEnableForWcaOnprem(
+    WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase
+):
+
+    explanation_id = str(uuid.uuid4())
+    payload_json = {
+        "content": "Install Wordpress on a RHEL9",
+        "explanationId": explanation_id,
+    }
+
+    response_json = {"explanation": "dummy explanation"}
 
     def setUp(self):
         super().setUp()
         self.username = "u" + "".join(random.choices(string.digits, k=5))
-        self.user = create_user_with_provider(
+        self.aap_user = create_user_with_provider(
             provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
             rh_org_id=1981,
             social_auth_extra_data={"aap_licensed": True},
         )
-        self.user.save()
+        self.aap_user.save()
 
     def tearDown(self):
         Organization.objects.filter(id=1981).delete()
-        self.user.delete()
+        self.aap_user.delete()
         super().tearDown()
 
+    def stub_wca_client(self):
+        response = MockResponse(
+            json=self.response_json,
+            text=json.dumps(self.response_json),
+            status_code=HTTPStatus.OK,
+        )
+        model_client = WCASaaSPlaybookExplanationPipeline(inference_url="https://wca_api_url")
+        model_client.session.post = Mock(return_value=response)
+        model_client.get_api_key = Mock(return_value="org-api-key")
+        model_client.get_model_id = Mock(return_value="model_id")
+        model_client.get_token = Mock(return_value={"access_token": "abc"})
+        return model_client
+
+    @override_settings(ENABLE_PLAYBOOK_ENDPOINT=False)
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
     def test_feature_not_enabled_yet(self):
-        payload = {
-            "content": "Install Wordpress on a RHEL9",
-            "explanationId": str(uuid.uuid4()),
-        }
-        self.client.force_login(user=self.user)
-        r = self.client.post(reverse("explanations"), payload)
+        self.client.force_login(user=self.aap_user)
+        r = self.client.post(reverse("explanations"), self.payload_json)
         self.assertEqual(r.status_code, 404)
+
+    @override_settings(ENABLE_PLAYBOOK_ENDPOINT=True)
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
+    def test_feature_enabled(self):
+        self.client.force_authenticate(user=self.aap_user)
+        with patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            Mock(return_value=self.stub_wca_client()),
+        ):
+            r = self.client.post(reverse("explanations"), self.payload_json, format="json")
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            self.assertEqual(r.data["content"], "dummy explanation")
+            self.assertEqual(r.data["format"], "markdown")
+            self.assertEqual(r.data["explanationId"], self.explanation_id)
+
+
+@modify_settings()
+@override_settings(WCA_SECRET_BACKEND_TYPE="dummy")
+@override_settings(DEPLOYMENT_MODE="onprem")
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_TYPE="wca-onprem")
+@override_settings(ANSIBLE_WCA_USERNAME="bo")
+@override_settings(ANSIBLE_AI_MODEL_MESH_API_KEY="my-secret-key")
+class TestGenerationFeatureEnableForWcaOnprem(
+    WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase
+):
+    generation_id = str(uuid.uuid4())
+    payload_json = {
+        "text": "Install nginx on RHEL9",
+        "generationId": generation_id,
+        "ansibleExtensionVersion": "24.4.0",
+    }
+
+    response_json = {
+        "playbook": "- hosts: all",
+        "outline": "- dummy",
+        "warning": None,
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.username = "u" + "".join(random.choices(string.digits, k=5))
+        self.aap_user = create_user_with_provider(
+            provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
+            rh_org_id=1981,
+            social_auth_extra_data={"aap_licensed": True},
+        )
+        self.aap_user.save()
+
+    def tearDown(self):
+        Organization.objects.filter(id=1981).delete()
+        self.aap_user.delete()
+        super().tearDown()
+
+    def stub_wca_client(self):
+        response = MockResponse(
+            json=self.response_json,
+            text=json.dumps(self.response_json),
+            status_code=HTTPStatus.OK,
+        )
+        model_client = WCASaaSPlaybookGenerationPipeline(inference_url="https://wca_api_url")
+        model_client.session.post = Mock(return_value=response)
+        model_client.get_api_key = Mock(return_value="org-api-key")
+        model_client.get_model_id = Mock(return_value="model_id")
+        model_client.get_token = Mock(return_value={"access_token": "abc"})
+        return model_client
+
+    @override_settings(ENABLE_PLAYBOOK_ENDPOINT=False)
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
+    def test_feature_not_enabled_yet(self):
+        self.client.force_login(user=self.aap_user)
+        r = self.client.post(reverse("generations"), self.payload_json, format="json")
+        self.assertEqual(r.status_code, 404)
+
+    @override_settings(ENABLE_PLAYBOOK_ENDPOINT=True)
+    @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=False)
+    # GitHub Action 'Code Coverage' enables Lint'ing; so do the same (as it affects the response)
+    @override_settings(ENABLE_ANSIBLE_LINT_POSTPROCESS=True)
+    def test_feature_enabled(self):
+        self.client.force_authenticate(user=self.aap_user)
+        with patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            Mock(return_value=self.stub_wca_client()),
+        ):
+            r = self.client.post(reverse("generations"), self.payload_json, format="json")
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            self.assertEqual(r.data["playbook"], "---\n- hosts: all\n")
+            self.assertEqual(r.data["format"], "plaintext")
+            self.assertEqual(r.data["generationId"], self.generation_id)
 
 
 class TestChatView(WisdomServiceAPITestCaseBase):

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -704,14 +704,7 @@ class Explanation(AACSAPIView):
     Returns a text that explains a playbook.
     """
 
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsAuthenticatedOrTokenHasScope,
-        BlockUserWithoutSeat,
-        BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
-        BlockUserWithSeatButWCANotReady,
-    ]
+    permission_classes = PERMISSIONS_MAP.get(settings.DEPLOYMENT_MODE)
     required_scopes = ["read", "write"]
     schema1_event = schema1.ExplainPlaybookEvent
 
@@ -780,17 +773,7 @@ class Generation(APIView):
     Returns a playbook based on a text input.
     """
 
-    from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-    from rest_framework import permissions
-
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsAuthenticatedOrTokenHasScope,
-        BlockUserWithoutSeat,
-        BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
-        BlockUserWithSeatButWCANotReady,
-    ]
+    permission_classes = PERMISSIONS_MAP.get(settings.DEPLOYMENT_MODE)
     required_scopes = ["read", "write"]
 
     throttle_cache_key_suffix = "_generation"

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -612,3 +612,9 @@ CHATBOT_URL = os.getenv("CHATBOT_URL")
 CHATBOT_DEFAULT_PROVIDER = os.getenv("CHATBOT_DEFAULT_PROVIDER")
 CHATBOT_DEFAULT_MODEL = os.getenv("CHATBOT_DEFAULT_MODEL")
 # ==========================================
+
+# ==========================================
+# Playbook Generation/Explanation endpoints
+# ------------------------------------------
+ENABLE_PLAYBOOK_ENDPOINT = os.getenv("ENABLE_PLAYBOOK_ENDPOINT", "False").lower() == "true"
+# ==========================================

--- a/ansible_ai_connect/main/settings/development.py
+++ b/ansible_ai_connect/main/settings/development.py
@@ -71,3 +71,5 @@ WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
 TELEMETRY_ADMIN_DASHBOARD_URL = (
     "https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard"
 )
+
+ENABLE_PLAYBOOK_ENDPOINT = True


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-32019

## Description
This PR adds support for Playbook Generation and Explanation for "on prem".

It is enabled/disabled with the environment variable `ENABLE_PLAYBOOK_ENDPOINT`

## Testing
TBD.

Once the container has been built by this PR I'll deploy an AAIC instance "on prem", test and document.

### Steps to test
1. Pull down the PR
2. Once the container has been built by this PR I'll deploy an AAIC instance "on prem", test and document.

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

This PR depends on https://github.com/ansible/ansible-wisdom-ops/pull/1096