### PR TITLE
AAP-36462: [r11]: Add support for HTTP422 response

### DIFF
--- a/ansible_ai_connect/ai/api/exceptions.py
+++ b/ansible_ai_connect/ai/api/exceptions.py
@@ -149,6 +149,16 @@ class WcaInstanceDeletedException(BaseWisdomAPIException):
     )
 
 
+class WcaInferenceFailureException(WisdomBadRequest):
+    default_code = "error__wca_inference_failure"
+    default_detail = "WCA inference failed. Completions request failed."
+
+
+class WcaValidationFailureException(WisdomBadRequest):
+    default_code = "error__wca_validation_failure"
+    default_detail = "WCA failed to validate response from model. Completions request failed."
+
+
 class WcaUserTrialExpiredException(WisdomAccessDenied):
     default_code = "permission_denied__user_trial_expired"
     default_detail = "User trial expired. Please contact your administrator."

--- a/ansible_ai_connect/ai/api/model_pipelines/exceptions.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/exceptions.py
@@ -99,6 +99,11 @@ class WcaInferenceFailure(WcaException):
 
 
 @dataclass
+class WcaValidationFailure(WcaException):
+    """An attempt to run a WCA inference failed."""
+
+
+@dataclass
 class WcaCodeMatchFailure(WcaException):
     """An attempt to run a WCA code match failed."""
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-36462

## Description
During testing of `r11` it was noted that WCA sometimes returns `HTTP422`.

IBM explained this is caused by WCA failing to validate the response from the model. A reproducer is included in the JIRA.

This PR adds support for propagating `HTTP422`'s to VSCode where a suitable message can be display.

## Testing
Run `ansible-ai-connect-service` with this PR.
Run VSCode, with the related PR applied, pointing to your local `ansible-ai-connect-instance`

### Steps to test
1. Pull down the PR
2. Run `ansible-ai-connect-service` with this PR.
3. Run VSCode, with the related PR applied, pointing to your local `ansible-ai-connect-instance`
4. Try the example playbook (in the JIRA)
5. A _friendly_ message should be displayed.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

Note. There is a VSCode PR too; however this PR can be merged "as is".

See https://github.com/ansible/vscode-ansible/pull/1672