### PR TITLE
Upgrade langchain to 0.3.7

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -214,13 +214,13 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain==0.3.6
+langchain==0.3.7
     # via
     #   -r requirements.in
     #   langchain-community
 langchain-community==0.3.4
     # via -r requirements.in
-langchain-core==0.3.14
+langchain-core==0.3.15
     # via
     #   langchain
     #   langchain-community

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -214,13 +214,13 @@ jwcrypto==1.5.6
     # via
     #   -r requirements.in
     #   django-oauth-toolkit
-langchain==0.3.6
+langchain==0.3.7
     # via
     #   -r requirements.in
     #   langchain-community
 langchain-community==0.3.4
     # via -r requirements.in
-langchain-core==0.3.14
+langchain-core==0.3.15
     # via
     #   langchain
     #   langchain-community

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ jinja2==3.1.4
 # pin jsonpickle on 3.3.0 to address SNYK-PYTHON-JSONPICKLE-8136229
 # remove this once ansible-risk-insight is updated
 jsonpickle==3.3.0
-langchain==0.3.6
+langchain==0.3.7
 langchain-community==0.3.4
 launchdarkly-server-sdk==8.3.0
 protobuf==5.28.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
langchain | 0.3.6 | PYSEC-2024-115 |  | A vulnerability in the GraphCypherQAChain class of langchain-ai/langchain version 0.2.5 allows for SQL injection through prompt injection. This vulnerability can lead to unauthorized data manipulation, data exfiltration, denial of service (DoS) by deleting all data, breaches in multi-tenant security environments, and data integrity issues. Attackers can create, update, or delete nodes and relationships without proper authorization, extract sensitive data, disrupt services, access data across different tenants, and compromise the integrity of the database.
```
See https://github.com/pypa/advisory-database/blob/eba03b11600f9250958b291c067947290bcb1ce7/vulns/langchain/PYSEC-2024-115.yaml#L4. Fix was included in https://github.com/langchain-ai/langchain/commit/c2a3021bb0c5f54649d380b42a0684ca5778c255 that seems to be included in `langchain 0.3.7`.
 
## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
