### PR TITLE
Chatbot debug mode

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -1130,8 +1130,12 @@ class Chat(APIView):
 
             data = {
                 "query": request_serializer.validated_data["query"],
-                "model": settings.CHATBOT_DEFAULT_MODEL,
-                "provider": settings.CHATBOT_DEFAULT_PROVIDER,
+                "model": request_serializer.validated_data.get(
+                    "model", settings.CHATBOT_DEFAULT_MODEL
+                ),
+                "provider": request_serializer.validated_data.get(
+                    "provider", settings.CHATBOT_DEFAULT_PROVIDER
+                ),
             }
             if "conversation_id" in request_serializer.validated_data:
                 data["conversation_id"] = str(request_serializer.validated_data["conversation_id"])

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -624,6 +624,7 @@ ANSIBLE_AI_ONE_CLICK_REPORTS_CONFIG: dict = (
 CHATBOT_URL = os.getenv("CHATBOT_URL")
 CHATBOT_DEFAULT_PROVIDER = os.getenv("CHATBOT_DEFAULT_PROVIDER")
 CHATBOT_DEFAULT_MODEL = os.getenv("CHATBOT_DEFAULT_MODEL")
+CHATBOT_DEBUG_UI = os.getenv("CHATBOT_DEBUG_UI", "False").lower() == "true"
 # ==========================================
 
 # ==========================================

--- a/ansible_ai_connect/main/templates/chatbot/index.html
+++ b/ansible_ai_connect/main/templates/chatbot/index.html
@@ -20,5 +20,6 @@
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
     <div id="bot_name" hidden>{{bot_name}}</div>
+    <div id="debug" hidden>{{debug}}</div>
 {% endblock content %}
 </html>

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -233,6 +233,7 @@ class TestMarkdownMe(TestCase):
 @override_settings(CHATBOT_DEFAULT_PROVIDER="wisdom")
 @override_settings(CHATBOT_DEFAULT_MODEL="granite-8b")
 @override_settings(ANSIBLE_AI_CHATBOT_NAME="Awesome Chatbot")
+@override_settings(CHATBOT_DEBUG_UI="false")
 class TestChatbotView(TestCase):
     CHATBOT_PAGE_TITLE = "<title>Awesome Chatbot</title>"
     DOCUMENT_URL = (
@@ -332,8 +333,10 @@ class TestChatbotView(TestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, TestChatbotView.CHATBOT_PAGE_TITLE)
         self.assertContains(r, self.rh_user.username)
+        self.assertContains(r, '<div id="debug" hidden>false</div>')
 
-    def test_chatbot_view_with_debug_option(self):
+    @override_settings(CHATBOT_DEBUG_UI="true")
+    def test_chatbot_view_with_debug_ui(self):
         self.client.force_login(user=self.rh_user)
         r = self.client.get(reverse("chatbot"), {"debug": "true"})
         self.assertEqual(r.status_code, HTTPStatus.OK)

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -332,3 +332,9 @@ class TestChatbotView(TestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, TestChatbotView.CHATBOT_PAGE_TITLE)
         self.assertContains(r, self.rh_user.username)
+
+    def test_chatbot_view_with_debug_option(self):
+        self.client.force_login(user=self.rh_user)
+        r = self.client.get(reverse("chatbot"), {"debug": "true"})
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, '<div id="debug" hidden>true</div>')

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -233,7 +233,7 @@ class TestMarkdownMe(TestCase):
 @override_settings(CHATBOT_DEFAULT_PROVIDER="wisdom")
 @override_settings(CHATBOT_DEFAULT_MODEL="granite-8b")
 @override_settings(ANSIBLE_AI_CHATBOT_NAME="Awesome Chatbot")
-@override_settings(CHATBOT_DEBUG_UI="false")
+@override_settings(CHATBOT_DEBUG_UI=False)
 class TestChatbotView(TestCase):
     CHATBOT_PAGE_TITLE = "<title>Awesome Chatbot</title>"
     DOCUMENT_URL = (
@@ -335,7 +335,7 @@ class TestChatbotView(TestCase):
         self.assertContains(r, self.rh_user.username)
         self.assertContains(r, '<div id="debug" hidden>false</div>')
 
-    @override_settings(CHATBOT_DEBUG_UI="true")
+    @override_settings(CHATBOT_DEBUG_UI=True)
     def test_chatbot_view_with_debug_ui(self):
         self.client.force_login(user=self.rh_user)
         r = self.client.get(reverse("chatbot"), {"debug": "true"})

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -125,8 +125,6 @@ class ChatbotView(ProtectedTemplateView):
             and settings.CHATBOT_DEFAULT_MODEL
             and settings.CHATBOT_DEFAULT_PROVIDER
         ):
-            debug = request.GET.get("debug", "false")
-            self.debug = debug.lower() == "true"
             return super().get(request)
 
         # Otherwise, redirect to the home page.
@@ -138,7 +136,7 @@ class ChatbotView(ProtectedTemplateView):
         user = self.request.user
         if user and user.is_authenticated:
             context["user_name"] = user.username
-        context["debug"] = "true" if self.debug else "false"
+        context["debug"] = "true" if settings.CHATBOT_DEBUG_UI == "true" else "false"
 
         return context
 

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -125,6 +125,8 @@ class ChatbotView(ProtectedTemplateView):
             and settings.CHATBOT_DEFAULT_MODEL
             and settings.CHATBOT_DEFAULT_PROVIDER
         ):
