### PR TITLE
AAP-33634: ModelPipelines: Health endpoint improvements

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/bam/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/bam/configuration.py
@@ -27,6 +27,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 
 # -- BAM
 # ANSIBLE_AI_MODEL_MESH_API_KEY
@@ -41,6 +42,7 @@ class BAMConfiguration(LangchainConfiguration):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         api_key: str,
         verify_ssl: bool,
     ):
@@ -48,6 +50,7 @@ class BAMConfiguration(LangchainConfiguration):
             inference_url,
             model_id,
             timeout,
+            enable_health_check,
         )
         self.api_key = api_key
         self.verify_ssl = verify_ssl
@@ -66,6 +69,7 @@ class BAMPipelineConfiguration(LangchainBasePipelineConfiguration):
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 api_key=kwargs["api_key"],
                 verify_ssl=kwargs["verify_ssl"],
             ),

--- a/ansible_ai_connect/ai/api/model_pipelines/config_pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_pipelines.py
@@ -23,10 +23,12 @@ class BaseConfig(metaclass=ABCMeta):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool] = False,
     ):
         self.inference_url = inference_url
         self.model_id = model_id
         self.timeout = timeout
+        self.enable_health_check = enable_health_check
 
     inference_url: str
     model_id: str

--- a/ansible_ai_connect/ai/api/model_pipelines/config_serializers.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_serializers.py
@@ -27,6 +27,7 @@ class BaseConfigSerializer(serializers.Serializer):
     inference_url = serializers.CharField(required=True)
     model_id = serializers.CharField(required=False, allow_null=True, default=None)
     timeout = serializers.IntegerField(required=False, allow_null=True, default=None)
+    enable_health_check = serializers.BooleanField(required=False, default=False)
 
 
 class PipelineConfigurationSerializer(serializers.Serializer):

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/configuration.py
@@ -37,11 +37,12 @@ class DummyConfiguration(BaseConfig):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         latency_use_jitter: bool,
         latency_max_msec: int,
         body: str,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.latency_use_jitter = latency_use_jitter
         self.latency_max_msec = latency_max_msec
         self.body = body
@@ -57,6 +58,7 @@ class DummyPipelineConfiguration(PipelineConfiguration[DummyConfiguration]):
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 latency_use_jitter=kwargs["latency_use_jitter"],
                 latency_max_msec=kwargs["latency_max_msec"],
                 body=kwargs["body"],

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -16,6 +16,7 @@ import json
 import logging
 import secrets
 import time
+from typing import Optional
 
 import requests
 
