### PR TITLE
pyproject: accept the regular flavor of psycopg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   'langchain-ollama~=0.2.1',
   'launchdarkly-server-sdk~=8.3.0',
   'protobuf~=5.28.2',
-  'psycopg[binary]~=3.1.8',
+  'psycopg~=3.1.8',
   'PyDrive2~=1.20.0',
   'pydantic==2.*',
   'pytz',


### PR DESCRIPTION
Don't force the use of the `binary` package. It may not be available (e.g Python 3.13 Linux).
