### PR TITLE
Update trial messages in both vscode extension and trial web page

### DIFF
--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -201,6 +201,12 @@ class TestMarkdownMe(TestCase):
         Logged in as: test_user_name<br>
         Plan: trial of 90 days<br>
         Expiration: {expired_at}
+
+            <br>Accelerate Playbook creation with AI-driven content recommendations
+            from <b>IBM Watsonx Code Assistant for Red Hat Ansible Lightspeed</b>,
+            enabling faster, more efficient automation development. <a href=
+            "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
+            Learn more</a>.
         """
         self.assertEqual(dedent(expectation).strip(), content)
 
@@ -223,7 +229,9 @@ class TestMarkdownMe(TestCase):
         r = self.client.get(reverse("me_summary"))
         self.assertEqual(r.status_code, 200)
         content = r.json()["content"]
-        self.assertTrue("Your trial has expired. Contact your Red Hat" in content)
+        self.assertTrue(
+            "Your trial has expired. To continue your Ansible automation journey" in content
+        )
 
         user.delete()
         trial_plan.delete()

--- a/ansible_ai_connect/users/one_click_trial.py
+++ b/ansible_ai_connect/users/one_click_trial.py
@@ -50,6 +50,14 @@ class OneClickTrial:
                     Plan: {active_plan.plan.name}<br>
                     Expiration: {expired_at}
                 """
+                if (active_plan.expired_at - timezone.now()).days <= 90:
+                    markdown_value += """
+                        <br>Accelerate Playbook creation with AI-driven content recommendations
+                        from <b>IBM Watsonx Code Assistant for Red Hat Ansible Lightspeed</b>,
+                        enabling faster, more efficient automation development. <a href=
+                        "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
+                        Learn more</a>.
+                    """
             elif active_plan and not active_plan.expired_at:
                 markdown_value = f"""
                     Logged in as: {self.user.username}<br>
@@ -59,11 +67,11 @@ class OneClickTrial:
             elif expired_plan:
                 markdown_value = f"""
                     Logged in as: {self.user.username}<br>
-                    Your trial has expired. Contact your Red Hat Organization's
-                    administrator to request access to
-                    <a href =
-                    "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
-                    Ansible Lightspeed with IBM watsonx Code Assistant</a>.
+                    Your trial has expired. To continue your Ansible automation journey,
+                    contact your Red Hat organization's administrator, or <a href=
+                    "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed
+                    ?schedulerform">connect with an IBM expert to subscribe to watsonx Code
+                    Assistant for Red Hat Ansible Lightspeed</a>.
                 """
             else:
                 markdown_value = f"""

--- a/ansible_ai_connect/users/templates/users/trial.html
+++ b/ansible_ai_connect/users/templates/users/trial.html
@@ -3,49 +3,49 @@
 
 {% block content %}
 
-{% if start_trial_button and accept_trial_terms is False %}
-<div class="pf-c-alert pf-m-warning" aria-label="Terms and Conditions Information alert">
-  <div class="pf-c-alert__icon">
-    <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
-  </div>
-  <p class="pf-c-alert__title">
-    Please accept the Terms and Conditions and allow information to be shared with IBM.
-  </p>
-</div>
-{% endif %}
+  {% if start_trial_button and accept_trial_terms is False %}
+    <div class="pf-c-alert pf-m-warning" aria-label="Terms and Conditions Information alert">
+      <div class="pf-c-alert__icon">
+        <i class="fas fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
+      </div>
+      <p class="pf-c-alert__title">
+        Please accept the Terms and Conditions and allow information to be shared with IBM.
+      </p>
+    </div>
+  {% endif %}
 
-<section class="pf-c-page__main-section pf-m-light">
-  <div class="pf-l-bullseye">
-    <div class="pf-l-bullseye__item">
-      <div class="pf-c-empty-state">
-        <div class="pf-c-empty-state__content">
+  <section class="pf-c-page__main-section pf-m-light">
+    <div class="pf-l-bullseye">
+      <div class="pf-l-bullseye__item">
+        <div class="pf-c-empty-state">
+          <div class="pf-c-empty-state__content">
 
