### PR TITLE
Fix chatbot UI autoscrolling and insert position for bot message feedback

### DIFF
--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -294,14 +294,17 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                   { referenced_documents, ...message }: ExtendedMessage,
                   index,
                 ) => (
-                  <div key={`m_div_${index}`}>
-                    <Message key={`m_msg_${index}`} {...message} />
-                    <ReferencedDocuments
-                      key={`m_docs_${index}`}
-                      caption="Refer to the following for more information:"
-                      referenced_documents={referenced_documents}
-                    />
-                  </div>
+                  <>
+                    {message.scrollToHere && <div ref={messagesEndRef} />}
+                    <div key={`m_div_${index}`}>
+                      <Message key={`m_msg_${index}`} {...message} />
+                      <ReferencedDocuments
+                        key={`m_docs_${index}`}
+                        caption="Refer to the following for more information:"
+                        referenced_documents={referenced_documents}
+                      />
+                    </div>
+                  </>
                 ),
               )}
               {isLoading ? (
@@ -309,7 +312,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
               ) : (
                 <></>
               )}
-              <div ref={messagesEndRef} />
             </MessageBox>
           </ChatbotContent>
           <ChatbotFooter>

--- a/ansible_ai_connect_chatbot/src/types/Message.ts
+++ b/ansible_ai_connect_chatbot/src/types/Message.ts
@@ -34,10 +34,12 @@ export type ReferencedDocumentsProp = {
 
 export type ExtendedMessage = MessageProps & {
   referenced_documents: ReferencedDocument[];
+  scrollToHere?: boolean;
 };
 
 export type ChatFeedback = {
   query: string;
   response: ChatResponse;
   sentiment: Sentiment;
+  message: ExtendedMessage;
 };

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -155,7 +155,7 @@ export const useChatbot = () => {
       newMessage.scrollToHere = true;
       let inserted = false;
       for (const msg of msgs) {
-        delete msg.scrollToHere;
+        msg.scrollToHere = false;
         newMsgs.push(msg);
         if (msg === addAfter) {
           newMsgs.push(newMessage);

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -146,25 +146,45 @@ export const useChatbot = () => {
   >(undefined);
   const [selectedModel, setSelectedModel] = useState("granite3-8b");
 
-  const addMessage = (newMessage: ExtendedMessage) => {
-    setMessages((msgs: ExtendedMessage[]) => [...msgs, newMessage]);
+  const addMessage = (
+    newMessage: ExtendedMessage,
+    addAfter?: ExtendedMessage,
+  ) => {
+    setMessages((msgs: ExtendedMessage[]) => {
+      const newMsgs: ExtendedMessage[] = [];
+      newMessage.scrollToHere = true;
+      let inserted = false;
+      for (const msg of msgs) {
+        delete msg.scrollToHere;
+        newMsgs.push(msg);
+        if (msg === addAfter) {
+          newMsgs.push(newMessage);
+          inserted = true;
+        }
+      }
+      if (!inserted) {
+        newMsgs.push(newMessage);
+      }
+      return newMsgs;
+    });
   };
 
   const botMessage = (
     response: ChatResponse | string,
     query = "",
-  ): MessageProps => {
-    const sendFeedback = async (sentiment: Sentiment) => {
-      if (typeof response === "object") {
-        handleFeedback({ query, response, sentiment });
-      }
-    };
-    const message: MessageProps = {
+  ): ExtendedMessage => {
+    const message: ExtendedMessage = {
       role: "bot",
       content: typeof response === "object" ? response.response : response,
       name: botName,
       avatar: logo,
       timestamp: getTimestamp(),
+      referenced_documents: [],
+    };
+    const sendFeedback = async (sentiment: Sentiment) => {
+      if (typeof response === "object") {
+        handleFeedback({ query, response, sentiment, message });
+      }
     };
 
     message.actions = {
@@ -224,7 +244,7 @@ export const useChatbot = () => {
           referenced_documents: [],
           ...feedbackMessage(feedbackRequest),
         };
-        addMessage(newBotMessage);
+        addMessage(newBotMessage, feedbackRequest.message);
       } else {
         setAlertMessage({
           title: "Error",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-35711>
This also will fix the issue reported by https://github.com/ansible/ansible-lightspeed-va-feedback/issues/15
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
On the existing implementaiton, when a new bot message is received, chatbot window scrolls to the bottom of the message. It is changed to scroll to the top of the last message instead.

Also when a ThumbsUp/Down icon is clicked for a bot message, which is NOT the last one, the feedback message is added to the bottom and chatbot window scrolls to the bottom (it is the issue reported by https://github.com/ansible/ansible-lightspeed-va-feedback/issues/15). With this PR, the feedback message will be added right after the bot message, to which the feedback was sent, and chatbot window scrolls to the top of the feedback message.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run the chatbot
3. Send more than one queries
4. Click ThubsUp/Down icon for a bot message, which is NOT the last one, and see the window scrolls to the feedback message ("Thank you for your feedback...")

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Manually tested as described above. See the video attached below.

https://github.com/user-attachments/assets/e3c62973-7bcf-4179-a681-eda84cfa9220




## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
