### PR TITLE
Use readiness endpoint for chatbot healthcheck

### DIFF
--- a/ansible_ai_connect/healthcheck/backends.py
+++ b/ansible_ai_connect/healthcheck/backends.py
@@ -33,6 +33,10 @@ class HealthCheckSummaryException:
         self.cause = cause
 
 
+class ChatbotServiceException(Exception):
+    pass
+
+
 class HealthCheckSummary:
 
     items: dict[str, HealthCheckSummaryException | str]
@@ -158,9 +162,9 @@ class ChatbotServiceHealthCheck(BaseLightspeedHealthCheck):
                 ready = data.get("ready")
                 if not ready:
                     reason = data.get("reason")
-                    raise Exception(reason)
+                    raise ChatbotServiceException(reason)
             else:
-                raise Exception(f"Status code {r.status_code} returned")
+                raise ChatbotServiceException(f"Status code {r.status_code} returned")
         except Exception as e:
             self.add_error(ServiceUnavailable(ERROR_MESSAGE), e)
 

--- a/ansible_ai_connect/healthcheck/backends.py
+++ b/ansible_ai_connect/healthcheck/backends.py
@@ -152,8 +152,14 @@ class ChatbotServiceHealthCheck(BaseLightspeedHealthCheck):
 
         try:
             headers = {"Content-Type": "application/json"}
-            r = requests.get(settings.CHATBOT_URL + "/liveness", headers=headers)
-            if r.status_code != 200:
+            r = requests.get(settings.CHATBOT_URL + "/readiness", headers=headers)
+            if r.status_code == 200:
+                data = r.json()
+                ready = data.get("ready")
+                if not ready:
+                    reason = data.get("reason")
+                    raise Exception(reason)
+            else:
                 raise Exception(f"Status code {r.status_code} returned")
         except Exception as e:
             self.add_error(ServiceUnavailable(ERROR_MESSAGE), e)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-35769>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Use the `/readiness` endpoint of chatbot service instead of the `/liveness` for chatbot-service healthcheck, which is performed when AI Connect service's `/check/status` endpoint is invoked.  Since the `/readiness` endpoint of chatbot service checks the statuses of RAG index and LLM, we can use it for monitoring LLM as well.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests, written by @mabashian are included in the PR.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