-          <div class="pf-l-bullseye pf-u-p-xl ls_logo_home">
-            <img src="{% static 'users/lightspeed.png' %}" width="95px" alt="{{ project_name }} logo"/>
-          </div>
+            <div class="pf-l-bullseye pf-u-p-xl ls_logo_home">
+              <img src="{% static 'users/lightspeed.png' %}" width="95px" alt="{{ project_name }} logo"/>
+            </div>
 
 
-          <h1 class="pf-c-title pf-m-lg">{{ project_name }}</h1>
+            <h1 class="pf-c-title pf-m-lg">{{ project_name }}</h1>
 
-          {% if user.is_authenticated %}
-          <div class = "ls_username">
-            <p>{% firstof user.external_username user.username %}</p>
-          </div>
+            {% if user.is_authenticated %}
+              <div class = "ls_username">
+                <p>{% firstof user.external_username user.username %}</p>
+              </div>
 
-          {% if deployment_mode != "saas" or not one_click_trial_available %}
+              {% if deployment_mode != "saas" or not one_click_trial_available %}
           <!-- Not supported -->
-          {% elif has_active_plan %}
-          <div class="ls_message_body">
-            <p>You have {{ days_left }} days left on your trial period</p>
-            {% if days_left <= 90 %}
-            <p>
-              Accelerate Playbook creation with AI-driven content recommendations from <b>IBM Watsonx Code Assistant for Red Hat Ansible Lightspeed</b>, enabling faster, more efficient automation development.
-              <a href =
-                 "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
-                Learn more</a>.
-            </p>
-            {% endif %}
-          </div>
+              {% elif has_active_plan %}
+                <div class="ls_message_body">
+                  <p>You have {{ days_left }} days left on your trial period</p>
+                  {% if days_left <= 90 %}
+                    <p>
+                      Accelerate Playbook creation with AI-driven content recommendations from <b>IBM Watsonx Code Assistant for Red Hat Ansible Lightspeed</b>, enabling faster, more efficient automation development.
+                      <a href =
+                          "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
+                        Learn more</a>.
+                    </p>
+                  {% endif %}
+                </div>
 
           <!--
               <div class="pf-v5-c-form__group pf-m-action">
@@ -60,68 +60,68 @@
               -->
 
               {% elif has_expired_plan %}
-              <div class="ls_message_body">
-              <p>
-                Your trial has expired. To continue your Ansible automation journey, contact your Red Hat organization's administrator, or
-                <a href =
-                   "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed?schedulerform">
-                  connect with an IBM expert to subscribe to watsonx Code Assistant for Red Hat Ansible Lightspeed</a>.
-              </p>
-              </div>
-              {% else  %}
-              <form action={% url 'trial' %} method="post">{% csrf_token %}
-
-                <div class="ls_button_checkbox_body pf-c-empty-state__content">
-                  <div class="ls_trial_text">
-                    <p>
-                      Start a trial to Ansible Lightspeed with IBM watsonx Code Assistant by accepting the terms below,
-                      and clicking the Start button.
-                    </p>
-                  </div>
-
-                  <div class="ls_checkbox_body">
-                    <div id = "ls_checkbox_terms" class = "ls_checkbox_wrapper">
-                      <p>
-                        <input type="checkbox" class="ls_checkbox" name="accept_trial_terms" {% if accept_trial_terms %}checked{% endif %} />
-                        By checking the box and activating this trial, you accept
-                        IBM <a href="https://www.ibm.com/terms/?id=i126-9853" target="_blank" rel="noopener">terms and conditions</a>
-                        and acknowledge that Red Hat will share your information with IBM.
-                        <i class = "ls_checkbox_required">Required <em class = "ls_checkbox_required_asterix">*</em></i>
-                      </p>
-                    </div>
-                  </div>
-
-                  <div class="hr-line"></div>
-
-                  <div class="ls_trial_text">
-                    <p>
-                      Red Hat may use your personal data to inform you about its products, services, and events.
-                    </p>
-                  </div>
-
-                  <div class="ls_checkbox_body">
-                    <div class = "ls_checkbox_wrapper">
-                      <p>
-                        <input type="checkbox"  class="ls_checkbox" name="accept_marketing_emails" {% if accept_marketing_emails %}checked{% endif %}/>
-                        Notify me about products, services, and events.
-                      </p>
-                    </div>
-                  </div>
-
+                <div class="ls_message_body">
                   <p>
