### PR TITLE
pip-audit: address GHSA-79v4-65xg-pq4g

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -56,3 +56,6 @@ jobs:
             GHSA-32p4-gm2c-wmch
             GHSA-jpxc-vmjf-9fcj
             GHSA-99w6-3xph-cx78
+            # To remove once we can install cryptography 44.0.1
+            # See: https://github.com/ansible/ansible-ai-connect-service/pull/1530
+            GHSA-79v4-65xg-pq4g

--- a/wisdom-service.Containerfile
+++ b/wisdom-service.Containerfile
@@ -42,6 +42,12 @@ COPY ansible_ai_connect /var/www/ansible-ai-connect-service/ansible_ai_connect
 RUN /usr/bin/python3.11 -m pip --no-cache-dir install supervisor
 RUN /usr/bin/python3.11 -m venv /var/www/venv
 ENV PATH="/var/www/venv/bin:${PATH}"
+
+# Address GHSA-79v4-65xg-pq4g and the fact jwcrypto prevent us from pulling cryptography 44.0.1
+# Please remove once jwcrypto and cryptography can be both upgraded
+RUN dnf install -y openssl-devel
+RUN /var/www/venv/bin/python3.11 -m pip --no-cache-dir install --no-binary=all cryptography==43.0.1
+
 RUN /var/www/venv/bin/python3.11 -m pip --no-cache-dir install -r/var/www/ansible-ai-connect-service/requirements.txt
 RUN /var/www/venv/bin/python3.11 -m pip --no-cache-dir install -e/var/www/ansible-ai-connect-service/
 RUN mkdir /var/run/uwsgi


### PR DESCRIPTION
The current `cryptography` wheel packages have a secruity vulnerability that
was address by `cryptography==44.0.1`.

`jwcrypto==1.5.6` prevents us from pulling `cryptography=44.0.1` because of the
way the requirements are defined: `cryptography<44,>=41.0.5'`.

So we build it from source for now.
