### PR TITLE
konflux: only use the tag to pin quay.io/redhat-appstudio-tekton-catalog/task-summary

### DIFF
--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -69,7 +69,7 @@ spec:
         - name: name
           value: summary
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+          value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
See: 404a60e0ba42d9ce93d3a26dec61a9a764946865
