### PR TITLE
Disable chat streaming temporarily

### DIFF
--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -160,7 +160,8 @@ class ChatbotView(ProtectedTemplateView):
         if user and user.is_authenticated:
             context["user_name"] = user.username
         context["debug"] = "true" if settings.CHATBOT_DEBUG_UI else "false"
-        context["stream"] = "true" if self.streaming_chatbot_enabled else "false"
+        # context["stream"] = "true" if self.streaming_chatbot_enabled else "false"
+        context["stream"] = "false"  # Disable chat streaming temporarily
 
         return context
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-39044>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Chat streaming was enabled with #1527, but it is not working.  AI Connect Service logs following error:
```
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'daphne'.
```
and `400` error is sent to chatbot UI.  Until a solution is found, we need to let chatbot UI to use non-streaming `/chat` endpoint.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
n/a

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
