### PR TITLE
dummy playbookgen: don't return Markdown tags

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -50,9 +50,7 @@ from ansible_ai_connect.healthcheck.backends import (
 
 logger = logging.getLogger(__name__)
 
-PLAYBOOK = """
-```yaml
----
+PLAYBOOK = """---
 - hosts: rhel9
   become: yes
   tasks:
@@ -75,7 +73,6 @@ PLAYBOOK = """
         name: nginx
         state: started
         enabled: yes
-```
 """
 
 ROLE_FILES = [


### PR DESCRIPTION
Don't wrap the YAML answer in between Markdown tags. Those breaks the
`YAML` structure and should not be part of the answer.
