### PR TITLE
reduce the severity of the "is not available for provider blabla" messages

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/registry.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/registry.py
@@ -81,7 +81,7 @@ def set_defaults():
         def v_or_default(k, v):
             defaults = REGISTRY["nop"]
             if v is None:
-                logger.warning(
+                logger.debug(
                     f"'{k.alias()}' is not available for provider '{pipeline_provider}',"
                     " failing back to 'nop'"
                 )


### PR DESCRIPTION
These messages are flooding our logs in production and pretty normal
until we finally migrate to `ANSIBLE_AI_MODEL_MESH_CONFIG`.
