### PR TITLE
Ignore GHSA-hc5w-c9f8-9cc4 until the CVE is corrected for the Python library

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -50,3 +50,4 @@ jobs:
             # See https://issues.redhat.com/browse/AAP-35075
             PYSEC-2024-111
             PYSEC-2024-115
+            GHSA-hc5w-c9f8-9cc4


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
langchain | 0.3.6 | GHSA-hc5w-c9f8-9cc4 |  | A path traversal vulnerability exists in the `getFullPath` ....
```
See https://issues.redhat.com/browse/AAP-35075 for details.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
