### PR TITLE
Option to enable chat streaming

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/configuration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/configuration.py
@@ -41,11 +41,14 @@ class HttpConfiguration(BaseConfig):
         timeout: Optional[int],
         enable_health_check: Optional[bool],
         verify_ssl: bool,
+        stream: bool = False,
     ):
         super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.verify_ssl = verify_ssl
+        self.stream = stream
 
     verify_ssl: bool
+    stream: bool
 
 
 @Register(api_type="http")
@@ -60,6 +63,7 @@ class HttpPipelineConfiguration(PipelineConfiguration[HttpConfiguration]):
                 timeout=kwargs["timeout"],
                 enable_health_check=kwargs["enable_health_check"],
                 verify_ssl=kwargs["verify_ssl"],
+                stream=kwargs["stream"],
             ),
         )
 
@@ -67,3 +71,4 @@ class HttpPipelineConfiguration(PipelineConfiguration[HttpConfiguration]):
 @Register(api_type="http")
 class HttpConfigurationSerializer(BaseConfigSerializer):
     verify_ssl = serializers.BooleanField(required=False, default=True)
+    stream = serializers.BooleanField(required=False, default=False)

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -541,7 +541,6 @@ ANSIBLE_AI_ONE_CLICK_REPORTS_CONFIG: dict = (
 # ------------------------------------------
 CHATBOT_DEFAULT_PROVIDER = os.getenv("CHATBOT_DEFAULT_PROVIDER")
 CHATBOT_DEBUG_UI = os.getenv("CHATBOT_DEBUG_UI", "False").lower() == "true"
-CHATBOT_STREAM = os.getenv("CHATBOT_STREAM", "False").lower() == "true"
 # ==========================================
 
 # ==========================================

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -541,6 +541,7 @@ ANSIBLE_AI_ONE_CLICK_REPORTS_CONFIG: dict = (
 # ------------------------------------------
 CHATBOT_DEFAULT_PROVIDER = os.getenv("CHATBOT_DEFAULT_PROVIDER")
 CHATBOT_DEBUG_UI = os.getenv("CHATBOT_DEBUG_UI", "False").lower() == "true"
+CHATBOT_STREAM = os.getenv("CHATBOT_STREAM", "False").lower() == "true"
 # ==========================================
 
 # ==========================================

--- a/ansible_ai_connect/main/settings/legacy.py
+++ b/ansible_ai_connect/main/settings/legacy.py
@@ -189,6 +189,7 @@ def load_from_env_vars():
             "inference_url": chatbot_service_url or "http://localhost:8000",
             "model_id": chatbot_service_model_id or "granite3-8b",
             "verify_ssl": model_service_verify_ssl,
+            "stream": False,
         },
     }
 

--- a/ansible_ai_connect/main/templates/chatbot/index.html
+++ b/ansible_ai_connect/main/templates/chatbot/index.html
@@ -21,5 +21,6 @@
     <div id="user_name" hidden>{{user_name}}</div>
     <div id="bot_name" hidden>{{bot_name}}</div>
     <div id="debug" hidden>{{debug}}</div>
+    <div id="stream" hidden>{{stream}}</div>
 {% endblock content %}
 </html>

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -339,6 +339,7 @@ class TestChatbotView(TestCase):
         self.assertContains(r, TestChatbotView.CHATBOT_PAGE_TITLE)
         self.assertContains(r, self.rh_user.username)
         self.assertContains(r, '<div id="debug" hidden>false</div>')
+        self.assertContains(r, '<div id="stream" hidden>false</div>')
 
     @override_settings(CHATBOT_DEBUG_UI=True)
     def test_chatbot_view_with_debug_ui(self):
@@ -346,3 +347,10 @@ class TestChatbotView(TestCase):
         r = self.client.get(reverse("chatbot"), {"debug": "true"})
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, '<div id="debug" hidden>true</div>')
+
+    @override_settings(CHATBOT_STREAM=True)
+    def test_chatbot_view_with_streaming_enabled(self):
+        self.client.force_login(user=self.rh_user)
+        r = self.client.get(reverse("chatbot"), {"stream": "true"})
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, '<div id="stream" hidden>true</div>')

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from textwrap import dedent
 
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
 from django.http import HttpResponseRedirect
@@ -25,6 +26,7 @@ from django.test import RequestFactory, TestCase, modify_settings, override_sett
 from django.urls import reverse
 from rest_framework.test import APITransactionTestCase
 
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import ModelPipelineChatBot
 from ansible_ai_connect.main.settings.base import SOCIAL_AUTH_OIDC_KEY
 from ansible_ai_connect.main.views import LoginView
 from ansible_ai_connect.test_utils import (
@@ -348,8 +350,11 @@ class TestChatbotView(TestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, '<div id="debug" hidden>true</div>')
 
-    @override_settings(CHATBOT_STREAM=True)
     def test_chatbot_view_with_streaming_enabled(self):
+        llm: ModelPipelineChatBot = apps.get_app_config("ai").get_model_pipeline(
+            ModelPipelineChatBot
+        )
+        llm.config.stream = True
         self.client.force_login(user=self.rh_user)
         r = self.client.get(reverse("chatbot"), {"stream": "true"})
         self.assertEqual(r.status_code, HTTPStatus.OK)

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -139,7 +139,11 @@ class ChatbotView(ProtectedTemplateView):
         if user and user.is_authenticated:
             context["user_name"] = user.username
         context["debug"] = "true" if settings.CHATBOT_DEBUG_UI else "false"
-        context["stream"] = "true" if settings.CHATBOT_STREAM else "false"
+
+        llm: ModelPipelineChatBot = apps.get_app_config("ai").get_model_pipeline(
+            ModelPipelineChatBot
+        )
+        context["stream"] = "true" if llm.config.stream else "false"
 
         return context
 

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -139,6 +139,7 @@ class ChatbotView(ProtectedTemplateView):
         if user and user.is_authenticated:
             context["user_name"] = user.username
         context["debug"] = "true" if settings.CHATBOT_DEBUG_UI else "false"
+        context["stream"] = "true" if settings.CHATBOT_STREAM else "false"
 
         return context
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-39043>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Add an option to enable chat streaming to our AI Connect service Django application. The new option is
```
CHATBOT_STREAM
```
and its default value is set to `False`.  Unless `CHATBOT_STREAM` is set to `True`, the chat streaming support code will 
not be enabled.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests are provided with this PR.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
