### PR TITLE
langchain/Ollama: move to langchain_ollama.OllamaLLM

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -21,5 +21,5 @@ jobs:
         python-version: '3.11'
     - name: install
       run: |
-        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain langchain-community grpcio django-health-check
+        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain langchain-ollama grpcio django-health-check
         pyright

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from langchain_community.llms import Ollama
+from langchain_ollama import OllamaLLM
 
 from ansible_ai_connect.ai.api.model_pipelines.langchain.pipelines import (
     LangchainCompletionsPipeline,
@@ -48,7 +48,7 @@ class OllamaCompletionsPipeline(LangchainCompletionsPipeline[OllamaConfiguration
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
-        return Ollama(
+        return OllamaLLM(
             base_url=self.config.inference_url,
             model=model_id,
         )
@@ -61,7 +61,7 @@ class OllamaPlaybookGenerationPipeline(LangchainPlaybookGenerationPipeline[Ollam
         super().__init__(config=config)
 
     def get_chat_model(self, model_id):
-        return Ollama(
+        return OllamaLLM(
             base_url=self.config.inference_url,
             model=model_id,
         )
@@ -74,7 +74,7 @@ class OllamaRoleGenerationPipeline(LangchainRoleGenerationPipeline[OllamaConfigu
         super().__init__(config=config)
 
     def get_chat_model(self, model_id):
-        return Ollama(
+        return OllamaLLM(
             base_url=self.config.inference_url,
             model=model_id,
         )
@@ -87,7 +87,7 @@ class OllamaPlaybookExplanationPipeline(LangchainPlaybookExplanationPipeline[Oll
         super().__init__(config=config)
 
     def get_chat_model(self, model_id):
-        return Ollama(
+        return OllamaLLM(
             base_url=self.config.inference_url,
             model=model_id,
         )

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_pipelines.py
@@ -43,7 +43,7 @@ class TestOllama(TestCase):
             "model_id": "a-model-id",
         }
 
-    @patch("ansible_ai_connect.ai.api.model_pipelines.ollama.pipelines.Ollama")
+    @patch("ansible_ai_connect.ai.api.model_pipelines.ollama.pipelines.OllamaLLM")
     def test_infer(self, m_ollama):
         def final(_):
             return f"- name: Vache volante!\n{indent(self.expected_task_body, '  ')}"

--- a/docs/pycharm-setup.md
+++ b/docs/pycharm-setup.md
@@ -262,10 +262,7 @@ Then run `runserver` in Debug mode with PyCharms Run > Debug… menu. Console ou
 import sys; print('Python %s on %s' % (sys.version, sys.platform))
 /home/ttakamiy/git/ansible/ansible-ai-connect-service/venv/bin/python -X pycache_prefix=/home/ttakamiy/.cache/JetBrains/PyCharmCE2024.1/cpython-cache /home/ttakamiy/.local/share/JetBrains/Toolbox/apps/pycharm-community/plugins/python-ce/helpers/pydev/pydevd.py --multiprocess --qt-support=auto --client 127.0.0.1 --port 35229 --file /home/ttakamiy/git/ansible/ansible-ai-connect-service/ansible_ai_connect/manage.py runserver --noreload
 Connected to pydev debugger (build 241.18034.82)
-/home/ttakamiy/git/ansible/ansible-ai-connect-service/venv/lib/python3.11/site-packages/langchain/llms/__init__.py:548: LangChainDeprecationWarning: Importing LLMs from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:
-`from langchain_community.llms import Ollama`.
-To install langchain-community run `pip install -U langchain-community`.
-  warnings.warn(
+(...)
 Performing system checks...
 System check identified no issues (0 silenced).
 June 28, 2024 - 16:56:26

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -7,9 +7,7 @@
 aiohappyeyeballs==2.3.5
     # via aiohttp
 aiohttp==3.10.11
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.6.0
@@ -77,8 +75,6 @@ cryptography==43.0.1
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
-dataclasses-json==0.6.7
-    # via langchain-community
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -171,8 +167,6 @@ httpx==0.27.2
     # via
     #   langsmith
     #   ollama
-httpx-sse==0.4.0
-    # via langchain-community
 idna==3.7
     # via
     #   -r requirements.in
@@ -216,15 +210,10 @@ jwcrypto==1.5.6
     #   -r requirements.in
     #   django-oauth-toolkit
 langchain==0.3.10
-    # via
-    #   -r requirements.in
-    #   langchain-community
-langchain-community==0.3.10
     # via -r requirements.in
 langchain-core==0.3.22
     # via
     #   langchain
-    #   langchain-community
     #   langchain-ollama
     #   langchain-text-splitters
 langchain-ollama==0.2.1
@@ -234,7 +223,6 @@ langchain-text-splitters==0.3.1
 langsmith==0.1.138
     # via
     #   langchain
-    #   langchain-community
     #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
@@ -242,8 +230,6 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.21.3
-    # via dataclasses-json
 matplotlib-inline==0.1.7
     # via ipython
 mdurl==0.1.2
@@ -255,13 +241,9 @@ multidict==6.0.5
     #   aiohttp
     #   yarl
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   typing-inspect
+    # via black
 numpy==1.26.4
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 oauth2client==4.1.3
     # via pydrive2
 oauthlib==3.2.2
@@ -285,7 +267,6 @@ packaging==23.2
     #   black
     #   django-allow-cidr
     #   langchain-core
-    #   marshmallow
 parso==0.8.4
     # via jedi
 pathspec==0.12.1
@@ -339,11 +320,8 @@ pydantic==2.9.2
     #   langchain-core
     #   langsmith
     #   ollama
-    #   pydantic-settings
 pydantic-core==2.23.4
     # via pydantic
-pydantic-settings==2.6.0
-    # via langchain-community
 pydrive2==1.20.0
     # via -r requirements.in
 pygments==2.17.2
@@ -366,8 +344,6 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   segment-analytics-python
-python-dotenv==1.0.1
-    # via pydantic-settings
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2024.1
@@ -383,7 +359,6 @@ pyyaml==6.0
     #   ansible-risk-insight
     #   drf-spectacular
     #   langchain
-    #   langchain-community
     #   langchain-core
     #   pydrive2
     #   tablib
@@ -401,7 +376,6 @@ requests==2.32.0
     #   django-oauth-toolkit
     #   google-api-core
     #   langchain
-    #   langchain-community
     #   langsmith
     #   requests-oauthlib
     #   requests-toolbelt
@@ -458,9 +432,7 @@ social-auth-core==4.5.4
     #   -r requirements.in
     #   social-auth-app-django
 sqlalchemy==2.0.29
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 sqlparse==0.5.0
     # via
     #   -r requirements.in
@@ -478,7 +450,6 @@ tabulate==0.9.0
 tenacity==8.2.3
     # via
     #   langchain
-    #   langchain-community
     #   langchain-core
 traitlets==5.14.3
     # via
@@ -493,9 +464,6 @@ typing-extensions==4.11.0
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   typing-inspect
-typing-inspect==0.9.0
-    # via dataclasses-json
 uritemplate==4.1.1
     # via
     #   drf-spectacular

--- a/requirements-dev-aarch64.txt
+++ b/requirements-dev-aarch64.txt
@@ -4,6 +4,31 @@
 #
 #    pip-compile --constraint=requirements-aarch64.txt --output-file=requirements-dev-aarch64.txt requirements-dev.in
 #
+aiohappyeyeballs==2.3.5
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
+aiohttp==3.10.11
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+aiosignal==1.3.1
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
+annotated-types==0.6.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   pydantic
+anyio==4.6.2.post1
+    # via
+    #   -c requirements-aarch64.txt
+    #   httpx
+attrs==23.2.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
 black==24.3.0
     # via
     #   -c requirements-aarch64.txt
@@ -14,6 +39,8 @@ certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5ac
     # via
     #   -c requirements-aarch64.txt
     #   -r requirements-dev.in
+    #   httpcore
+    #   httpx
     #   requests
 cfgv==3.4.0
     # via pre-commit
@@ -28,6 +55,8 @@ click==8.1.7
     #   pip-tools
 coverage==7.2.1
     # via -r requirements-dev.in
+dataclasses-json==0.6.7
+    # via langchain-community
 distlib==0.3.8
     # via virtualenv
 enum-compat==0.0.3
@@ -38,34 +67,109 @@ filelock==3.13.4
     #   virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
+frozenlist==1.4.1
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
+    #   aiosignal
+greenlet==3.0.3
+    # via
+    #   -c requirements-aarch64.txt
+    #   sqlalchemy
 grpcio==1.66.2
     # via
     #   -c requirements-aarch64.txt
     #   grpcio-tools
 grpcio-tools==1.66.2
     # via -r requirements-dev.in
+h11==0.14.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   httpcore
+httpcore==1.0.6
+    # via
+    #   -c requirements-aarch64.txt
+    #   httpx
+httpx==0.27.2
+    # via
+    #   -c requirements-aarch64.txt
+    #   langsmith
+httpx-sse==0.4.0
+    # via langchain-community
 identify==2.5.36
     # via pre-commit
 idna==3.7
     # via
     #   -c requirements-aarch64.txt
     #   -r requirements-dev.in
+    #   anyio
+    #   httpx
     #   requests
+    #   yarl
 isort==5.10.1
     # via -r requirements-dev.in
+jsonpatch==1.33
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain-core
+jsonpointer==2.4
+    # via
+    #   -c requirements-aarch64.txt
+    #   jsonpatch
+langchain==0.3.10
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain-community
+langchain-community==0.3.10
+    # via -r requirements-dev.in
+langchain-core==0.3.22
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.3.1
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+langsmith==0.1.138
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
+marshmallow==3.23.1
+    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
+multidict==6.0.5
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements-aarch64.txt
     #   black
+    #   typing-inspect
 nodeenv==1.8.0
     # via pre-commit
+numpy==1.26.4
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+orjson==3.10.1
+    # via
+    #   -c requirements-aarch64.txt
+    #   langsmith
 packaging==23.2
     # via
     #   -c requirements-aarch64.txt
     #   black
     #   build
+    #   langchain-core
+    #   marshmallow
 pathspec==0.12.1
     # via
     #   -c requirements-aarch64.txt
@@ -80,32 +184,88 @@ platformdirs==4.2.1
     #   virtualenv
 pre-commit==3.7.0
     # via -r requirements-dev.in
+propcache==0.2.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   yarl
 protobuf==5.28.2
     # via
     #   -c requirements-aarch64.txt
     #   grpcio-tools
 pycodestyle==2.10.0
     # via flake8
+pydantic==2.9.2
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-core
+    #   langsmith
+    #   pydantic-settings
+pydantic-core==2.23.4
+    # via
+    #   -c requirements-aarch64.txt
+    #   pydantic
+pydantic-settings==2.6.1
+    # via langchain-community
 pyflakes==3.0.1
     # via flake8
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
+python-dotenv==1.0.1
+    # via pydantic-settings
 pyyaml==6.0
     # via
     #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
     #   pre-commit
     #   responses
     #   yamllint
 requests==2.32.0
     # via
     #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+    #   langsmith
+    #   requests-toolbelt
     #   responses
+requests-toolbelt==1.0.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   langsmith
 responses==0.24.1
     # via -r requirements-dev.in
+sniffio==1.3.1
+    # via
+    #   -c requirements-aarch64.txt
+    #   anyio
+    #   httpx
+sqlalchemy==2.0.29
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+tenacity==8.2.3
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 torch-model-archiver==0.10.0
     # via -r requirements-dev.in
+typing-extensions==4.11.0
+    # via
+    #   -c requirements-aarch64.txt
+    #   langchain-core
+    #   pydantic
+    #   pydantic-core
+    #   sqlalchemy
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 urllib3==1.26.19
     # via
     #   -c requirements-aarch64.txt
@@ -121,6 +281,10 @@ yamllint==1.35.1
     # via
     #   -c requirements-aarch64.txt
     #   -r requirements-dev.in
+yarl==1.17.2
+    # via
+    #   -c requirements-aarch64.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev-x86_64.txt
+++ b/requirements-dev-x86_64.txt
@@ -4,6 +4,31 @@
 #
 #    pip-compile --constraint=requirements-x86_64.txt --output-file=requirements-dev-x86_64.txt requirements-dev.in
 #
+aiohappyeyeballs==2.3.5
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
+aiohttp==3.10.11
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+aiosignal==1.3.1
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
+annotated-types==0.6.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   pydantic
+anyio==4.6.2.post1
+    # via
+    #   -c requirements-x86_64.txt
+    #   httpx
+attrs==23.2.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
 black==24.3.0
     # via
     #   -c requirements-x86_64.txt
@@ -14,6 +39,8 @@ certifi @ git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5ac
     # via
     #   -c requirements-x86_64.txt
     #   -r requirements-dev.in
+    #   httpcore
+    #   httpx
     #   requests
 cfgv==3.4.0
     # via pre-commit
@@ -28,6 +55,8 @@ click==8.1.7
     #   pip-tools
 coverage==7.2.1
     # via -r requirements-dev.in
+dataclasses-json==0.6.7
+    # via langchain-community
 distlib==0.3.8
     # via virtualenv
 enum-compat==0.0.3
@@ -38,34 +67,109 @@ filelock==3.13.4
     #   virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
+frozenlist==1.4.1
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
+    #   aiosignal
+greenlet==3.0.3
+    # via
+    #   -c requirements-x86_64.txt
+    #   sqlalchemy
 grpcio==1.66.2
     # via
     #   -c requirements-x86_64.txt
     #   grpcio-tools
 grpcio-tools==1.66.2
     # via -r requirements-dev.in
+h11==0.14.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   httpcore
+httpcore==1.0.6
+    # via
+    #   -c requirements-x86_64.txt
+    #   httpx
+httpx==0.27.2
+    # via
+    #   -c requirements-x86_64.txt
+    #   langsmith
+httpx-sse==0.4.0
+    # via langchain-community
 identify==2.5.36
     # via pre-commit
 idna==3.7
     # via
     #   -c requirements-x86_64.txt
     #   -r requirements-dev.in
+    #   anyio
+    #   httpx
     #   requests
+    #   yarl
 isort==5.10.1
     # via -r requirements-dev.in
+jsonpatch==1.33
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain-core
+jsonpointer==2.4
+    # via
+    #   -c requirements-x86_64.txt
+    #   jsonpatch
+langchain==0.3.10
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain-community
+langchain-community==0.3.10
+    # via -r requirements-dev.in
+langchain-core==0.3.22
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-text-splitters
+langchain-text-splitters==0.3.1
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+langsmith==0.1.138
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
+marshmallow==3.23.1
+    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
+multidict==6.0.5
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements-x86_64.txt
     #   black
+    #   typing-inspect
 nodeenv==1.8.0
     # via pre-commit
+numpy==1.26.4
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+orjson==3.10.1
+    # via
+    #   -c requirements-x86_64.txt
+    #   langsmith
 packaging==23.2
     # via
     #   -c requirements-x86_64.txt
     #   black
     #   build
+    #   langchain-core
+    #   marshmallow
 pathspec==0.12.1
     # via
     #   -c requirements-x86_64.txt
@@ -80,32 +184,88 @@ platformdirs==4.2.1
     #   virtualenv
 pre-commit==3.7.0
     # via -r requirements-dev.in
+propcache==0.2.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   yarl
 protobuf==5.28.2
     # via
     #   -c requirements-x86_64.txt
     #   grpcio-tools
 pycodestyle==2.10.0
     # via flake8
+pydantic==2.9.2
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-core
+    #   langsmith
+    #   pydantic-settings
+pydantic-core==2.23.4
+    # via
+    #   -c requirements-x86_64.txt
+    #   pydantic
+pydantic-settings==2.6.1
+    # via langchain-community
 pyflakes==3.0.1
     # via flake8
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
+python-dotenv==1.0.1
+    # via pydantic-settings
 pyyaml==6.0
     # via
     #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
     #   pre-commit
     #   responses
     #   yamllint
 requests==2.32.0
     # via
     #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+    #   langsmith
+    #   requests-toolbelt
     #   responses
+requests-toolbelt==1.0.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   langsmith
 responses==0.24.1
     # via -r requirements-dev.in
+sniffio==1.3.1
+    # via
+    #   -c requirements-x86_64.txt
+    #   anyio
+    #   httpx
+sqlalchemy==2.0.29
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+tenacity==8.2.3
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain
+    #   langchain-community
+    #   langchain-core
 torch-model-archiver==0.10.0
     # via -r requirements-dev.in
+typing-extensions==4.11.0
+    # via
+    #   -c requirements-x86_64.txt
+    #   langchain-core
+    #   pydantic
+    #   pydantic-core
+    #   sqlalchemy
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via dataclasses-json
 urllib3==1.26.19
     # via
     #   -c requirements-x86_64.txt
@@ -121,6 +281,10 @@ yamllint==1.35.1
     # via
     #   -c requirements-x86_64.txt
     #   -r requirements-dev.in
+yarl==1.17.2
+    # via
+    #   -c requirements-x86_64.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,6 +6,7 @@ grpcio-tools==1.66.2
 # pin idna until responses -> requests is updated
 idna==3.7
 isort==5.10.1
+langchain_community
 pip-tools
 pre-commit
 responses==0.24.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -7,9 +7,7 @@
 aiohappyeyeballs==2.3.5
     # via aiohttp
 aiohttp==3.10.11
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.6.0
@@ -77,8 +75,6 @@ cryptography==43.0.1
     #   jwcrypto
     #   pyopenssl
     #   social-auth-core
-dataclasses-json==0.6.7
-    # via langchain-community
 decorator==5.1.1
     # via ipython
 defusedxml==0.8.0rc2
@@ -171,8 +167,6 @@ httpx==0.27.2
     # via
     #   langsmith
     #   ollama
-httpx-sse==0.4.0
-    # via langchain-community
 idna==3.7
     # via
     #   -r requirements.in
@@ -216,15 +210,10 @@ jwcrypto==1.5.6
     #   -r requirements.in
     #   django-oauth-toolkit
 langchain==0.3.10
-    # via
-    #   -r requirements.in
-    #   langchain-community
-langchain-community==0.3.10
     # via -r requirements.in
 langchain-core==0.3.22
     # via
     #   langchain
-    #   langchain-community
     #   langchain-ollama
     #   langchain-text-splitters
 langchain-ollama==0.2.1
@@ -234,7 +223,6 @@ langchain-text-splitters==0.3.1
 langsmith==0.1.138
     # via
     #   langchain
-    #   langchain-community
     #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
@@ -242,8 +230,6 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-marshmallow==3.21.3
-    # via dataclasses-json
 matplotlib-inline==0.1.7
     # via ipython
 mdurl==0.1.2
@@ -255,13 +241,9 @@ multidict==6.0.5
     #   aiohttp
     #   yarl
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   typing-inspect
+    # via black
 numpy==1.26.4
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 oauth2client==4.1.3
     # via pydrive2
 oauthlib==3.2.2
@@ -285,7 +267,6 @@ packaging==23.2
     #   black
     #   django-allow-cidr
     #   langchain-core
-    #   marshmallow
 parso==0.8.4
     # via jedi
 pathspec==0.12.1
@@ -339,11 +320,8 @@ pydantic==2.9.2
     #   langchain-core
     #   langsmith
     #   ollama
-    #   pydantic-settings
 pydantic-core==2.23.4
     # via pydantic
-pydantic-settings==2.6.0
-    # via langchain-community
 pydrive2==1.20.0
     # via -r requirements.in
 pygments==2.17.2
@@ -366,8 +344,6 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   segment-analytics-python
-python-dotenv==1.0.1
-    # via pydantic-settings
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2024.1
@@ -383,7 +359,6 @@ pyyaml==6.0
     #   ansible-risk-insight
     #   drf-spectacular
     #   langchain
-    #   langchain-community
     #   langchain-core
     #   pydrive2
     #   tablib
@@ -401,7 +376,6 @@ requests==2.32.0
     #   django-oauth-toolkit
     #   google-api-core
     #   langchain
-    #   langchain-community
     #   langsmith
     #   requests-oauthlib
     #   requests-toolbelt
@@ -458,9 +432,7 @@ social-auth-core==4.5.4
     #   -r requirements.in
     #   social-auth-app-django
 sqlalchemy==2.0.29
-    # via
-    #   langchain
-    #   langchain-community
+    # via langchain
 sqlparse==0.5.0
     # via
     #   -r requirements.in
@@ -478,7 +450,6 @@ tabulate==0.9.0
 tenacity==8.2.3
     # via
     #   langchain
-    #   langchain-community
     #   langchain-core
 traitlets==5.14.3
     # via
@@ -493,9 +464,6 @@ typing-extensions==4.11.0
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   typing-inspect
-typing-inspect==0.9.0
-    # via dataclasses-json
 uritemplate==4.1.1
     # via
     #   drf-spectacular

--- a/requirements.in
+++ b/requirements.in
@@ -44,7 +44,6 @@ jinja2==3.1.4
 # remove this once ansible-risk-insight is updated
 jsonpickle==3.3.0
 langchain==0.3.10
-langchain-community==0.3.10
 langchain-ollama==0.2.1
 launchdarkly-server-sdk==8.3.0
 protobuf==5.28.2


### PR DESCRIPTION
The class `Ollama` was deprecated in LangChain 0.3.1 and will be removed in 1.0.0.

See: https://github.com/langchain-ai/langchain/commit/95a87291fd821bb02fe1bb0f3e9cb65f3e75e39b
