### PR TITLE
schema1: set the new plan_ids keys

### DIFF
--- a/ansible_ai_connect/ai/api/telemetry/schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema1.py
@@ -96,6 +96,7 @@ class Schema1Event:
     _user: User | None = None
     _created_at: int = time.time()
     plans: list[PlanEntry] = Factory(list)
+    plan_ids: list[int] = Factory(list)
     timestamp: str | None = None
     duration: float | None = None
 
@@ -119,6 +120,7 @@ class Schema1Event:
             self.rh_user_org_id = user.organization.id
         self.groups = list(user.groups.values_list("name", flat=True))
         self.plans = [PlanEntry.init(up) for up in user.userplan_set.all()]
+        self.plan_ids = [up.plan_id for up in user.userplan_set.all()]
 
     def set_request(self, request):
         if hasattr(request, "user"):  # e.g WSGIRequest generated when we run update-openapi-schema

--- a/ansible_ai_connect/ai/api/telemetry/test_schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/test_schema1.py
@@ -98,6 +98,7 @@ class TestOneClickTrialStartedEvent(WisdomServiceAPITestCaseBaseOIDC):
         self.assertEqual(event1.plans[0].name, "Some plan")
         self.assertTrue(event1.plans[0].created_at.startswith("20"))
         self.assertEqual(event1.plans[0].plan_id, self.trial_plan.id)
+        self.assertEqual(event1.plan_ids, [self.trial_plan.id])
 
 
 @override_settings(AUTHZ_BACKEND_TYPE="dummy")


### PR DESCRIPTION
Amplitude cannot do a filter that match a single key in an array, if we want to
correctly identify an event's plan(s) we need to flatten the plan_id keys.
