### PR TITLE
AAP-34871: Tasks in wrong order

### DIFF
--- a/ansible_ai_connect/ai/api/formatter.py
+++ b/ansible_ai_connect/ai/api/formatter.py
@@ -384,12 +384,10 @@ def restore_original_task_names(output_yaml, prompt, payload_context=""):
         payload_context_task_list = get_task_list_from_yaml_data_obj(payload_context_data)
         context_task_list_length = len(payload_context_task_list)
 
-        # We enumarate starting with an index that equals to the lenght of the context task list.
-        # We are doign this to skip the first N tasks, then start with the Nth index
+        # We enumerate starting with an index that equals to the length of the context task list.
+        # We are doing this to skip the first N tasks, then start with the Nth index
         # to process only the suggested tasks
-        for i, task in enumerate(
-            full_task_list[context_task_list_length:], context_task_list_length
-        ):
+        for i, task in enumerate(full_task_list[context_task_list_length:]):
             try:
                 task_name = task.get("name", "")
                 task_line = "- name:  " + task_name

--- a/ansible_ai_connect/ai/api/tests/test_formatter.py
+++ b/ansible_ai_connect/ai/api/tests/test_formatter.py
@@ -599,14 +599,14 @@ var3: value3
             "    - name:  Install Apache\n      ansible.builtin.apt:\n        "
             "name: apache2\n        state: latest\n"
         )
-        multi_task_prompt = "# Say hello & install mail server & email TO aykut@redhat.com \n"
+        multi_task_prompt = "# Say hello & install mail server & email TO aykut@anemail.com \n"
 
         multi_task_yaml = (
             "    - name:  Say hello\n      "
             "ansible.builtin.debug:\n        msg: Hello there\n"
             "    - name: Install mail server\n      "
             "ansible.builtin.package:\n        name: postfix\n        state: latest\n"
-            "    - name: Email TO aykut@redhat.com\n      "
+            "    - name: Email TO aykut@anemail.com\n      "
             "community.general.mail:\n        to: william10@example.com\n"
             "        subject: Ansible playbook\n"
             "        body: Ansible playbook\n"

--- a/ansible_ai_connect/ai/api/tests/test_formatter.py
+++ b/ansible_ai_connect/ai/api/tests/test_formatter.py
@@ -599,11 +599,17 @@ var3: value3
             "    - name:  Install Apache\n      ansible.builtin.apt:\n        "
             "name: apache2\n        state: latest\n"
         )
-        multi_task_prompt = "# say hello test@example.com\n"
+        multi_task_prompt = "# Say hello & install mail server & email TO aykut@redhat.com \n"
 
         multi_task_yaml = (
-            "    - name:  say hello test@example.com\n      "
-            "ansible.builtin.debug:\n        msg: Hello there olivia1@example.com\n"
+            "    - name:  Say hello\n      "
+            "ansible.builtin.debug:\n        msg: Hello there\n"
+            "    - name: Install mail server\n      "
+            "ansible.builtin.package:\n        name: postfix\n        state: latest\n"
+            "    - name: Email TO aykut@redhat.com\n      "
+            "community.general.mail:\n        to: william10@example.com\n"
+            "        subject: Ansible playbook\n"
+            "        body: Ansible playbook\n"
         )
 
         self.assertEqual(


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-34871>
<!-- This PR does not need a corresponding Jira item. -->

## Description
Please see Jira Issue: <https://issues.redhat.com/browse/AAP-34871> and
see https://github.com/rh-ibm-synergy/wca-feedback/issues/129

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the wisdom service on your local and connect it to your vscode.
3.  Create a YAML playbook file on your local with the following content:

```

---
- name: Deploy simple website using Ansible Lightspeed with watsonx Code Assistant
  hosts: all
  gather_facts: false
  become: true

  tasks:
    # No tasks included
    - name: Ensure httpd package is installed
      ansible.builtin.package:
        name: httpd
        state: present

    - name: Configure httpd on port 8083
      ansible.builtin.copy:
        content: <h1>Hello world from AWS</h1>
        dest: /var/www/html/index.html

    # Start and enable firewalld & Allow the traffic through firewalld & Reload firewalld
```

4.  After saving the playbook, go to the end of the line " # Start and enable firewalld & Allow the traffic through firewalld & Reload firewalld" and hit enter. You should see the tasks generated in the right order and correct names:

```
    - name: Start and enable firewalld
      ansible.builtin.service:
        name: firewalld
        state: started
        enabled: true

    - name: Allow the traffic through firewalld
      ansible.posix.firewalld:
        port: 8083/tcp
        permanent: true
        state: enabled
        immediate: true

    - name: Reload firewalld
      ansible.builtin.command: firewall-cmd --reload
 ```

### Scenarios tested
Other playbooks mentioned [here](https://github.com/rh-ibm-synergy/wca-feedback/issues/129) are tested.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