@@ -142,7 +143,7 @@ class DummyCompletionsPipeline(DummyMetaData, ModelPipelineCompletions[DummyConf
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         return HealthCheckSummary(
             {
                 MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
@@ -165,7 +166,7 @@ class DummyPlaybookGenerationPipeline(
             return PLAYBOOK, OUTLINE, []
         return PLAYBOOK, "", []
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -179,7 +180,7 @@ class DummyRoleGenerationPipeline(DummyMetaData, ModelPipelineRoleGeneration[Dum
         create_outline = params.create_outline
         return "install_nginx", ROLE_FILES, OUTLINE if create_outline else ""
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -194,5 +195,5 @@ class DummyPlaybookExplanationPipeline(
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         return EXPLANATION
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/grpc/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/grpc/configuration.py
@@ -27,7 +27,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
-# ANSIBLE_GRPC_HEALTHCHECK_URL
+# ENABLE_HEALTHCHECK_XXX
 
 
 @dataclass
@@ -38,9 +38,10 @@ class GrpcConfiguration(BaseConfig):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         health_check_url: str,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.health_check_url = health_check_url
 
     health_check_url: str
@@ -56,6 +57,7 @@ class GrpcPipelineConfiguration(PipelineConfiguration[GrpcConfiguration]):
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 health_check_url=kwargs["health_check_url"],
             ),
         )

--- a/ansible_ai_connect/ai/api/model_pipelines/http/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/configuration.py
@@ -28,6 +28,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
 # ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
+# ENABLE_HEALTHCHECK_XXX
 
 
 @dataclass
@@ -38,9 +39,10 @@ class HttpConfiguration(BaseConfig):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         verify_ssl: bool,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.verify_ssl = verify_ssl
 
     verify_ssl: bool
@@ -56,6 +58,7 @@ class HttpPipelineConfiguration(PipelineConfiguration[HttpConfiguration]):
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 verify_ssl=kwargs["verify_ssl"],
             ),
         )

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/configuration.py
@@ -27,6 +27,7 @@ from ansible_ai_connect.main.settings.types import t_model_mesh_api_type
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 
 
 class LangchainConfiguration(BaseConfig):
@@ -36,8 +37,9 @@ class LangchainConfiguration(BaseConfig):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool] = False,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
 
 
 class LangchainBasePipelineConfiguration(

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -16,7 +16,7 @@ import logging
 import re
 from abc import ABCMeta
 from textwrap import dedent
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 import requests
 from langchain_core.messages import BaseMessage
@@ -48,6 +48,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     RoleGenerationParameters,
     RoleGenerationResponse,
 )
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ class LangchainCompletionsPipeline(
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -261,7 +262,7 @@ class LangchainPlaybookGenerationPipeline(
 
         return playbook, outline, []
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -282,7 +283,7 @@ class LangchainRoleGenerationPipeline(
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         return "dummy_role", [], "dummy_outline"
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -344,7 +345,7 @@ class LangchainPlaybookExplanationPipeline(
         explanation = chain.invoke({"playbook": content})
         return explanation
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/configuration.py
@@ -28,6 +28,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
 # ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
+# ENABLE_HEALTHCHECK_XXX
 
 
 @dataclass
@@ -38,9 +39,10 @@ class LlamaCppConfiguration(BaseConfig):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         verify_ssl: bool,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.verify_ssl = verify_ssl
 
     verify_ssl: bool
@@ -56,6 +58,7 @@ class LlamaCppPipelineConfiguration(PipelineConfiguration[LlamaCppConfiguration]
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 verify_ssl=kwargs["verify_ssl"],
             ),
         )

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+from typing import Optional
 
 import requests
 
@@ -29,6 +30,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ModelPipelineCompletions,
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 
 logger = logging.getLogger(__name__)
 
@@ -124,5 +126,5 @@ class LlamaCppCompletionsPipeline(
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/configuration.py
@@ -26,7 +26,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 class NopConfiguration(BaseConfig):
 
     def __init__(self):
-        super().__init__("NOP", "NOP", None)
+        super().__init__("NOP", "NOP", None, False)
 
 
 @Register(api_type="nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
@@ -11,6 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Optional
+
 from ansible_ai_connect.ai.api.model_pipelines.nop.configuration import NopConfiguration
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ChatBotParameters,
@@ -34,6 +36,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     RoleGenerationResponse,
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 
 
 @Register(api_type="nop")
@@ -55,7 +58,7 @@ class NopCompletionsPipeline(NopMetaData, ModelPipelineCompletions[NopConfigurat
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -68,7 +71,7 @@ class NopContentMatchPipeline(NopMetaData, ModelPipelineContentMatch[NopConfigur
     def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -81,7 +84,7 @@ class NopPlaybookGenerationPipeline(NopMetaData, ModelPipelinePlaybookGeneration
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -94,7 +97,7 @@ class NopRoleGenerationPipeline(NopMetaData, ModelPipelineRoleGeneration[NopConf
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -109,7 +112,7 @@ class NopPlaybookExplanationPipeline(
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -122,5 +125,5 @@ class NopChatBotPipeline(NopMetaData, ModelPipelineChatBot[NopConfiguration]):
     def invoke(self, params: ChatBotParameters) -> ChatBotResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/configuration.py
@@ -25,6 +25,7 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 # ANSIBLE_AI_MODEL_MESH_API_URL
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 
 
 @dataclass
@@ -35,12 +36,9 @@ class OllamaConfiguration(LangchainConfiguration):
         inference_url: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
     ):
-        super().__init__(
-            inference_url,
-            model_id,
-            timeout,
-        )
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
 
 
 @Register(api_type="ollama")
@@ -53,6 +51,7 @@ class OllamaPipelineConfiguration(LangchainBasePipelineConfiguration):
                 inference_url=kwargs["inference_url"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
             ),
         )
 

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -24,6 +24,7 @@ from rest_framework.response import Response
 from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
     PIPELINE_CONFIGURATION,
 )
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 
 logger = logging.getLogger(__name__)
 
@@ -235,12 +236,17 @@ class ModelPipeline(
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    @staticmethod
+    @abstractmethod
+    def alias() -> str:
+        raise NotImplementedError
+
     @abstractmethod
     def invoke(self, params: PIPELINE_PARAMETERS) -> PIPELINE_RETURN:
         raise NotImplementedError
 
     @abstractmethod
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -252,6 +258,10 @@ class ModelPipelineCompletions(
 
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
+
+    @staticmethod
+    def alias():
+        return "model-server"
 
     @abstractmethod
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
@@ -267,6 +277,10 @@ class ModelPipelineContentMatch(
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    @staticmethod
+    def alias():
+        return "content-match"
+
 
 class ModelPipelinePlaybookGeneration(
     ModelPipeline[PIPELINE_CONFIGURATION, PlaybookGenerationParameters, PlaybookGenerationResponse],
@@ -277,6 +291,10 @@ class ModelPipelinePlaybookGeneration(
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    @staticmethod
+    def alias():
+        return "playbook-generation"
+
 
 class ModelPipelineRoleGeneration(
     ModelPipeline[PIPELINE_CONFIGURATION, RoleGenerationParameters, RoleGenerationResponse],
@@ -286,6 +304,10 @@ class ModelPipelineRoleGeneration(
 
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
+
+    @staticmethod
+    def alias():
+        return "role-generation"
 
 
 class ModelPipelinePlaybookExplanation(
@@ -299,6 +321,10 @@ class ModelPipelinePlaybookExplanation(
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    @staticmethod
+    def alias():
+        return "playbook-explanation"
+
 
 class ModelPipelineChatBot(
     ModelPipeline[PIPELINE_CONFIGURATION, ChatBotParameters, ChatBotResponse],
@@ -308,3 +334,7 @@ class ModelPipelineChatBot(
 
     def __init__(self, config: PIPELINE_CONFIGURATION):
         super().__init__(config=config)
+
+    @staticmethod
+    def alias():
+        return "chatbot-service"

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
@@ -72,6 +72,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 api_key=extract("api_key", "an-api-key", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
             )
         case "dummy":
@@ -80,6 +81,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 inference_url=inference_url,
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 latency_use_jitter=extract("latency_use_jitter", False, **kwargs),
                 latency_max_msec=extract("latency_max_msec", 0, **kwargs),
                 body=extract("body", "body", **kwargs),
@@ -90,6 +92,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 inference_url=extract("inference_url", "http://localhost", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 health_check_url=extract("health_check_url", "another-url", **kwargs),
             )
         case "http":
@@ -97,6 +100,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 inference_url=extract("inference_url", "http://localhost", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
             )
         case "llamacpp":
@@ -104,6 +108,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 inference_url=extract("inference_url", "http://localhost", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
             )
         case "ollama":
@@ -111,6 +116,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 inference_url=extract("inference_url", "http://localhost", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
             )
         case "wca":
             return WCASaaSConfiguration(
@@ -118,6 +124,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 api_key=extract("api_key", "an-api-key", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
                 retry_count=extract("retry_count", 4, **kwargs),
                 enable_ari_postprocessing=extract("enable_ari_postprocessing", False, **kwargs),
@@ -143,6 +150,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 api_key=extract("api_key", "an-api-key", **kwargs),
                 model_id=extract("model_id", "a-model-id", **kwargs),
                 timeout=extract("timeout", 1000, **kwargs),
+                enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
                 retry_count=extract("retry_count", 4, **kwargs),
                 enable_ari_postprocessing=extract("enable_ari_postprocessing", False, **kwargs),

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
@@ -30,6 +30,7 @@ from ansible_ai_connect.main.settings.types import t_model_mesh_api_type
 # ANSIBLE_AI_MODEL_MESH_API_KEY
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 # ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
 # ANSIBLE_WCA_RETRY_COUNT
 # WCA_ENABLE_ARI_POSTPROCESS
@@ -45,13 +46,14 @@ class WCABaseConfiguration(BaseConfig, metaclass=ABCMeta):
         api_key: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         verify_ssl: bool,
         retry_count: int,
         enable_ari_postprocessing: bool,
         health_check_api_key: str,
         health_check_model_id: str,
     ):
-        super().__init__(inference_url, model_id, timeout)
+        super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.api_key = api_key
         self.verify_ssl = verify_ssl
         self.retry_count = retry_count

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_dummy.py
@@ -23,6 +23,9 @@ from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 
 # -- Base
 # ANSIBLE_AI_MODEL_MESH_API_URL
+# ANSIBLE_AI_MODEL_MESH_MODEL_ID
+# ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 
 
 @dataclass
@@ -32,10 +35,7 @@ class WCADummyConfiguration(BaseConfig):
         self,
         inference_url: str,
     ):
-        super().__init__("dummy", "dummy", None)
-        self.inference_url = inference_url
-
-    inference_url: str
+        super().__init__(inference_url, "dummy", None, False)
 
 
 @Register(api_type="wca-dummy")

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
@@ -28,6 +28,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_base import (
 # ANSIBLE_AI_MODEL_MESH_API_KEY
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 # ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
 # ANSIBLE_WCA_RETRY_COUNT
 # WCA_ENABLE_ARI_POSTPROCESS
@@ -47,6 +48,7 @@ class WCAOnPremConfiguration(WCABaseConfiguration):
         api_key: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         verify_ssl: bool,
         retry_count: int,
         enable_ari_postprocessing: bool,
@@ -59,6 +61,7 @@ class WCAOnPremConfiguration(WCABaseConfiguration):
             api_key,
             model_id,
             timeout,
+            enable_health_check,
             verify_ssl,
             retry_count,
             enable_ari_postprocessing,
@@ -81,6 +84,7 @@ class WCAOnPremPipelineConfiguration(WCABasePipelineConfiguration):
                 api_key=kwargs["api_key"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 verify_ssl=kwargs["verify_ssl"],
                 retry_count=kwargs["retry_count"],
                 enable_ari_postprocessing=kwargs["enable_ari_postprocessing"],

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
@@ -28,6 +28,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_base import (
 # ANSIBLE_AI_MODEL_MESH_API_KEY
 # ANSIBLE_AI_MODEL_MESH_MODEL_ID
 # ANSIBLE_AI_MODEL_MESH_API_TIMEOUT
+# ENABLE_HEALTHCHECK_XXX
 # ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
 # ANSIBLE_WCA_RETRY_COUNT
 # WCA_ENABLE_ARI_POSTPROCESS
@@ -51,6 +52,7 @@ class WCASaaSConfiguration(WCABaseConfiguration):
         api_key: str,
         model_id: str,
         timeout: Optional[int],
+        enable_health_check: Optional[bool],
         verify_ssl: bool,
         retry_count: int,
         enable_ari_postprocessing: bool,
@@ -67,6 +69,7 @@ class WCASaaSConfiguration(WCABaseConfiguration):
             api_key,
             model_id,
             timeout,
+            enable_health_check,
             verify_ssl,
             retry_count,
             enable_ari_postprocessing,
@@ -97,6 +100,7 @@ class WCASaaSPipelineConfiguration(WCABasePipelineConfiguration):
                 api_key=kwargs["api_key"],
                 model_id=kwargs["model_id"],
                 timeout=kwargs["timeout"],
+                enable_health_check=kwargs["enable_health_check"],
                 verify_ssl=kwargs["verify_ssl"],
                 retry_count=kwargs["retry_count"],
                 enable_ari_postprocessing=kwargs["enable_ari_postprocessing"],

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
@@ -80,7 +80,7 @@ class WCADummyCompletionsPipeline(
     def infer_from_parameters(self, *args, **kwargs):
         return ""
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         return HealthCheckSummary(
             {
                 MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
@@ -100,5 +100,5 @@ class WCADummyRoleGenerationPipeline(
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         return "wca_dummy_role", [], "wca_dummy_outline"
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -176,7 +176,7 @@ class WCAOnPremContentMatchPipeline(
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
         return self._get_base_headers(api_key)
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -195,7 +195,7 @@ class WCAOnPremPlaybookGenerationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -208,7 +208,7 @@ class WCAOnPremRoleGenerationPipeline(
     def __init__(self, config: WCAOnPremConfiguration):
         super().__init__(config=config)
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -227,5 +227,5 @@ class WCAOnPremPlaybookExplanationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -304,7 +304,7 @@ class WCASaaSContentMatchPipeline(
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
         return self._get_base_headers(api_key)
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -323,7 +323,7 @@ class WCASaaSPlaybookGenerationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -336,7 +336,7 @@ class WCASaaSRoleGenerationPipeline(
     def __init__(self, config: WCASaaSConfiguration):
         super().__init__(config=config)
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -355,5 +355,5 @@ class WCASaaSPlaybookExplanationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -125,6 +125,7 @@ from ansible_ai_connect.ai.api.pipelines.completion_stages.response import (
     CompletionsPromptType,
 )
 from ansible_ai_connect.ai.api.serializers import CompletionRequestSerializer
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 from ansible_ai_connect.main.tests.test_views import create_user_with_provider
 from ansible_ai_connect.organizations.models import Organization
 from ansible_ai_connect.test_utils import (
@@ -217,7 +218,7 @@ class MockedPipelineCompletions(ModelPipelineCompletions[MockedConfig]):
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -229,7 +230,7 @@ class MockedPipelineContentMatch(ModelPipelineContentMatch[MockedConfig]):
     def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise NotImplementedError
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -242,7 +243,7 @@ class MockedPipelinePlaybookGeneration(ModelPipelinePlaybookGeneration[MockedCon
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
         return self.response_data, self.response_data, []
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -255,7 +256,7 @@ class MockedPipelineRoleGeneration(ModelPipelineRoleGeneration[MockedConfig]):
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         return self.response_data, [], self.response_data
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 
@@ -268,7 +269,7 @@ class MockedPipelinePlaybookExplanation(ModelPipelinePlaybookExplanation[MockedC
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         return self.response_data
 
-    def self_test(self):
+    def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 
 

--- a/ansible_ai_connect/healthcheck/apps.py
+++ b/ansible_ai_connect/healthcheck/apps.py
@@ -20,14 +20,17 @@ class HealthCheckAppConfig(AppConfig):
     name = "ansible_ai_connect.healthcheck"
 
     def ready(self):
+        from ansible_ai_connect.ai.api.model_pipelines.pipelines import ModelPipeline
+        from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY_ENTRY
+
         from .backends import (
             AuthorizationHealthCheck,
             AWSSecretManagerHealthCheck,
-            ChatbotServiceHealthCheck,
-            ModelServerHealthCheck,
+            ModelPipelineHealthCheck,
         )
 
-        plugin_dir.register(ModelServerHealthCheck)
         plugin_dir.register(AWSSecretManagerHealthCheck)
         plugin_dir.register(AuthorizationHealthCheck)
-        plugin_dir.register(ChatbotServiceHealthCheck)
+        for pipeline in REGISTRY_ENTRY.keys():
+            if issubclass(pipeline, ModelPipeline):
+                plugin_dir.register(ModelPipelineHealthCheck, pipeline_type=pipeline)

--- a/ansible_ai_connect/healthcheck/views.py
+++ b/ansible_ai_connect/healthcheck/views.py
@@ -53,15 +53,18 @@ def common_data():
 
 
 class HealthCheckCustomView(MainView):
+
+    from ansible_ai_connect.ai.api.model_pipelines.pipelines import ModelPipeline
+    from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY_ENTRY
+
     _plugin_name_map = {
         "DatabaseBackend": "db",
-        "ModelServerHealthCheck": "model-server",
         "AWSSecretManagerHealthCheck": "secret-manager",
-        "WCAHealthCheck": "wca",
-        "WCAOnPremHealthCheck": "wca-onprem",
         "AuthorizationHealthCheck": "authorization",
-        "ChatbotServiceHealthCheck": "chatbot-service",
     }
+    for pipeline in REGISTRY_ENTRY.keys():
+        if issubclass(pipeline, ModelPipeline):
+            _plugin_name_map[pipeline.__name__] = pipeline.alias()
 
     @method_decorator(cache_page(CACHE_TIMEOUT))
     def get(self, request, *args, **kwargs):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import sys
+from copy import deepcopy
 from importlib.resources import files
 from pathlib import Path
 from typing import cast
@@ -694,7 +695,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData  # noqa
 from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY_ENTRY  # noqa
 
 pipelines = [i for i in REGISTRY_ENTRY.keys() if issubclass(i, MetaData)]
-pipeline_config: dict = {k.__name__: ANSIBLE_AI_PIPELINE_CONFIG for k in pipelines}
+pipeline_config: dict = {k.__name__: deepcopy(ANSIBLE_AI_PIPELINE_CONFIG) for k in pipelines}
 
 # The ChatBot does not use the same configuration as everything else
 pipeline_config["ModelPipelineChatBot"] = {
@@ -705,6 +706,14 @@ pipeline_config["ModelPipelineChatBot"] = {
         "verify_ssl": ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL,
     },
 }
+
+# Enable Health Checks where we have them implemented
+pipeline_config["ModelPipelineCompletions"]["config"][
+    "enable_health_check"
+] = ENABLE_HEALTHCHECK_MODEL_MESH
+pipeline_config["ModelPipelineChatBot"]["config"][
+    "enable_health_check"
+] = ENABLE_HEALTHCHECK_MODEL_MESH
 
 ANSIBLE_AI_MODEL_MESH_CONFIG = json.dumps(pipeline_config)
 # ==========================================


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-33634

## Description
Add/expose "Health Check" for each pipeline.

The "aliases" of "Completions" and "Chat Bot" have been preserved as `model-server` and `chatbot-service` respectfully.

This means we _should not_ have to update our test suites - nor anybody else who depends on the existing names.

## Testing
Run the service locally and check the _health_ endpoint: http://127.0.0.1:8000/check/status/

Example output:
```
{
  "timestamp": "2024-12-06T09:38:32.625598",
  "version": "image-tags-not-defined",
  "git_commit": "git-commit-hash-not-defined",
  "deployed_region": "unknown",
  "status": "error",
  "dependencies": [
    {
      "name": "secret-manager",
      "status": "ok",
      "time_taken": 466.697
    },
    {
      "name": "authorization",
      "status": "ok",
      "time_taken": 0.032
    },
    {
      "name": "db",
      "status": "ok",
      "time_taken": 39.233
    },
    {
      "name": "chatbot-service",
      "status": {
        "provider": "http",
        "models": "unavailable: An error occurred" ## <!-- [manstis] I don't have a public route to the ChatBot backend
      },
      "time_taken": 41.034
    },
    {
      "name": "model-server",
      "status": {
        "provider": "wca",
        "tokens": "ok",
        "models": "ok"
      },
      "time_taken": 3394.077
    },
    {
      "name": "content-match",
      "status": "disabled",
      "time_taken": 0.002
    },
    {
      "name": "playbook-explanation",
      "status": "disabled",
      "time_taken": 0.002
    },
    {
      "name": "playbook-generation",
      "status": "disabled",
      "time_taken": 0.001
    },
    {
      "name": "role-generation",
      "status": "disabled",
      "time_taken": 0.002
    }
  ]
}
```

### Steps to test
1. Pull down the PR
2. Run the service locally
3. Check the _health_ endpoint http://127.0.0.1:8000/check/status/

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: