### PR TITLE
config: failback on "nop" if provider is not available

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/config_providers.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_providers.py
@@ -16,6 +16,7 @@ from typing import Dict
 from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
     PipelineConfiguration,
 )
+from ansible_ai_connect.ai.api.model_pipelines.registry import get_registry_entry
 
 
 class Configuration(Dict):
@@ -23,12 +24,10 @@ class Configuration(Dict):
     def __init__(self, **kwargs):
         super().__init__(kwargs)
 
-        from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY
-
         for k, v in self.items():
             pipeline_config = v["config"]
             pipeline_provider = v["provider"]
-            registry_entry = REGISTRY[pipeline_provider]
+            registry_entry = get_registry_entry(pipeline_provider)
             config_class = registry_entry[PipelineConfiguration]
             config_instance = config_class(**pipeline_config)
             self[k] = config_instance

--- a/ansible_ai_connect/ai/api/model_pipelines/factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/factory.py
@@ -22,7 +22,10 @@ from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
 )
 from ansible_ai_connect.ai.api.model_pipelines.config_providers import Configuration
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import PIPELINE_TYPE
-from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY, REGISTRY_ENTRY
+from ansible_ai_connect.ai.api.model_pipelines.registry import (
+    REGISTRY_ENTRY,
+    get_registry_entry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +50,7 @@ class ModelPipelineFactory:
             # Get the configuration for the requested pipeline
             pipeline_config: PipelineConfiguration = self.pipelines_config[pipeline_type.__name__]
             # Get the pipeline class for the configured provider
-            pipelines = REGISTRY[pipeline_config.provider]
+            pipelines = get_registry_entry(pipeline_config.provider)
             pipeline = pipelines[pipeline_type]
             config = pipeline_config.config
             # No explicit implementation defined; fallback to NOP

--- a/ansible_ai_connect/ai/api/model_pipelines/registry.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/registry.py
@@ -70,3 +70,18 @@ class Register:
         elif issubclass(cls, Serializer):
             REGISTRY[self.api_type][Serializer] = cls
         return cls
+
+
+def get_registry_entry(pipeline_provider):
+
+    def v_or_default(k, v):
+        defaults = REGISTRY["nop"]
+        if v is None:
+            logger.error(
+                f"'{k.alias()}' is not available for provider={pipeline_provider},"
+                " failing back to 'nop'"
+            )
+            return defaults[k]
+        return v
+
+    return {k: v_or_default(k, v) for k, v in REGISTRY[pipeline_provider].items()}


### PR DESCRIPTION
Failback on the `nop` provider if the requested provider is not available. This way,
the service can start despite the misconfiguration.

Another approch is to "fail fast" and raise a critical exception with a clear message
to let the user fix the configuration.
