### PR TITLE
Update login.html

### DIFF
--- a/ansible_ai_connect/main/templates/registration/login.html
+++ b/ansible_ai_connect/main/templates/registration/login.html
@@ -28,7 +28,7 @@
                 <div class="pf-l-bullseye">
                   <div class="pf-l-bullseye__item">
                     <div class="pf-l-level pf-m-gutter ls_bottom_menu">
-                      <a class="pf-l-level__item" href="https://docs.ai.ansible.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
+                      <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
                       <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
                       {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_org_has_subscription and user.rh_user_is_org_admin %}
                       <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -44,6 +44,7 @@ class LoginView(auth_views.LoginView):
         context["deployment_mode"] = settings.DEPLOYMENT_MODE
         context["project_name"] = settings.ANSIBLE_AI_PROJECT_NAME
         context["aap_api_provider_name"] = settings.AAP_API_PROVIDER_NAME
+        context["documentation_url"] = settings.COMMERCIAL_DOCUMENTATION_URL
         return context
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
Updated deprecated documentation URL to use the official commercial documentation URL.

Jira Issue: [<https://issues.redhat.com/browse/AAP-33000>](https://issues.redhat.com/browse/AAP-33000)

## Description
Updated the documentation URL for the login page to point to the official commercial documentation URL.

## Testing

### Steps to test
1. Pull down the PR
2. Run the service
3. Ensure that before you login, clicking the Documentation link takes you to the commercial documentation URL on access.redhat.com (and not docs.ai...)

### Scenarios tested
Visual verification only.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
