### PR TITLE
AACSAPIView: validate the payload in the class

### DIFF
--- a/ansible_ai_connect/ai/api/exceptions.py
+++ b/ansible_ai_connect/ai/api/exceptions.py
@@ -201,11 +201,6 @@ class ChatbotNotEnabledException(BaseWisdomAPIException):
     default_detail = "Chatbot is not enabled"
 
 
-class ChatbotInvalidRequestException(WisdomBadRequest):
-    default_code = "error__chatbot_invalid_request"
-    default_detail = "Invalid request"
-
-
 class ChatbotInvalidResponseException(BaseWisdomAPIException):
     status_code = 500
     default_code = "error__chatbot_invalid_response"

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -424,6 +424,7 @@ class ExplanationRequestSerializer(Metadata):
         required=False,
         label="Custom prompt",
         help_text="Custom prompt passed to the LLM when explaining a playbook.",
+        default="",
     )
     explanationId = serializers.UUIDField(
         format="hex_verbose",
@@ -432,8 +433,9 @@ class ExplanationRequestSerializer(Metadata):
         help_text=(
             "A UUID that identifies the particular explanation data is being requested for."
         ),
+        default="",
     )
-    model = serializers.CharField(required=False, allow_blank=True)
+    model = serializers.CharField(required=False, allow_blank=True, default="")
     metadata = Metadata(required=False)
 
     def validate(self, data):
@@ -483,12 +485,14 @@ class GenerationPlaybookRequestSerializer(serializers.Serializer):
         required=False,
         label="Custom prompt",
         help_text="Custom prompt passed to the LLM when generating the text of a playbook.",
+        default="",
     )
     generationId = serializers.UUIDField(
         format="hex_verbose",
         required=False,
         label="generation ID",
         help_text=("A UUID that identifies the particular generation data is being requested for."),
+        default="",
     )
     createOutline = serializers.BooleanField(
         required=False,
@@ -503,12 +507,14 @@ class GenerationPlaybookRequestSerializer(serializers.Serializer):
         required=False,
         label="outline",
         help_text="A long step by step outline of the expected Ansible Playbook.",
+        default="",
     )
     wizardId = serializers.UUIDField(
         format="hex_verbose",
         required=False,
         label="wizard ID",
         help_text=("A UUID to track the succession of interaction from the user."),
+        default="",
     )
     model = serializers.CharField(required=False, allow_blank=True)
 
@@ -622,7 +628,7 @@ class GenerationPlaybookResponseSerializer(serializers.Serializer):
     generationId = serializers.UUIDField(
         format="hex_verbose",
         required=False,
-        label="Explanation ID",
+        label="Generation ID",
         help_text=("A UUID that identifies the particular summary data is being requested for."),
     )
     outline = serializers.CharField()
