### PR TITLE
PlaybookExplanationFeedback: do not accept action == 3

### DIFF
--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -309,7 +309,9 @@ class PlaybookGenerationAction(serializers.Serializer):
 
 
 class PlaybookExplanationFeedback(serializers.Serializer):
-    action = GenerationActionEnum()
+    USER_ACTION_CHOICES = (("0", "ACCEPTED"), ("1", "REJECTED"), ("2", "IGNORED"))
+
+    action = serializers.ChoiceField(choices=USER_ACTION_CHOICES, required=True)
     explanationId = serializers.UUIDField(
         format="hex_verbose",
         required=True,

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1219,7 +1219,7 @@ components:
       type: object
       properties:
         action:
-          $ref: '#/components/schemas/Action693Enum'
+          $ref: '#/components/schemas/Action4c6Enum'
         explanationId:
           type: string
           format: uuid


### PR DESCRIPTION
Partial revert of b2e04ee to be sure we don't accept an `PlaybookExplanationFeedback` event when action == 3 and fix the name
of the actions in the OpenAPI schema.
