### PR TITLE
Cover generations v1 urls changes unitests

### DIFF
--- a/ansible_ai_connect/ai/api/versions/v1/ai/tests/test_role_generation_view.py
+++ b/ansible_ai_connect/ai/api/versions/v1/ai/tests/test_role_generation_view.py
@@ -20,3 +20,7 @@ from ansible_ai_connect.ai.api.versions.v1.test_base import API_VERSION
 
 class TestRoleGenerationViewVersion1(TestRoleGenerationView):
     api_version = API_VERSION
+
+    def test_generation_role_version_url(self):
+        url = self.api_version_reverse("generations/role")
+        self.assertEqual(url, f"/api/{self.api_version}/ai/generations/role/")

--- a/ansible_ai_connect/ai/api/versions/v1/ai/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/versions/v1/ai/tests/test_views.py
@@ -57,6 +57,10 @@ class TestGenerationFeatureEnableForWcaOnpremVersion1(TestGenerationFeatureEnabl
 class TestGenerationViewVersion1(TestGenerationView):
     api_version = API_VERSION
 
+    def test_generation_playbook_version_url(self):
+        url = self.api_version_reverse("generations/playbook")
+        self.assertEqual(url, f"/api/{self.api_version}/ai/generations/playbook/")
+
 
 class TestGenerationViewWithWCAVersion1(TestGenerationViewWithWCA):
     api_version = API_VERSION


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-37980


## Description
add unitests to cover v1 urls for generations/playbook and generations/role


## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
