### PR TITLE
podman-compose cannot recognize relative paths correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,27 +67,27 @@ run-server-containerized:
 
 .PHONY: docker-compose
 docker-compose:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose.yaml up --remove-orphans
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose.yaml up --remove-orphans
 
 .PHONY: start-db
 # Run db in container for running Django application from source
 start-db:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml up --remove-orphans -d
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose-db.yaml up --remove-orphans -d
 
 .PHONY: stop-db
 # stop db container
 stop-db:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml up down
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose-db.yaml down
 
 .PHONY: start-backends
 # Run backend services in container for running Django application from source
 start-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml -f tools/docker-compose/compose-prom-grafana.yaml up --remove-orphans -d
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose-db.yaml -f ${PWD}/tools/docker-compose/compose-prom-grafana.yaml up --remove-orphans -d
 
 .PHONY: stop-backends
 # Stop backend services
 stop-backends:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose-db.yaml -f tools/docker-compose/compose-prom-grafana.yaml down
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose-db.yaml -f ${PWD}/tools/docker-compose/compose-prom-grafana.yaml down
 
 .PHONY: update-openapi-schema
 # Update OpenAPI 3.0 schema while running the service in development env
@@ -96,7 +96,7 @@ update-openapi-schema:
 
 .PHONY: docker-compose-clean
 docker-compose-clean:
-	${COMPOSE_RUNTIME} -f tools/docker-compose/compose.yaml down
+	${COMPOSE_RUNTIME} -f ${PWD}/tools/docker-compose/compose.yaml down
 
 .PHONY: pip-compile-x86_64
 pip-compile-x86_64:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
podman-compose 1.20 has an issue to recognize relative paths given with `-f` parameter. ([reference](https://github.com/containers/podman-compose/issues/1059))
Since it still can process absolute paths, we'll update our `Makefile` to use absolute paths by adding `${PWD}` in front of relative paths

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run some make targets that uses `podman-compose`, like `make start-backends`.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Manually ran `make` targets.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
