### PR TITLE
model_pipeline: set a default configuration for "dummy"

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/config_serializers.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_serializers.py
@@ -48,11 +48,12 @@ class ConfigurationSerializer(serializers.Serializer):
         from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY_ENTRY
 
         pipelines = list(filter(lambda p: issubclass(p, MetaData), REGISTRY_ENTRY.keys()))
-        pipeline_fields: dict = {}
-        for pipeline in pipelines:
-            pipeline_fields[pipeline.__name__] = PipelineConfigurationSerializer(
+        pipeline_fields: dict = {
+            p.__name__: PipelineConfigurationSerializer(
                 required=False, default={"provider": "nop", "config": {}}
             )
+            for p in pipelines
+        }
         self.pipeline_fields = pipeline_fields
 
     def get_fields(self):

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/configuration.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from dataclasses import dataclass
 from typing import Optional
 
 from rest_framework import serializers
@@ -31,7 +30,6 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 # DUMMY_MODEL_RESPONSE_BODY
 
 
-@dataclass
 class DummyConfiguration(BaseConfig):
 
     def __init__(
@@ -47,10 +45,6 @@ class DummyConfiguration(BaseConfig):
         self.latency_use_jitter = latency_use_jitter
         self.latency_max_msec = latency_max_msec
         self.body = body
-
-    latency_use_jitter: bool
-    latency_max_msec: int
-    body: str
 
 
 @Register(api_type="dummy")

--- a/ansible_ai_connect/ai/api/model_pipelines/registry.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/registry.py
@@ -45,9 +45,10 @@ REGISTRY_ENTRY = dict.fromkeys(
         Serializer,
     ]
 )
-REGISTRY = {}
-for model_mesh_api_type in get_args(t_model_mesh_api_type):
-    REGISTRY[model_mesh_api_type] = deepcopy(REGISTRY_ENTRY)
+REGISTRY = {
+    model_mesh_api_type: deepcopy(REGISTRY_ENTRY)
+    for model_mesh_api_type in get_args(t_model_mesh_api_type)
+}
 
 
 class Register:

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -671,6 +671,16 @@ elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "wca-onprem":
             "username": ANSIBLE_WCA_USERNAME,
         },
     }
+elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "dummy":
+    ANSIBLE_AI_WCA_CONFIG = {
+        "provider": "dummy",
+        "config": {
+            "inference_url": ANSIBLE_AI_MODEL_MESH_API_URL,
+            "body": DUMMY_MODEL_RESPONSE_BODY,
+            "latency_max_msec": DUMMY_MODEL_RESPONSE_MAX_LATENCY_MSEC,
+            "latency_use_jitter": DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER,
+        },
+    }
 else:
     ANSIBLE_AI_WCA_CONFIG = {
         "provider": "wca-dummy",
@@ -679,14 +689,13 @@ else:
         },
     }
 
+
 # Lazy import to avoid circular dependencies
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData  # noqa
 from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY_ENTRY  # noqa
 
-pipelines = list(filter(lambda p: issubclass(p, MetaData), REGISTRY_ENTRY.keys()))
-pipeline_config: dict = {}
-for pipeline in pipelines:
-    pipeline_config[pipeline.__name__] = ANSIBLE_AI_WCA_CONFIG
+pipelines = [i for i in REGISTRY_ENTRY.keys() if issubclass(i, MetaData)]
+pipeline_config: dict = {k.__name__: ANSIBLE_AI_WCA_CONFIG for k in pipelines}
 
 ANSIBLE_AI_MODEL_MESH_CONFIG = json.dumps(pipeline_config)
 # ==========================================


### PR DESCRIPTION
Set a default configuration structure for the "dummy" api type and
adjust the codebase to use Python Comprehensive when possible.
