### PR TITLE
AAP-40235: Improve error notification of features that are not available

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 from typing import Optional
 
+from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.nop.configuration import NopConfiguration
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ChatBotParameters,
@@ -59,7 +60,7 @@ class NopCompletionsPipeline(NopMetaData, ModelPipelineCompletions[NopConfigurat
         super().__init__(config=config)
 
     def invoke(self, params: CompletionsParameters) -> CompletionsResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
@@ -75,7 +76,7 @@ class NopContentMatchPipeline(NopMetaData, ModelPipelineContentMatch[NopConfigur
         super().__init__(config=config)
 
     def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -88,7 +89,7 @@ class NopPlaybookGenerationPipeline(NopMetaData, ModelPipelinePlaybookGeneration
         super().__init__(config=config)
 
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -101,7 +102,7 @@ class NopRoleGenerationPipeline(NopMetaData, ModelPipelineRoleGeneration[NopConf
         super().__init__(config=config)
 
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -116,7 +117,7 @@ class NopPlaybookExplanationPipeline(
         super().__init__(config=config)
 
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -129,7 +130,7 @@ class NopRoleExplanationPipeline(NopMetaData, ModelPipelineRoleExplanation[NopCo
         super().__init__(config=config)
 
     def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -142,7 +143,7 @@ class NopChatBotPipeline(NopMetaData, ModelPipelineChatBot[NopConfiguration]):
         super().__init__(config=config)
 
     def invoke(self, params: ChatBotParameters) -> ChatBotResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
@@ -155,7 +156,7 @@ class NopStreamingChatBotPipeline(NopMetaData, ModelPipelineStreamingChatBot[Nop
         super().__init__(config=config)
 
     def invoke(self, params: StreamingChatBotParameters) -> StreamingChatBotResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/tests/test_factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/tests/test_factory.py
@@ -1,0 +1,66 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.nop.pipelines import (
+    NopChatBotPipeline,
+    NopCompletionsPipeline,
+    NopContentMatchPipeline,
+    NopPlaybookExplanationPipeline,
+    NopPlaybookGenerationPipeline,
+    NopRoleExplanationPipeline,
+    NopRoleGenerationPipeline,
+)
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_factory import (
+    TestModelPipelineFactoryImplementations,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG="{}")
+class TestModelPipelineFactory(TestModelPipelineFactoryImplementations):
+
+    def test_completions_pipeline(self):
+        self.assert_default_implementation(ModelPipelineCompletions, NopCompletionsPipeline)
+
+    def test_content_match_pipeline(self):
+        self.assert_default_implementation(ModelPipelineContentMatch, NopContentMatchPipeline)
+
+    def test_playbook_generation_pipeline(self):
+        self.assert_default_implementation(
+            ModelPipelinePlaybookGeneration, NopPlaybookGenerationPipeline
+        )
+
+    def test_role_generation_pipeline(self):
+        self.assert_default_implementation(ModelPipelineRoleGeneration, NopRoleGenerationPipeline)
+
+    def test_playbook_explanation_pipeline(self):
+        self.assert_default_implementation(
+            ModelPipelinePlaybookExplanation, NopPlaybookExplanationPipeline
+        )
+
+    def test_role_explanation_pipeline(self):
+        self.assert_default_implementation(ModelPipelineRoleExplanation, NopRoleExplanationPipeline)
+
+    def test_chatbot_pipeline(self):
+        self.assert_default_implementation(ModelPipelineChatBot, NopChatBotPipeline)

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
@@ -16,6 +16,7 @@ from typing import Type
 
 from django.test import override_settings
 
+from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
 from ansible_ai_connect.ai.api.model_pipelines.nop.pipelines import (
     NopContentMatchPipeline,
@@ -129,5 +130,5 @@ class TestModelPipelineFactoryImplementations(WisdomServiceAPITestCaseBaseOIDC):
                 f"Using NOP implementation for '{pipeline_type.__name__}'.",
                 log,
             )
-            with self.assertRaises(NotImplementedError):
+            with self.assertRaises(FeatureNotAvailable):
                 pipeline.invoke(None)

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -27,6 +27,7 @@ from health_check.exceptions import ServiceUnavailable
 from prometheus_client import Counter, Histogram
 from requests.exceptions import HTTPError
 
+from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.formatter import (
     get_task_names_from_prompt,
     strip_task_preamble_from_multi_task_prompt,
@@ -526,7 +527,7 @@ class WCABaseRoleGenerationPipeline(
         super().__init__(config=config)
 
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable
 
 
 class WCABasePlaybookExplanationPipeline(
@@ -606,4 +607,4 @@ class WCABaseRoleExplanationPipeline(
         super().__init__(config=config)
 
     def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
-        raise NotImplementedError
+        raise FeatureNotAvailable

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -224,9 +224,6 @@ class WCAOnPremRoleExplanationPipeline(
     def __init__(self, config: WCAOnPremConfiguration):
         super().__init__(config=config)
 
-    def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
-        raise NotImplementedError
-
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -427,9 +427,6 @@ class WCASaaSRoleExplanationPipeline(
     def __init__(self, config: WCASaaSConfiguration):
         super().__init__(config=config)
 
-    def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
-        raise NotImplementedError
-
     def self_test(self) -> Optional[HealthCheckSummary]:
         raise NotImplementedError
 

--- a/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
+++ b/ansible_ai_connect/ai/api/pipelines/completion_stages/inference.py
@@ -25,6 +25,7 @@ from prometheus_client import Histogram
 from ansible_ai_connect.ai.api.data.data_model import ModelMeshPayload
 from ansible_ai_connect.ai.api.exceptions import (
     BaseWisdomAPIException,
+    FeatureNotAvailable,
     ModelTimeoutException,
     ServiceUnavailable,
     WcaBadRequestException,
@@ -220,6 +221,13 @@ class InferenceStage(PipelineElement):
             )
             detail = exception.json_response["detail"]
             raise WcaValidationFailureException(cause=e, detail={"reason": detail})
+
+        except FeatureNotAvailable as e:
+            exception = e
+            logger.exception(
+                f"Completions feature is not available for suggestion {payload.suggestionId}."
+            )
+            raise FeatureNotAvailable(cause=e)
 
         except Exception as e:
             exception = e

--- a/ansible_ai_connect/ai/api/tests/test_completion_view.py
+++ b/ansible_ai_connect/ai/api/tests/test_completion_view.py
@@ -28,6 +28,7 @@ from rest_framework.exceptions import APIException
 
 from ansible_ai_connect.ai.api.data.data_model import APIPayload
 from ansible_ai_connect.ai.api.exceptions import (
+    FeatureNotAvailable,
     PostprocessException,
     PreprocessInvalidYamlException,
 )
@@ -628,6 +629,7 @@ class TestCompletionView(APIVersionTestCaseBase, WisdomServiceAPITestCaseBase):
             (WcaNoDefaultModelId(), HTTPStatus.FORBIDDEN),
             (WcaModelIdNotFound(), HTTPStatus.FORBIDDEN),
             (WcaEmptyResponse(), HTTPStatus.NO_CONTENT),
+            (FeatureNotAvailable(), HTTPStatus.NOT_FOUND),
             (ConnectionError(), HTTPStatus.SERVICE_UNAVAILABLE),
         ]:
             invoke.side_effect = self.get_side_effect(error)


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-40235

## Description
Change use of `NotImplementedError` to `FeatureNotAvailable` when a pipeline does not implement a feature.

## Testing
- Run `ansible-ai-connect-service` locally with `ANSIBLE_AI_MODEL_MESH_CONFIG="{}"`.
- Run the Ansible VSCode extension configured to use the local `ansible-ai-connect-service`. 
- Attempts to use "Completions", "Content Match", "Playbook Generation" etc should result in a "The requested action is not available in your environment" message.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
