### PR TITLE
AAP-36663: GenerationRoleResponseSerializer: fix two key names

### DIFF
--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -608,7 +608,7 @@ class GenerationWarningResponseSerializer(serializers.Serializer):
 class GenerationRoleFileEntrySerializer(serializers.Serializer):
     path = serializers.CharField()
     content = serializers.CharField()
-    fileType = serializers.CharField()
+    file_type = serializers.CharField()
 
 
 class GenerationResponseSerializer(serializers.Serializer):
@@ -625,7 +625,7 @@ class GenerationResponseSerializer(serializers.Serializer):
 
 
 class GenerationRoleResponseSerializer(serializers.Serializer):
-    name = serializers.CharField()
+    role = serializers.CharField(help_text=("Name of the role."))
     files = serializers.ListField(child=GenerationRoleFileEntrySerializer())
     generationId = serializers.UUIDField(
         format="hex_verbose",

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -988,11 +988,11 @@ components:
           type: string
         content:
           type: string
-        fileType:
+        file_type:
           type: string
       required:
       - content
-      - fileType
+      - file_type
       - path
     GenerationRoleRequest:
       type: object
@@ -1045,8 +1045,9 @@ components:
     GenerationRoleResponse:
       type: object
       properties:
-        name:
+        role:
           type: string
+          description: Name of the role.
         files:
           type: array
           items:
@@ -1065,8 +1066,8 @@ components:
             $ref: '#/components/schemas/GenerationWarningResponse'
       required:
       - files
-      - name
       - outline
+      - role
     GenerationWarningResponse:
       type: object
       properties:


### PR DESCRIPTION
Adjust the name of the keys used to return the role name and the file type.