+            debug = request.GET.get("debug", "false")
+            self.debug = debug.lower() == "true"
             return super().get(request)
 
         # Otherwise, redirect to the home page.
@@ -136,6 +138,7 @@ class ChatbotView(ProtectedTemplateView):
         user = self.request.user
         if user and user.is_authenticated:
             context["user_name"] = user.username
+        context["debug"] = "true" if self.debug else "false"
 
         return context
 

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -136,7 +136,7 @@ class ChatbotView(ProtectedTemplateView):
         user = self.request.user
         if user and user.is_authenticated:
             context["user_name"] = user.username
-        context["debug"] = "true" if settings.CHATBOT_DEBUG_UI == "true" else "false"
+        context["debug"] = "true" if settings.CHATBOT_DEBUG_UI else "false"
 
         return context
 

--- a/ansible_ai_connect_chatbot/index.html
+++ b/ansible_ai_connect_chatbot/index.html
@@ -23,5 +23,6 @@
     </div>
     <div id="user_name" hidden>{{user_name}}</div>
     <div id="bot_name" hidden>{{bot_name}}</div>
+    <div id="debug" hidden>{{debug}}</div>
   </body>
 </html>

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -33,12 +33,18 @@ import lightspeedLogo from "../assets/lightspeed.svg";
 import lightspeedLogoDark from "../assets/lightspeed_dark.svg";
 
 import "./AnsibleChatbot.scss";
-import { botMessage, useChatbot } from "../useChatbot/useChatbot";
+import {
+  botMessage,
+  inDebugMode,
+  modelsSupported,
+  useChatbot,
+} from "../useChatbot/useChatbot";
 import { ReferencedDocuments } from "../ReferencedDocuments/ReferencedDocuments";
 
 import type { ExtendedMessage } from "../types/Message";
 import {
   ChatbotAlert,
+  ChatbotHeaderSelectorDropdown,
   ChatbotToggle,
   FileDropZone,
 } from "@patternfly/virtual-assistant";
