### PR TITLE
AAP-33633: ModelPipelines: Configuration improvements. WCA(-onprem) API Key is optional

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
@@ -74,7 +74,7 @@ class WCABasePipelineConfiguration(PipelineConfiguration[WCABaseConfiguration], 
 
 
 class WCABaseConfigurationSerializer(BaseConfigSerializer):
-    api_key = serializers.CharField(required=True)
+    api_key = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     verify_ssl = serializers.BooleanField(required=False, default=False)
     retry_count = serializers.IntegerField(required=False, default=4)
     enable_ari_postprocessing = serializers.BooleanField(required=False, default=False)

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
@@ -71,7 +71,7 @@ class WCAOnPremConfiguration(WCABaseConfiguration):
 
 
 @Register(api_type="wca-onprem")
-class WCASaaSPipelineConfiguration(WCABasePipelineConfiguration):
+class WCAOnPremPipelineConfiguration(WCABasePipelineConfiguration):
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_configuration_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_configuration_onprem.py
@@ -1,0 +1,32 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_pipeline_config
+from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_onprem import (
+    WCAOnPremConfiguration,
+    WCAOnPremConfigurationSerializer,
+)
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+
+
+class TestWCAOnPremConfigurationSerializer(WisdomServiceAPITestCaseBaseOIDC):
+
+    def test_serializer_with_api_key(self):
+        config: WCAOnPremConfiguration = mock_pipeline_config("wca-onprem")
+        serializer = WCAOnPremConfigurationSerializer(data=config.__dict__)
+        self.assertTrue(serializer.is_valid())
+
+    def test_serializer_without_api_key(self):
+        config: WCAOnPremConfiguration = mock_pipeline_config("wca-onprem", api_key=None)
+        serializer = WCAOnPremConfigurationSerializer(data=config.__dict__)
+        self.assertTrue(serializer.is_valid())

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_configuration_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_configuration_saas.py
@@ -1,0 +1,32 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_pipeline_config
+from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_saas import (
+    WCASaaSConfiguration,
+    WCASaaSConfigurationSerializer,
+)
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+
+
+class TestWCASaaSConfigurationSerializer(WisdomServiceAPITestCaseBaseOIDC):
+
+    def test_serializer_with_api_key(self):
+        config: WCASaaSConfiguration = mock_pipeline_config("wca")
+        serializer = WCASaaSConfigurationSerializer(data=config.__dict__)
+        self.assertTrue(serializer.is_valid())
+
+    def test_serializer_without_api_key(self):
+        config: WCASaaSConfiguration = mock_pipeline_config("wca", api_key=None)
+        serializer = WCASaaSConfigurationSerializer(data=config.__dict__)
+        self.assertTrue(serializer.is_valid())


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-33633

## Description
Further to https://github.com/ansible/ansible-ai-connect-service/pull/1389

@TamiTakamiya reported Staging `Pod`'s were failing to start as the `api_key` was missing.

I added `ANSIBLE_AI_MODEL_API_KEY` environment variable to both Staging and Production AWS Secret Manager.

However @ldjebran reported his use of VSCode against Production with the environment variable set was broken.

Reverting `ANSIBLE_AI_MODEL_API_KEY` fixed the problem; meaning `api_key` *should be optional*.

This PR makes `api_key` optional.
 
## Testing
Unit Tests.

However the issue was not evident until deployment to Staging was attempted.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
