### PR TITLE
PR tp remove chatbot model selector which now defaults to granite3-8b

### DIFF
--- a/ansible_ai_connect_chatbot/README.md
+++ b/ansible_ai_connect_chatbot/README.md
@@ -62,6 +62,7 @@ one of models defined in the configuration used by the chat service.
 ```commandline
 CHATBOT_URL=http://127.0.0.1:8080
 CHATBOT_DEFAULT_PROVIDER=wisdom
+CHATBOT_DEFAULT_MODEL=granite3-8b
 ```
 
 You also need to configure Red Hat SSO authentication on your local

--- a/ansible_ai_connect_chatbot/README.md
+++ b/ansible_ai_connect_chatbot/README.md
@@ -62,7 +62,6 @@ one of models defined in the configuration used by the chat service.
 ```commandline
 CHATBOT_URL=http://127.0.0.1:8080
 CHATBOT_DEFAULT_PROVIDER=wisdom
-CHATBOT_DEFAULT_MODEL=granite-8b
 ```
 
 You also need to configure Red Hat SSO authentication on your local

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -46,7 +46,6 @@ import {
   ChatbotAlert,
   ChatbotDisplayMode,
   ChatbotHeaderMain,
-  ChatbotHeaderSelectorDropdown,
   ChatbotToggle,
   FileDropZone,
 } from "@patternfly/chatbot";
@@ -225,20 +224,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
             </ChatbotHeaderTitle>
           </ChatbotHeaderMain>
           <ChatbotHeaderActions>
-            {inDebugMode() && (
-              <ChatbotHeaderSelectorDropdown
-                value={selectedModel}
-                onSelect={onSelectModel}
-              >
-                <DropdownList>
-                  {modelsSupported.map((m) => (
-                    <DropdownItem value={m.model} key={m.model}>
-                      {m.model}
-                    </DropdownItem>
-                  ))}
-                </DropdownList>
-              </ChatbotHeaderSelectorDropdown>
-            )}
             <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
               <DropdownGroup label="Display mode">
                 <DropdownList>

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -34,8 +34,6 @@ import lightspeedLogoDark from "../assets/lightspeed_dark.svg";
 
 import "./AnsibleChatbot.scss";
 import {
-  inDebugMode,
-  modelsSupported,
   useChatbot,
 } from "../useChatbot/useChatbot";
 import { ReferencedDocuments } from "../ReferencedDocuments/ReferencedDocuments";
@@ -84,8 +82,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
     handleSend,
     alertMessage,
     setAlertMessage,
-    selectedModel,
-    setSelectedModel,
     setConversationId,
   } = useChatbot();
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
@@ -101,13 +97,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
-
-  const onSelectModel = (
-    _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined,
-  ) => {
-    setSelectedModel(value as string);
-  };
 
   const onSelectDisplayMode = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -34,6 +34,8 @@ import lightspeedLogoDark from "../assets/lightspeed_dark.svg";
 
 import "./AnsibleChatbot.scss";
 import {
+  inDebugMode,
+  modelsSupported,
   useChatbot,
 } from "../useChatbot/useChatbot";
 import { ReferencedDocuments } from "../ReferencedDocuments/ReferencedDocuments";
@@ -44,6 +46,7 @@ import {
   ChatbotAlert,
   ChatbotDisplayMode,
   ChatbotHeaderMain,
+  ChatbotHeaderSelectorDropdown,
   ChatbotToggle,
   FileDropZone,
 } from "@patternfly/chatbot";
@@ -82,6 +85,8 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
     handleSend,
     alertMessage,
     setAlertMessage,
+    selectedModel,
+    setSelectedModel,
     setConversationId,
   } = useChatbot();
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
@@ -97,6 +102,13 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  const onSelectModel = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    setSelectedModel(value as string);
+  };
 
   const onSelectDisplayMode = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -213,6 +225,20 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
             </ChatbotHeaderTitle>
           </ChatbotHeaderMain>
           <ChatbotHeaderActions>
