### PR TITLE
Upgrade aiohttp to 3.10.11

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.3.5
     # via aiohttp
-aiohttp==3.10.2
+aiohttp==3.10.11
     # via
     #   -r requirements.in
     #   langchain
@@ -297,6 +297,8 @@ prometheus-client==0.20.0
     # via django-prometheus
 prompt-toolkit==3.0.43
     # via ipython
+propcache==0.2.0
+    # via yarl
 proto-plus==1.24.0
     # via google-api-core
 protobuf==5.28.2
@@ -511,5 +513,5 @@ xlwt==1.3.0
     # via tablib
 yamllint==1.35.1
     # via ansible-lint
-yarl==1.9.4
+yarl==1.17.2
     # via aiohttp

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.3.5
     # via aiohttp
-aiohttp==3.10.2
+aiohttp==3.10.11
     # via
     #   -r requirements.in
     #   langchain
@@ -297,6 +297,8 @@ prometheus-client==0.20.0
     # via django-prometheus
 prompt-toolkit==3.0.43
     # via ipython
+propcache==0.2.0
+    # via yarl
 proto-plus==1.24.0
     # via google-api-core
 protobuf==5.28.2
@@ -511,5 +513,5 @@ xlwt==1.3.0
     # via tablib
 yamllint==1.35.1
     # via ansible-lint
-yarl==1.9.4
+yarl==1.17.2
     # via aiohttp

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ ansible-lint==24.2.2
 # pin aiohttp on 3.10.2 to address SNYK-PYTHON-AIOHTTP-7675597
 # aiohttp is used by langchain and langchain-community that
 # specify a version ^3.8.3
-aiohttp==3.10.2
+aiohttp==3.10.11
 boto3==1.26.84
 # pin black on 24.3.0 to address PYSEC-2024-48.
 black==24.3.0


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
aiohttp | 3.10.2 | GHSA-8495-4g3g-x7pr | 3.10.11 | ### Summary The Python parser parses newlines in chunk extensions incorrectly which can lead to request smuggling vulnerabilities under certain conditions.
```

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
