### PR TITLE
Chatbot feedback model and API implementation with Schema 1 telemetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
   - id: isort
     name: isort (python)
 - repo: https://github.com/ambv/black
-  rev: 24.8.0
+  rev: 24.10.0
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]
     language_version: python3
     require_serial: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     language_version: python3
@@ -29,7 +29,7 @@ repos:
     args: [--config=.flake8]
     language_version: python3
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.17.0
+  rev: v3.19.0
   hooks:
   - id: pyupgrade
     language_version: python3

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -664,6 +664,21 @@ components:
         * `0` - ACCEPTED
         * `1` - REJECTED
         * `2` - IGNORED
+    ChatFeedback:
+      type: object
+      properties:
+        query:
+          type: string
+          title: Prompt
+          description: Prompt being sent to the LLM.
+        response:
+          $ref: '#/components/schemas/ChatResponse'
+        sentiment:
+          $ref: '#/components/schemas/SentimentEnum'
+      required:
+      - query
+      - response
+      - sentiment
     ChatRequest:
       type: object
       properties:
@@ -903,6 +918,8 @@ components:
           $ref: '#/components/schemas/SentimentFeedback'
         suggestionQualityFeedback:
           $ref: '#/components/schemas/SuggestionQualityFeedback'
+        chatFeedback:
+          $ref: '#/components/schemas/ChatFeedback'
     GenerationRequest:
       type: object
       properties:
@@ -1217,6 +1234,16 @@ components:
       required:
       - docs_url
       - title
+    SentimentEnum:
+      enum:
+      - '0'
+      - '1'
+      - NOT_LIKE
+      type: string
+      description: |-
+        * `0` - LIKE
+        * `1` - 1
+        * `NOT_LIKE` - NOT_LIKE
     SentimentFeedback:
       type: object
       properties:


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-33570>

## Description
Adding support for both feedback an operational events, on `schema1`, for the chatbot. 

NOTE: As commented with Marty, those chatbot telemetry events are **NOT inheriting fields** as in other `schema1` events, such as `hostname`, `groups`, `plans`, `has_seat` etc. Let us know if you see any issue on that. We just want to ensure we don't spend payload on unnecessary stuff.

## Testing
1. Pull down the PR
2. Set the proper `SEGMENT_WRITE_KEY`
3. Run wisdom service and access the chatbot UI
4. Perform any Q -> a new `chatOperationalEvent`event  must be sent
5. Click on thumbs up/down -> a new `chatFeedbackEvent`event  must be sent

### Scenarios tested
Local against chatbot on staging.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
