### PR TITLE
AAP-34739: Implement the role generation with the Ollama pipeline

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/tests/test_pipeline.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/tests/test_pipeline.py
@@ -15,12 +15,16 @@ from ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines import (
     LangchainCompletionsPipeline,
     LangchainPlaybookExplanationPipeline,
     LangchainPlaybookGenerationPipeline,
+    LangchainRoleGenerationPipeline,
+    unwrap_message_with_yaml_answer,
     unwrap_playbook_answer,
+    unwrap_role_answer,
     unwrap_task_answer,
 )
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     PlaybookExplanationParameters,
     PlaybookGenerationParameters,
+    RoleGenerationParameters,
 )
 from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 
@@ -104,12 +108,123 @@ class TestUnwrapPlaybookAnswer(TestCase):
         - and that
         """
 
-        class MyMessage(BaseMessage):
-            pass
-
         playbook, outline = unwrap_playbook_answer(_content)
         self.assertTrue(playbook.startswith("- hosts"))
         self.assertTrue(outline.startswith("This playbook"))
+
+
+class TestUnwrapRoleAnswer(TestCase):
+    _first_request_content = """
+Role name: vpc_subnet_ec2
+
+tasks/main.yml
+
+---
+# Tasks for AWS VPC Creation, Subnet Creation and EC2 Instance Deployment
+
+```yaml
+# Define the AWS region
+- aws_region: "us-west-2"
+ tags:
+    Name: "{{ ansible_playbook_name }}-region"
+
+# Attach the internet gateway to VPC
+- name: Attach Internet Gateway to VPC
+ aws_eip_association:
+    eip: "{{ igw.internet_gateways[0].id }}"
+    vpc: "{{ vpc.vpcs[0].id }}"
+    state: present
+
+# Print the EC2 instance ID for verification
+- name: Display EC2 Instance ID
+  debug: var = ec2_instance.instances[0].id
+
+```
+"""
+    _second_request_content = """
+# defaults/main.yml
+
+```yaml
+# Set default AWS region if not provided in the inventory file
+aws_region: "us-west-2"
+```
+"""
+    _expected_second_request_content = unwrap_message_with_yaml_answer(_second_request_content)
+    _wrong_role_name_format = """
+```yaml
+---
+# Role Name: Preparing_VPC
+
+# Tasks:
+ - name: Create VPC
+   ec2_vpc:
+     cidr_block: 10.0.0.0/16
+     region: us-east-1
+     tags:
+       Name: MyVPC
+
+ - name: Create EC2 Instance
+   ec2_instance:
+     subnet_id: "{{ vpcs.vpcs[0].subnets[0] }}"
+     region: us-east-1
+     image_id: ami-0a42b56c7d8e9f01
+     instance_type: t2.micro
+     wait: yes
+     tags:
+       Name: MyEC2
+```
+"""
+
+    _content_without_yaml = """
+# Role Name: amazon-vpc-ec2-deploy
+
+   ---
+   # Main file for tasks in amazon-vpc-ec2-deploy role.
+
+   - name: Create VPC
+     aws_vpc:
+       state: present
+       cidr_block: 10.0.0.0/16
+       tags:
+         Name: my-vpc
+
+   - name: Wait for EC2 instance to be ready
+     wait_for:
+       delay: 10
+       timeout: 600
+       seconds: 300
+     when: ec2_instance is defined and ec2_instance.instance_id is defined
+"""
+
+    def test_unwrap_wrong_role(self):
+        role, files, outline = unwrap_role_answer(self._wrong_role_name_format, False)
+        self.assertEqual(role, "role_name")
+        self.assertTrue(files[0]["content"].startswith("---"))
+        self.assertTrue(files[0]["content"].endswith("Name: MyEC2"))
+        self.assertEqual(-1, files[0]["content"].find("```"))
+        self.assertEqual(-1, files[0]["content"].find("yaml"))
+        self.assertEqual(outline, "")
+
+    def test_role_without_yaml(self):
+        role, files, outline = unwrap_role_answer(self._content_without_yaml, False)
+        self.assertEqual(role, "amazon-vpc-ec2-deploy")
+        self.assertTrue(files[0]["content"].startswith("---"))
+        self.assertTrue(files[0]["content"].endswith("is defined"))
+        self.assertEqual(outline, "")
+
+    def test_unwrap_role(self):
+        role, files, outline = unwrap_role_answer(self._first_request_content, True)
+        self.assertEqual(role, "vpc_subnet_ec2")
+        self.assertTrue(files[0]["content"].startswith("# Define"))
+        self.assertTrue(files[0]["content"].endswith("ec2_instance.instances[0].id"))
+        self.assertEqual(-1, files[0]["content"].find("```"))
+        self.assertEqual(-1, files[0]["content"].find("yaml"))
+        self.assertEqual(
+            outline,
+            """1. Attach Internet Gateway to VPC
+2. Display EC2 Instance ID
+""",
+        )
 
 
 class TestLangChainClientNotImplemented(TestCase):
@@ -175,6 +290,59 @@ class TestLangChainPlaybookGenerationPipeline(WisdomServiceLogAwareTestCase):
             )
             self.assertEqual(playbook, "my_playbook")
             self.assertEqual(outline, "my outline")
+
+
+class TestLangChainRoleGenerationPipeline(WisdomServiceLogAwareTestCase):
+
+    _first_call = True
+
+    def setUp(self):
+        self._first_call = True
+        self.my_client = LangchainRoleGenerationPipeline(
+            LangchainConfiguration(
+                inference_url="http://localhost", model_id="a-model-id", timeout=None
+            )
+        )
+
+        def fake_get_chat_mode(model_id=None):
+
+            logger.debug(f"get_chat_mode: model_id={model_id}")
+            if self._first_call:
+                self._first_call = False
+                return FakeListLLM(responses=[TestUnwrapRoleAnswer._first_request_content, ""])
+            else:
+                return FakeListLLM(responses=[TestUnwrapRoleAnswer._second_request_content, ""])
+
+        self.my_client.get_chat_model = fake_get_chat_mode
+
+    def test_generate_role(self):
+        role, files, outline = self.my_client.invoke(
+            RoleGenerationParameters.init(
+                request=Mock(),
+                text="foo",
+                create_outline=False,
+            )
+        )
+        self.assertEqual(role, "vpc_subnet_ec2")
+        self.assertEqual(files[1]["content"], TestUnwrapRoleAnswer._expected_second_request_content)
+        self.assertEqual(outline, "")
+
+    def test_generate_role_with_outline(self):
+        role, files, outline = self.my_client.invoke(
+            RoleGenerationParameters.init(
+                request=Mock(),
+                text="foo",
+                create_outline=True,
+            )
+        )
+        self.assertEqual(role, "vpc_subnet_ec2")
+        self.assertEqual(files[1]["content"], TestUnwrapRoleAnswer._expected_second_request_content)
+        self.assertEqual(
+            outline,
+            """1. Attach Internet Gateway to VPC
+2. Display EC2 Instance ID
+""",
+        )
 
 
 class TestLangChainPlaybookExplanationPipeline(WisdomServiceLogAwareTestCase):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -681,7 +681,7 @@ elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "dummy":
         },
     }
 elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "ollama":
-    ANSIBLE_AI_WCA_CONFIG = {
+    ANSIBLE_AI_PIPELINE_CONFIG = {
         "provider": "ollama",
         "config": {
             "inference_url": ANSIBLE_AI_MODEL_MESH_API_URL,

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -680,6 +680,15 @@ elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "dummy":
             "latency_use_jitter": DUMMY_MODEL_RESPONSE_LATENCY_USE_JITTER,
         },
     }
+elif ANSIBLE_AI_MODEL_MESH_API_TYPE == "ollama":
+    ANSIBLE_AI_WCA_CONFIG = {
+        "provider": "ollama",
+        "config": {
+            "inference_url": ANSIBLE_AI_MODEL_MESH_API_URL,
+            "model_id": ANSIBLE_AI_MODEL_MESH_MODEL_ID,
+            "timeout": ANSIBLE_AI_MODEL_MESH_API_TIMEOUT,
+        },
+    }
 else:
     ANSIBLE_AI_PIPELINE_CONFIG = {
         "provider": "wca-dummy",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-34739>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Ran locally with Ollama
3. Get token: `python ansible_ai_connect/manage.py createtoken --username admin_test`
4. Run culr request:
```bash
curl -X 'POST' \
  'http://127.0.0.1:8000/api/v0/ai/generations/role' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer LlY0NYDDj5fLqmMzsfVkyNuNcreSRS" \
  -d '{
    "text": "Prepare a VPC, create the subnets, and deploy an ec2-instance",
    "createOutline": true,
    "generationId": "6abdaa82-a704-4883-9f7b-759b85fc1d9e"
    }'
```

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
