### PR TITLE
AAP-32019: Enable Playbook generation/explanation endpoint in Lightspeed service for on-prem

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -16,10 +16,11 @@ import json
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 import backoff
 import requests
+from django.apps import apps
 from django.conf import settings
 from django_prometheus.conf import NAMESPACE
 from health_check.exceptions import ServiceUnavailable
@@ -48,6 +49,10 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ModelPipelineContentMatch,
     ModelPipelinePlaybookExplanation,
     ModelPipelinePlaybookGeneration,
+    PlaybookExplanationParameters,
+    PlaybookExplanationResponse,
+    PlaybookGenerationParameters,
+    PlaybookGenerationResponse,
 )
 from ansible_ai_connect.ai.api.model_pipelines.wca.wca_utils import (
     ContentMatchResponseChecks,
@@ -389,6 +394,75 @@ class WCABasePlaybookGenerationPipeline(
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
 
+    def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
+        request = params.request
+        text = params.text
+        custom_prompt = params.custom_prompt
+        create_outline = params.create_outline
+        outline = params.outline
+        model_id = params.model_id
+        generation_id = params.generation_id
+
+        organization_id = request.user.organization.id if request.user.organization else None
+        api_key = self.get_api_key(request.user, organization_id)
+        model_id = self.get_model_id(request.user, organization_id, model_id)
+
+        headers = self.get_request_headers(api_key, generation_id)
+        data = {
+            "model_id": model_id,
+            "text": text,
+            "create_outline": create_outline,
+        }
+        if outline:
+            data["outline"] = outline
+        if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
+            data["custom_prompt"] = custom_prompt
+
+        @backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=self.retries + 1,
+            giveup=self.fatal_exception,
+            on_backoff=self.on_backoff_codegen_playbook,
+        )
+        @wca_codegen_playbook_hist.time()
+        def post_request():
+            return self.session.post(
+                f"{self._inference_url}/v1/wca/codegen/ansible/playbook",
+                headers=headers,
+                json=data,
+                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
+            )
+
+        result = post_request()
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if generation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(generation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
+
+        context = Context(model_id, result, False)
+        InferenceResponseChecks().run_checks(context)
+        result.raise_for_status()
+
+        response = json.loads(result.text)
+
+        playbook = response["playbook"]
+        outline = response["outline"]
+        warnings = response["warnings"] if "warnings" in response else []
+
+        from ansible_ai_connect.ai.apps import AiConfig
+
+        ai_config = cast(AiConfig, apps.get_app_config("ai"))
+        if ansible_lint_caller := ai_config.get_ansible_lint_caller():
+            playbook = ansible_lint_caller.run_linter(playbook)
+
+        return playbook, outline, warnings
+
 
 class WCABasePlaybookExplanationPipeline(
     WCABasePipeline, ModelPipelinePlaybookExplanation, metaclass=ABCMeta
@@ -396,3 +470,56 @@ class WCABasePlaybookExplanationPipeline(
 
     def __init__(self, inference_url):
         super().__init__(inference_url=inference_url)
+
+    def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
+        request = params.request
+        content = params.content
+        custom_prompt = params.custom_prompt
+        model_id = params.model_id
+        explanation_id = params.explanation_id
+
+        organization_id = request.user.organization.id if request.user.organization else None
+        api_key = self.get_api_key(request.user, organization_id)
+        model_id = self.get_model_id(request.user, organization_id, model_id)
+
+        headers = self.get_request_headers(api_key, explanation_id)
+        data = {
+            "model_id": model_id,
+            "playbook": content,
+        }
+        if custom_prompt:
+            if not custom_prompt.endswith("\n"):
+                custom_prompt = f"{custom_prompt}\n"
+            data["custom_prompt"] = custom_prompt
+
+        @backoff.on_exception(
+            backoff.expo,
+            Exception,
+            max_tries=self.retries + 1,
+            giveup=self.fatal_exception,
+            on_backoff=self.on_backoff_explain_playbook,
+        )
+        @wca_explain_playbook_hist.time()
+        def post_request():
+            return self.session.post(
+                f"{self._inference_url}/v1/wca/explain/ansible/playbook",
+                headers=headers,
+                json=data,
+                verify=settings.ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
+            )
+
+        result = post_request()
+
+        x_request_id = result.headers.get(WCA_REQUEST_ID_HEADER)
+        if explanation_id and x_request_id:
+            # request/payload suggestion_id is a UUID not a string whereas
+            # HTTP headers are strings.
+            if x_request_id != str(explanation_id):
+                raise WcaRequestIdCorrelationFailure(model_id=model_id, x_request_id=x_request_id)
+
+        context = Context(model_id, result, False)
+        InferenceResponseChecks().run_checks(context)
+        result.raise_for_status()
+
+        response = json.loads(result.text)
+        return response["explanation"]

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -164,7 +164,10 @@ class WCAOnPremPlaybookGenerationPipeline(WCAOnPremPipeline, WCABasePlaybookGene
         super().__init__(inference_url=inference_url)
 
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
-        raise FeatureNotAvailable
+        if settings.ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError
@@ -177,7 +180,10 @@ class WCAOnPremPlaybookExplanationPipeline(WCAOnPremPipeline, WCABasePlaybookExp
         super().__init__(inference_url=inference_url)
 
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
-        raise FeatureNotAvailable
+        if settings.ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT:
+            return super().invoke(params)
+        else:
+            raise FeatureNotAvailable
 
     def self_test(self):
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -704,14 +704,7 @@ class Explanation(AACSAPIView):
     Returns a text that explains a playbook.
     """
 
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsAuthenticatedOrTokenHasScope,
-        BlockUserWithoutSeat,
-        BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
-        BlockUserWithSeatButWCANotReady,
-    ]
+    permission_classes = PERMISSIONS_MAP.get(settings.DEPLOYMENT_MODE)
     required_scopes = ["read", "write"]
     schema1_event = schema1.ExplainPlaybookEvent
 
@@ -780,17 +773,7 @@ class Generation(APIView):
     Returns a playbook based on a text input.
     """
 
-    from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-    from rest_framework import permissions
-
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsAuthenticatedOrTokenHasScope,
-        BlockUserWithoutSeat,
-        BlockWCANotReadyButTrialAvailable,
-        BlockUserWithoutSeatAndWCAReadyOrg,
-        BlockUserWithSeatButWCANotReady,
-    ]
+    permission_classes = PERMISSIONS_MAP.get(settings.DEPLOYMENT_MODE)
     required_scopes = ["read", "write"]
 
     throttle_cache_key_suffix = "_generation"

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -612,3 +612,14 @@ CHATBOT_URL = os.getenv("CHATBOT_URL")
 CHATBOT_DEFAULT_PROVIDER = os.getenv("CHATBOT_DEFAULT_PROVIDER")
 CHATBOT_DEFAULT_MODEL = os.getenv("CHATBOT_DEFAULT_MODEL")
 # ==========================================
+
+# ==========================================
+# Playbook Generation/Explanation endpoints
+# ------------------------------------------
+ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT = (
+    os.getenv(
+        "ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT", "False" if DEPLOYMENT_MODE == "on-prem" else "True"
+    ).lower()
+    == "true"
+)
+# ==========================================

--- a/ansible_ai_connect/main/settings/development.py
+++ b/ansible_ai_connect/main/settings/development.py
@@ -71,3 +71,5 @@ WCA_SECRET_DUMMY_SECRETS = os.getenv("WCA_SECRET_DUMMY_SECRETS", "")
 TELEMETRY_ADMIN_DASHBOARD_URL = (
     "https://console.stage.redhat.com/ansible/lightspeed-admin-dashboard"
 )
+
+ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT = True


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-32019

## Description
This PR adds support for Playbook Generation and Explanation for "on prem".

It is enabled/disabled with the environment variable `ENABLE_PLAYBOOK_ENDPOINT`

## Testing
See JIRA for instructions.

### Steps to test
See JIRA for instructions.

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

This PR depends on https://github.com/ansible/ansible-wisdom-ops/pull/1096