-                    You can stop receiving marketing emails by clicking the unsubscribe link in each email or
-                    withdraw your consent at any time in the
-                    <a href = "https://www.redhat.com/en/email-preferences" target="_blank" rel="noopener">preference center</a>.
-                    See <a href = "https://www.redhat.com/en/about/privacy-policy" target="_blank" rel="noopener">Privacy Statement</a> for details.
+                    Your trial has expired. To continue your Ansible automation journey, contact your Red Hat organization's administrator, or
+                    <a href =
+                        "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed?schedulerform">
+                      connect with an IBM expert to subscribe to watsonx Code Assistant for Red Hat Ansible Lightspeed</a>.
                   </p>
-
                 </div>
-                <p>
-                  <button class="pf-c-button pf-m-primary ls_start_trial_button" type="submit" name="start_trial_button" value="True">
-                    Start trial
-                  </button>
-                </p>
-              </form>
+              {% else  %}
+                <form action={% url 'trial' %} method="post">{% csrf_token %}
+
+                  <div class="ls_button_checkbox_body pf-c-empty-state__content">
+                    <div class="ls_trial_text">
+                      <p>
+                        Start a trial to Ansible Lightspeed with IBM watsonx Code Assistant by accepting the terms below,
+                        and clicking the Start button.
+                      </p>
+                    </div>
+
+                    <div class="ls_checkbox_body">
+                      <div id = "ls_checkbox_terms" class = "ls_checkbox_wrapper">
+                        <p>
+                          <input type="checkbox" class="ls_checkbox" name="accept_trial_terms" {% if accept_trial_terms %}checked{% endif %} />
+                          By checking the box and activating this trial, you accept
+                          IBM <a href="https://www.ibm.com/terms/?id=i126-9853" target="_blank" rel="noopener">terms and conditions</a>
+                          and acknowledge that Red Hat will share your information with IBM.
+                          <i class = "ls_checkbox_required">Required <em class = "ls_checkbox_required_asterix">*</em></i>
+                        </p>
+                      </div>
+                    </div>
+
+                    <div class="hr-line"></div>
+
+                    <div class="ls_trial_text">
+                      <p>
+                        Red Hat may use your personal data to inform you about its products, services, and events.
+                      </p>
+                    </div>
+
+                    <div class="ls_checkbox_body">
+                      <div class = "ls_checkbox_wrapper">
+                        <p>
+                          <input type="checkbox"  class="ls_checkbox" name="accept_marketing_emails" {% if accept_marketing_emails %}checked{% endif %}/>
+                          Notify me about products, services, and events.
+                        </p>
+                      </div>
+                    </div>
+
+                    <p>
+                      You can stop receiving marketing emails by clicking the unsubscribe link in each email or
+                      withdraw your consent at any time in the
+                      <a href = "https://www.redhat.com/en/email-preferences" target="_blank" rel="noopener">preference center</a>.
+                      See <a href = "https://www.redhat.com/en/about/privacy-policy" target="_blank" rel="noopener">Privacy Statement</a> for details.
+                    </p>
+
+                  </div>
+                  <p>
+                    <button class="pf-c-button pf-m-primary ls_start_trial_button" type="submit" name="start_trial_button" value="True">
+                      Start trial
+                    </button>
+                  </p>
+                </form>
               {% endif %}
               <div class="ls_message_body">
                 <form id="logout-form" method="post" action="{% url 'logout' %}">
@@ -129,25 +129,29 @@
                   <button class="pf-c-button pf-m-secondary" type="submit">Log out</button>
                 </form>
               </div>
-              {% else %}
+            {% else %}
               <div class="pf-c-empty-state__body">You are currently not logged in. Please log in using the button below.</div>
               <a class="pf-c-button pf-m-primary" type="button" href="{% url 'login' %}">Log in</a>
-              {% endif %}
+            {% endif %}
 
-              <div class="pf-l-level ls_bottom_menu">
-                <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
-                <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank" rel="noopener"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
+            <div class="pf-l-bullseye">
+              <div class="pf-l-bullseye__item">
+                <div class="pf-l-level pf-m-gutter ls_bottom_menu">
+                  <a class="pf-l-level__item" href="{{ documentation_url }}" target="_blank"><span class="fas fa-sharp fa-solid fa-external-link-alt"></span> Documentation</a>
+                  <a class="pf-l-level__item" href="https://status.redhat.com/" target="_blank"><span class="fas fa-sharp fa-solid fa-check"></span> Status</a>
 