+            {inDebugMode() && (
+              <ChatbotHeaderSelectorDropdown
+                value={selectedModel}
+                onSelect={onSelectModel}
+              >
+                <DropdownList>
+                  {modelsSupported.map((m) => (
+                    <DropdownItem value={m.model} key={m.model}>
+                      {m.model}
+                    </DropdownItem>
+                  ))}
+                </DropdownList>
+              </ChatbotHeaderSelectorDropdown>
+            )}
             <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
               <DropdownGroup label="Display mode">
                 <DropdownList>

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -311,6 +311,12 @@ describe("App tests", () => {
     mockAxios(200);
 
     renderApp(true);
+    const modelSelection = screen.getByText("granite3-8b");
+    await act(async () => fireEvent.click(modelSelection));
+    expect(screen.getByRole("menuitem", { name: "granite3-8b" })).toBeTruthy();
+    await act(async () =>
+      screen.getByRole("menuitem", { name: "granite3-8b" }).click(),
+    );
 
     const textArea = screen.getByLabelText("Send a message...");
     await act(async () => userEvent.type(textArea, "Hello"));

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -311,13 +311,6 @@ describe("App tests", () => {
     mockAxios(200);
 
     renderApp(true);
-    const modelSelection = screen.getByText("granite-8b");
-    await act(async () => fireEvent.click(modelSelection));
-    expect(screen.getByRole("menuitem", { name: "granite-8b" })).toBeTruthy();
-    expect(screen.getByRole("menuitem", { name: "granite3-8b" })).toBeTruthy();
-    await act(async () =>
-      screen.getByRole("menuitem", { name: "granite3-8b" }).click(),
-    );
 
     const textArea = screen.getByLabelText("Send a message...");
     await act(async () => userEvent.type(textArea, "Hello"));

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -22,11 +22,6 @@ const userName = document.getElementById("user_name")?.innerText ?? "User";
 const botName =
   document.getElementById("bot_name")?.innerText ?? "Ansible Lightspeed";
 
-export const modelsSupported: LLMModel[] = [
-  { model: "granite-8b", provider: "my_rhoai" },
-  { model: "granite3-8b", provider: "my_rhoai_g3" },
-];
-
 export const readCookie = (name: string): string | null => {
   const nameEQ = name + "=";
   const ca = document.cookie.split(";");
@@ -123,7 +118,6 @@ export const useChatbot = () => {
   const [conversationId, setConversationId] = useState<
     string | null | undefined
   >(undefined);
-  const [selectedModel, setSelectedModel] = useState("granite-8b");
 
   const addMessage = (newMessage: ExtendedMessage) => {
     setMessages((msgs: ExtendedMessage[]) => [...msgs, newMessage]);
@@ -224,15 +218,6 @@ export const useChatbot = () => {
       query: message,
     };
 
-    if (inDebugMode()) {
-      for (const m of modelsSupported) {
-        if (selectedModel === m.model) {
-          chatRequest.model = m.model;
-          chatRequest.provider = m.provider;
-        }
-      }
-    }
-
     setIsLoading(true);
     try {
       const csrfToken = readCookie("csrftoken");
@@ -301,8 +286,6 @@ export const useChatbot = () => {
     handleSend,
     alertMessage,
     setAlertMessage,
-    selectedModel,
-    setSelectedModel,
     setConversationId,
   };
 };

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -22,6 +22,10 @@ const userName = document.getElementById("user_name")?.innerText ?? "User";
 const botName =
   document.getElementById("bot_name")?.innerText ?? "Ansible Lightspeed";
 
+export const modelsSupported: LLMModel[] = [
+  { model: "granite3-8b", provider: "my_rhoai_g3" },
+];
+
 export const readCookie = (name: string): string | null => {
   const nameEQ = name + "=";
   const ca = document.cookie.split(";");
@@ -118,6 +122,7 @@ export const useChatbot = () => {
   const [conversationId, setConversationId] = useState<
     string | null | undefined
   >(undefined);
+  const [selectedModel, setSelectedModel] = useState("granite3-8b");
 
   const addMessage = (newMessage: ExtendedMessage) => {
     setMessages((msgs: ExtendedMessage[]) => [...msgs, newMessage]);
@@ -218,6 +223,15 @@ export const useChatbot = () => {
       query: message,
     };
 
+    if (inDebugMode()) {
+      for (const m of modelsSupported) {
+        if (selectedModel === m.model) {
+          chatRequest.model = m.model;
+          chatRequest.provider = m.provider;
+        }
+      }
+    }
+
     setIsLoading(true);
     try {
       const csrfToken = readCookie("csrftoken");
@@ -286,6 +300,8 @@ export const useChatbot = () => {
     handleSend,
     alertMessage,
     setAlertMessage,
+    selectedModel,
+    setSelectedModel,
     setConversationId,
   };
 };


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: NA
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
PR tp remove chatbot model selector which now defaults to granite3-8b

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. npm install
3. npm run start
4. chatbot model selector is defaulted to 3-8b and 8b is removed from option.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
NA

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
