### PR TITLE
Skip seated user check for chat segment events

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -1968,6 +1968,8 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
                 "sentiment": "1",
             }
         }
+        self.user.rh_user_has_seat = True
+        self.user.organization = Organization.objects.get_or_create(id=1)[0]
         self.client.force_authenticate(user=self.user)
         with self.assertLogs(logger="root", level="DEBUG") as log:
             r = self.client.post(reverse("feedback"), payload, format="json")
@@ -1977,7 +1979,7 @@ class TestFeedbackView(WisdomServiceAPITestCaseBase):
             self.assertTrue(len(segment_events) > 0)
             self.assertEqual(
                 segment_events[0]["properties"]["rh_user_org_id"],
-                123,
+                self.user.organization.id,
             )
             self.assertEqual(
                 segment_events[0]["properties"]["chat_prompt"],
@@ -4166,6 +4168,8 @@ class TestChatView(WisdomServiceAPITestCaseBase):
 
     @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
     def test_operational_telemetry(self):
+        self.user.rh_user_has_seat = True
+        self.user.organization = Organization.objects.get_or_create(id=1)[0]
         self.client.force_authenticate(user=self.user)
         with (
             patch.object(

--- a/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
+++ b/ansible_ai_connect/ai/api/utils/seated_users_allow_list.py
@@ -384,4 +384,10 @@ ALLOW_LIST = {
         "rh_user_org_id": None,
         "plans": None,
     },
+    "chatFeedbackEvent": {
+        "*": None,
+    },
+    "chatOperationalEvent": {
+        "*": None,
+    },
 }

--- a/ansible_ai_connect/ai/api/utils/segment.py
+++ b/ansible_ai_connect/ai/api/utils/segment.py
@@ -181,6 +181,10 @@ def redact_seated_users_data(event: Dict[str, Any], allow_list: Dict[str, Any]) 
     Returns:
     - dict: A new dictionary containing only the allowed nested keys from the source dictionary.
     """
+    # If an asterisk is found in the allow list, just return the given event dict to allow all keys.
+    if "*" in allow_list:
+        return event
+
     redacted_event = {}
     for key, sub_whitelist in (
         allow_list.items() if isinstance(allow_list, dict) else allow_list[0].items()

--- a/ansible_ai_connect/ai/api/utils/tests/test_segment.py
+++ b/ansible_ai_connect/ai/api/utils/tests/test_segment.py
@@ -270,6 +270,48 @@ class TestSegment(TestCase):
             redact_seated_users_data(test_data, ALLOW_LIST["trialExpired"]), expected_result
         )
 
+    def test_redact_chat_operational_event(self, *args):
+        test_data = {
+            "type": "chatOperationalEvent",
+            "modelName": "org-model-id",
+            "rh_user_has_seat": True,
+            "rh_user_org_id": 101,
+            "anything": "whatever",
+        }
+
+        expected_result = {
+            "type": "chatOperationalEvent",
+            "modelName": "org-model-id",
+            "rh_user_has_seat": True,
+            "rh_user_org_id": 101,
+            "anything": "whatever",  # Any properties won't be redacted for chatOperationalEvent
+        }
+
+        self.assertEqual(
+            redact_seated_users_data(test_data, ALLOW_LIST["chatOperationalEvent"]), expected_result
+        )
+
+    def test_redact_chat_feedback_event(self, *args):
+        test_data = {
+            "type": "chatFeedbackEvent",
+            "modelName": "org-model-id",
+            "rh_user_has_seat": True,
+            "rh_user_org_id": 101,
+            "anything": "whatever",
+        }
+
+        expected_result = {
+            "type": "chatFeedbackEvent",
+            "modelName": "org-model-id",
+            "rh_user_has_seat": True,
+            "rh_user_org_id": 101,
+            "anything": "whatever",  # Any properties won't be redacted for chatFeedbackEvent
+        }
+
+        self.assertEqual(
+            redact_seated_users_data(test_data, ALLOW_LIST["chatFeedbackEvent"]), expected_result
+        )
+
     @mock.patch("ansible_ai_connect.ai.api.utils.segment.analytics.group")
     @override_settings(SEGMENT_WRITE_KEY="DUMMY_KEY_VALUE")
     def test_send_segment_group(self, group_method):


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Skip "seated user check" for Chat-related segment events because Chat is irrelevant to "seated users" or WCA.

I added two new entries to `allow_list`:
``` 
    "chatFeedbackEvent": {
        "*": None,
    },
    "chatOperationalEvent": {
        "*": None,
    },
```
The line` "*": None,` implies all properties are allows.

The problem was found on the `chatOperationalEvent`, but I have added a fix for the `chatFeedbackEvent` as well.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests + manual tests by running local AI Connect server.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