@@ -66,8 +72,15 @@ const footnoteProps = {
 };
 
 export const AnsibleChatbot: React.FunctionComponent = () => {
-  const { messages, isLoading, handleSend, alertMessage, setAlertMessage } =
-    useChatbot();
+  const {
+    messages,
+    isLoading,
+    handleSend,
+    alertMessage,
+    setAlertMessage,
+    selectedModel,
+    setSelectedModel,
+  } = useChatbot();
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
   const [displayMode, setDisplayMode] = useState<ChatbotDisplayMode>(
     ChatbotDisplayMode.default,
@@ -81,6 +94,13 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  const onSelectModel = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    setSelectedModel(value as string);
+  };
 
   const onSelectDisplayMode = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -114,6 +134,20 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
             </Bullseye>
           </ChatbotHeaderTitle>
           <ChatbotHeaderActions>
+            {inDebugMode() && (
+              <ChatbotHeaderSelectorDropdown
+                value={selectedModel}
+                onSelect={onSelectModel}
+              >
+                <DropdownList>
+                  {modelsSupported.map((m) => (
+                    <DropdownItem value={m.model} key={m.model}>
+                      {m.model}
+                    </DropdownItem>
+                  ))}
+                </DropdownList>
+              </ChatbotHeaderSelectorDropdown>
+            )}
             <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
               <DropdownGroup label="Display mode">
                 <DropdownList>

--- a/ansible_ai_connect_chatbot/src/types/Model.ts
+++ b/ansible_ai_connect_chatbot/src/types/Model.ts
@@ -1,0 +1,4 @@
+export type LLMModel = {
+  model: string;
+  provider: string;
+};

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -6,12 +6,18 @@ import type {
   ChatRequest,
   ChatResponse,
 } from "../types/Message";
+import type { LLMModel } from "../types/Model";
 import logo from "../assets/lightspeed.svg";
 import userLogo from "../assets/user_logo.png";
 
 const userName = document.getElementById("user_name")?.innerText ?? "User";
 const botName =
   document.getElementById("bot_name")?.innerText ?? "Ansible Lightspeed";
+
+export const modelsSupported: LLMModel[] = [
+  { model: "granite-8b", provider: "my_rhoai" },
+  { model: "granite3-8b", provider: "my_rhoai_g3" },
+];
 
 export const readCookie = (name: string): string | null => {
   const nameEQ = name + "=";
@@ -28,6 +34,11 @@ export const readCookie = (name: string): string | null => {
 const getTimestamp = () => {
   const date = new Date();
   return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+export const inDebugMode = () => {
+  const debug = document.getElementById("debug")?.innerText ?? "false";
+  return debug === "true";
 };
 
 export const botMessage = (content: string): MessageProps => ({
@@ -66,6 +77,7 @@ export const useChatbot = () => {
   const [conversationId, setConversationId] = useState<
     string | null | undefined
   >(undefined);
+  const [selectedModel, setSelectedModel] = useState("granite-8b");
 
   const handleSend = async (message: string) => {
     const userMessage: ExtendedMessage = {
@@ -82,6 +94,15 @@ export const useChatbot = () => {
       conversation_id: conversationId,
       query: message,
     };
+
+    if (inDebugMode()) {
+      for (const m of modelsSupported) {
+        if (selectedModel === m.model) {
+          chatRequest.model = m.model;
+          chatRequest.provider = m.provider;
+        }
+      }
+    }
 
     setIsLoading(true);
     try {
@@ -129,5 +150,13 @@ export const useChatbot = () => {
     }
   };
 
-  return { messages, isLoading, handleSend, alertMessage, setAlertMessage };
+  return {
+    messages,
+    isLoading,
+    handleSend,
+    alertMessage,
+    setAlertMessage,
+    selectedModel,
+    setSelectedModel,
+  };
 };


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-35616>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Enable "debug" chatbot UI that allows end-user to pick up a model to be used. This time it only allows to use the default `granite-8b` model and the `granite3-8b` model, which was installed with AAP-35616,

![image](https://github.com/user-attachments/assets/659d4f56-a91b-4da5-b6d6-c488e02b342f)

This is enabled only when the chatbot UI is loaded with `?debug=true` query parameter, e.g.

https://stage.ai.ansible.redhat.com/chatbot?debug=true

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit test


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests are included

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
