### PR TITLE
AAP-37014: Make Wisdom's Chatbot interfaces available to RH employees only

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -98,6 +98,7 @@ from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
 )
 from ansible_ai_connect.users.models import User
 
+from ...main.permissions import IsRHEmployee, IsTestUser
 from ...users.throttling import EndpointRateThrottle
 from ..feature_flags import FeatureFlags
 from .data.data_model import ContentMatchPayloadData, ContentMatchResponseDto
@@ -1119,6 +1120,7 @@ class Chat(APIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
+        IsRHEmployee | IsTestUser,
     ]
     required_scopes = ["read", "write"]
     throttle_classes = [ChatEndpointThrottle]


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-37014>

## Description
- Make Wisdom's Chatbot interfaces available to RH employees only
- Assume a RH employee when it has the `redhat:employees` realm role and it's email is from `redhat.com` domain

## Testing
Tested locally against an employee user, and a non-employee user. 
Tested both chatbot view and API endpoint.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
