### PR TITLE
Reenable chat streaming

### DIFF
--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -17,7 +17,6 @@
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from textwrap import dedent
-from unittest import skip
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -337,7 +336,6 @@ class TestChatbotView(TestCase):
         self.assertEqual(r.status_code, HTTPStatus.FOUND)
         self.assertEqual(r.url, "/")
 
-    @skip("Chat streaming is temporarily disabled")
     def test_chatbot_view_with_rh_user(self):
         self.client.force_login(user=self.rh_user)
         r = self.client.get(reverse("chatbot"))

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -160,8 +160,7 @@ class ChatbotView(ProtectedTemplateView):
         if user and user.is_authenticated:
             context["user_name"] = user.username
         context["debug"] = "true" if settings.CHATBOT_DEBUG_UI else "false"
-        # context["stream"] = "true" if self.streaming_chatbot_enabled else "false"
-        context["stream"] = "false"  # Disable chat streaming temporarily
+        context["stream"] = "true" if self.streaming_chatbot_enabled else "false"
 
         return context
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-39044>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Re-enable chat streaming.  After applying #1545, `/streaming_chat` endpoint started returning expected values. Now it's time to let chatbot UI to use streaming chat endpoint instead of non-streaming one:
```
$ curl -v https://stage.ai.ansible.redhat.com/api/v1/ai/streaming_chat/ -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer ${TOKEN}" -d '{"query":"Hello","media_type":"application/json"}'
* Host stage.ai.ansible.redhat.com:443 was resolved.
* IPv6: 2600:9000:23ca:8800:5:ded9:11c0:93a1, 2600:9000:23ca:f000:5:ded9:11c0:93a1, 2600:9000:23ca:9200:5:ded9:11c0:93a1, 2600:9000:23ca:2200:5:ded9:11c0:93a1, 2600:9000:23ca:7600:5:ded9:11c0:93a1, 2600:9000:23ca:2e00:5:ded9:11c0:93a1, 2600:9000:23ca:6000:5:ded9:11c0:93a1, 2600:9000:23ca:7800:5:ded9:11c0:93a1
* IPv4: 108.139.29.105, 108.139.29.33, 108.139.29.47, 108.139.29.97
*   Trying 108.139.29.105:443...
* Connected to stage.ai.ansible.redhat.com (108.139.29.105) port 443
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/pki/tls/certs/ca-bundle.crt
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / x25519 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.ai.ansible.redhat.com
*  start date: Jul 16 00:00:00 2024 GMT
*  expire date: Aug 14 23:59:59 2025 GMT
*  subjectAltName: host "stage.ai.ansible.redhat.com" matched cert's "*.ai.ansible.redhat.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 2: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://stage.ai.ansible.redhat.com/api/v1/ai/streaming_chat/
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: stage.ai.ansible.redhat.com]
* [HTTP/2] [1] [:path: /api/v1/ai/streaming_chat/]
* [HTTP/2] [1] [user-agent: curl/8.9.1]
* [HTTP/2] [1] [content-type: application/json]
* [HTTP/2] [1] [accept: application/json]
* [HTTP/2] [1] [authorization: Bearer WttugZDbZww68uzZc4yec7LNReK9hc]
* [HTTP/2] [1] [content-length: 49]
> POST /api/v1/ai/streaming_chat/ HTTP/2
> Host: stage.ai.ansible.redhat.com
> User-Agent: curl/8.9.1
> Content-Type: application/json
> Accept: application/json
> Authorization: Bearer WttugZDbZww68uzZc4yec7LNReK9hc
> Content-Length: 49
>
* upload completely sent off: 49 bytes
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 200
< server: CloudFront
< content-type: text/event-stream
< date: Mon, 03 Mar 2025 18:30:21 GMT
< set-cookie: r_s_session=0c6609ceb2771f349e0751ec979af5df; path=/; HttpOnly; Secure; SameSite=Lax
< allow: POST, OPTIONS
< content-security-policy: default-src 'self' data:; connect-src 'self'
< x-frame-options: DENY
< vary: Authorization, Cookie
< x-content-type-options: nosniff
< referrer-policy: strict-origin
< cross-origin-opener-policy: same-origin
< x-robots-tag: noindex, nofollow
< x-cache: Miss from cloudfront
< via: 1.1 4a1ea8b67dc2325b2469ed51d3e186ac.cloudfront.net (CloudFront)
< x-amz-cf-pop: JFK50-P2
< x-amz-cf-id: Q29diXsqXiwUR4fSc-JwXFSSstqm-jWGqO7kRMHQMJMVGFIK-5nETA==
< x-xss-protection: 1; mode=block
< strict-transport-security: max-age=31536000
< vary: Origin
<
data: {"event": "start", "data": {"conversation_id": "cda85c10-5b9b-40fe-9a0a-420bc7dfb386"}}

data: {"event": "token", "data": {"id": 0, "token": ""}}

data: {"event": "token", "data": {"id": 1, "token": "Hello"}}

data: {"event": "token", "data": {"id": 2, "token": "!"}}

data: {"event": "token", "data": {"id": 3, "token": " I"}}

data: {"event": "token", "data": {"id": 4, "token": "'m"}}

data: {"event": "token", "data": {"id": 5, "token": " Ansible"}}

data: {"event": "token", "data": {"id": 6, "token": " L"}}

data: {"event": "token", "data": {"id": 7, "token": "ights"}}

data: {"event": "token", "data": {"id": 8, "token": "peed"}}

data: {"event": "token", "data": {"id": 9, "token": ","}}

data: {"event": "token", "data": {"id": 10, "token": " your"}}

data: {"event": "token", "data": {"id": 11, "token": " virtual"}}

data: {"event": "token", "data": {"id": 12, "token": " assistant"}}

data: {"event": "token", "data": {"id": 13, "token": " for"}}

data: {"event": "token", "data": {"id": 14, "token": " all"}}

data: {"event": "token", "data": {"id": 15, "token": " things"}}

data: {"event": "token", "data": {"id": 16, "token": " Ansible"}}

data: {"event": "token", "data": {"id": 17, "token": "."}}

data: {"event": "token", "data": {"id": 18, "token": " How"}}

data: {"event": "token", "data": {"id": 19, "token": " can"}}

data: {"event": "token", "data": {"id": 20, "token": " I"}}

data: {"event": "token", "data": {"id": 21, "token": " assist"}}

data: {"event": "token", "data": {"id": 22, "token": " you"}}

data: {"event": "token", "data": {"id": 23, "token": " today"}}

data: {"event": "token", "data": {"id": 24, "token": "?"}}

data: {"event": "token", "data": {"id": 25, "token": ""}}

data: {"event": "end", "data": {"referenced_documents": [], "truncated": false, "input_tokens": 241, "output_tokens": 25}}

* Connection #0 to host stage.ai.ansible.redhat.com left intact
~ $
```

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
