### PR TITLE
Tekton: remove the extra SHA256 used to pin task-summary version

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -72,7 +72,7 @@ spec:
         - name: name
           value: summary
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+          value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Rely only on the 0.2 tag to get quay.io/redhat-appstudio-tekton-catalog/task-summary.