@@ -635,7 +641,7 @@ class GenerationRoleResponseSerializer(serializers.Serializer):
     generationId = serializers.UUIDField(
         format="hex_verbose",
         required=False,
-        label="Explanation ID",
+        label="Generation ID",
         help_text=("A UUID that identifies the particular summary data is being requested for."),
     )
     outline = serializers.CharField()

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -40,7 +40,6 @@ from ansible_ai_connect.ai.api.data.data_model import APIPayload
 from ansible_ai_connect.ai.api.exceptions import (
     ChatbotForbiddenException,
     ChatbotInternalServerException,
-    ChatbotInvalidRequestException,
     ChatbotInvalidResponseException,
     ChatbotNotEnabledException,
     ChatbotPromptTooLongException,
@@ -2747,7 +2746,7 @@ This playbook emails admin@redhat.com with a list of passwords.
 """
 
     def test_ok(self):
-        explanation_id = str(uuid.uuid4())
+        explanation_id = uuid.uuid4()
         payload = {
             "content": """---
 - name: Setup nginx
@@ -2773,7 +2772,7 @@ This playbook emails admin@redhat.com with a list of passwords.
         self.assertEqual(r.data["explanationId"], explanation_id)
 
     def test_ok_with_model_id(self):
-        explanation_id = str(uuid.uuid4())
+        explanation_id = uuid.uuid4()
         model = "mymodel"
         payload = {
             "content": """---
@@ -3255,7 +3254,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_ok(self):
-        generation_id = str(uuid.uuid4())
+        generation_id = uuid.uuid4()
         payload = {
             "text": "Install nginx on RHEL9",
             "generationId": generation_id,
@@ -3270,7 +3269,7 @@ class TestGenerationView(WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase)
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     def test_ok_with_model_id(self):
-        generation_id = str(uuid.uuid4())
+        generation_id = uuid.uuid4()
         model = "mymodel"
         payload = {
             "text": "Install nginx on RHEL9",
@@ -3787,7 +3786,7 @@ class TestExplanationFeatureEnableForWcaOnprem(
     WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase
 ):
 
-    explanation_id = str(uuid.uuid4())
+    explanation_id = uuid.uuid4()
     payload_json = {
         "content": "Install Wordpress on a RHEL9",
         "explanationId": explanation_id,
@@ -3853,7 +3852,7 @@ class TestExplanationFeatureEnableForWcaOnprem(
 class TestGenerationFeatureEnableForWcaOnprem(
     WisdomAppsBackendMocking, WisdomServiceAPITestCaseBase
 ):
-    generation_id = str(uuid.uuid4())
+    generation_id = uuid.uuid4()
     payload_json = {
         "text": "Install nginx on RHEL9",
         "generationId": generation_id,
@@ -4104,14 +4103,6 @@ class TestChatView(WisdomServiceAPITestCaseBase):
     def test_chat_not_enabled_exception(self):
         self.assert_test(
             TestChatView.VALID_PAYLOAD, 503, ChatbotNotEnabledException, "Chatbot is not enabled"
-        )
-
-    def test_chat_invalid_request_exception(self):
-        self.assert_test(
-            TestChatView.INVALID_PAYLOAD,
-            400,
-            ChatbotInvalidRequestException,
-            "ChatbotInvalidRequestException",
         )
 
     def test_chat_invalid_response_exception(self):

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -907,16 +907,19 @@ components:
           description: The playbook that needs to be explained.
         customPrompt:
           type: string
+          default: ''
           title: Custom prompt
           description: Custom prompt passed to the LLM when explaining a playbook.
         explanationId:
           type: string
           format: uuid
+          default: ''
           title: Explanation ID
           description: A UUID that identifies the particular explanation data is being
             requested for.
         model:
           type: string
+          default: ''
         metadata:
           $ref: '#/components/schemas/Metadata'
       required:
@@ -974,12 +977,14 @@ components:
           description: The description that needs to be converted to a playbook.
         customPrompt:
           type: string
+          default: ''
           title: Custom prompt
           description: Custom prompt passed to the LLM when generating the text of
             a playbook.
         generationId:
           type: string
           format: uuid
+          default: ''
           title: generation ID
           description: A UUID that identifies the particular generation data is being
             requested for.
@@ -991,10 +996,12 @@ components:
             of the Ansible Playbook.
         outline:
           type: string
+          default: ''
           description: A long step by step outline of the expected Ansible Playbook.
         wizardId:
           type: string
           format: uuid
+          default: ''
           title: wizard ID
           description: A UUID to track the succession of interaction from the user.
         model:
@@ -1013,7 +1020,7 @@ components:
         generationId:
           type: string
           format: uuid
-          title: Explanation ID
+          title: Generation ID
           description: A UUID that identifies the particular summary data is being
             requested for.
         outline:
@@ -1100,7 +1107,7 @@ components:
         generationId:
           type: string
           format: uuid
-          title: Explanation ID
+          title: Generation ID
           description: A UUID that identifies the particular summary data is being
             requested for.
         outline:


### PR DESCRIPTION
Validate the view parameter from within the `AACSAPIView` class as soon as the `request_serializer_class` attribute is set with a Serializer class.

Also introduce minor cosmetic changes in Serializer class definitions to set some default values.
These changes are optional but the ultimate goal is to ensure all the fields are set in the `validated_data`
structure. This to reduce the use of `.get()`, which can silently hide an actually problem. This is also a way to
ensure the type of the field remains the same.

