### PR TITLE
Upgrade Django to cover GHSA-8498-2h75-472j

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -89,7 +89,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.16
+django==4.2.17
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -89,7 +89,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 diff-match-patch==20230430
     # via django-import-export
-django==4.2.16
+django==4.2.17
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ boto3==1.26.84
 black==24.3.0
 certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 cryptography==43.0.1
-Django==4.2.16
+Django==4.2.17
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: No Jira issues
<!-- This PR does not need a corresponding Jira item. -->

## Description
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
django | 4.2.16 | GHSA-8498-2h75-472j | 4.2.17,5.0.10,5.1.4 | An issue was discovered in Django 5.1 before 5.1.4, 5.0 before 5.0.10, and 4.2 before 4.2.17. The strip_tags() method and striptags template filter are subject to a potential denial-of-service attack via certain inputs containing large sequences of nested incomplete HTML entities.
django | 4.2.16 | GHSA-m9g8-fxxm-xg86 | 4.2.17,5.0.10,5.1.4 | An issue was discovered in Django 5.1 before 5.1.4, 5.0 before 5.0.10, and 4.2 before 4.2.17. Direct usage of the django.db.models.fields.json.HasKey lookup, when an Oracle database is used, is subject to SQL injection if untrusted data is used as an lhs value. (Applications that use the jsonfield.has_key lookup via __ are unaffected.)

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Green pipeline

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