-                {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
-                <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
-                {% endif %}
-                {% if chatbot_enabled and deployment_mode == 'saas' and user.is_authenticated and rh_employee_or_test_user %}
-                <a class="pf-l-level__item" href="/chatbot"><span class="fas fa-solid fa-comments"></span> Chatbot</a>
-                {% endif %}
+                  {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
+                    <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
+                  {% endif %}
+                  {% if chatbot_enabled and deployment_mode == 'saas' and user.is_authenticated and rh_employee_or_test_user %}
+                    <a class="pf-l-level__item" href="/chatbot"><span class="fas fa-solid fa-comments"></span> Chatbot</a>
+                  {% endif %}
+                </div>
               </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 {% endblock content %}

--- a/ansible_ai_connect/users/templates/users/trial.html
+++ b/ansible_ai_connect/users/templates/users/trial.html
@@ -36,9 +36,16 @@
           <!-- Not supported -->
           {% elif has_active_plan %}
           <div class="ls_message_body">
-            You have {{ days_left }} days left on your trial period
+            <p>You have {{ days_left }} days left on your trial period</p>
+            {% if days_left <= 90 %}
+            <p>
+              Accelerate Playbook creation with AI-driven content recommendations from <b>IBM Watsonx Code Assistant for Red Hat Ansible Lightspeed</b>, enabling faster, more efficient automation development.
+              <a href =
+                 "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
+                Learn more</a>.
+            </p>
+            {% endif %}
           </div>
-
 
           <!--
               <div class="pf-v5-c-form__group pf-m-action">
@@ -55,10 +62,10 @@
               {% elif has_expired_plan %}
               <div class="ls_message_body">
               <p>
-                Your trial has expired. Contact your Red Hat Organization's administrator to request access to
+                Your trial has expired. To continue your Ansible automation journey, contact your Red Hat organization's administrator, or
                 <a href =
-                   "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed">
-                  Ansible Lightspeed with IBM watsonx Code Assistant</a>.
+                   "https://www.ibm.com/products/watsonx-code-assistant-ansible-lightspeed?schedulerform">
+                  connect with an IBM expert to subscribe to watsonx Code Assistant for Red Hat Ansible Lightspeed</a>.
               </p>
               </div>
               {% else  %}

--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -344,7 +344,9 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
         )
         self.user.plans.add(trial_plan)
         r = self.client.get(reverse("trial"))
-        self.assertContains(r, "Your trial has expired. Contact your Red Hat")
+        self.assertContains(
+            r, "Your trial has expired. To continue your Ansible automation journey"
+        )
 
     @override_settings(SEGMENT_WRITE_KEY="blablabla")
     def test_accept_trial_schema1(self):


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-36175>
<!-- This PR does not need a corresponding Jira item. -->

## Description
This updates the messages that we present to the user when a trial will expire in <= 90 days as well as when a trial is expired.

## Testing
I tested out all of the various scenarios by manipulating the expired_at timestamp on the user plan.  There are 4 options/scenarios:
1. A trial hasn't started yet
2. Expired (date set to something in the past)
3. About to expire (date set to something within the next 90 days)
4. Not about to expire (date set to something more than 90 days out).  Theoretically this shouldn't be possible but it's a scenario we already cover so I tested it anyway.

<img width="512" alt="Screenshot 2024-12-13 at 1 43 13 PM" src="https://github.com/user-attachments/assets/e8c189cd-bab8-4a30-98d8-bf134048f9f1" />
<img width="514" alt="Screenshot 2024-12-13 at 1 42 46 PM" src="https://github.com/user-attachments/assets/730d3592-ed47-412c-9acb-cc4c830b391f" />
<img width="518" alt="Screenshot 2024-12-13 at 1 42 12 PM" src="https://github.com/user-attachments/assets/b6d2108e-7590-4c64-adbe-991917a087b9" />
<img width="521" alt="Screenshot 2024-12-13 at 1 41 05 PM" src="https://github.com/user-attachments/assets/7e671be5-fe0c-4f02-8831-465a591b4950" />


<img width="1703" alt="Screenshot 2024-12-13 at 2 51 27 PM" src="https://github.com/user-attachments/assets/1e7936b8-e7ae-4f64-a08a-a288d6eb1b2c" />
<img width="1701" alt="Screenshot 2024-12-13 at 2 50 54 PM" src="https://github.com/user-attachments/assets/d15b7ec5-fbb0-49a8-a7ca-44af6cfc7da6" />


### Scenarios tested
See above

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
