### PR TITLE
update LLM model/provider defaults defined in chatbot UI

### DIFF
--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -558,12 +558,12 @@ test("Debug mode test", async () => {
   mockAxios(200);
 
   await renderApp(true);
-  await expect.element(page.getByText("granite3-8b")).toBeVisible();
-  await page.getByText("granite3-8b").click();
+  await expect.element(page.getByText("granite3-1-8b")).toBeVisible();
+  await page.getByText("granite3-1-8b").click();
   await expect
-    .element(page.getByRole("menuitem", { name: "granite3-1-8b" }))
+    .element(page.getByRole("menuitem", { name: "granite3-8b" }))
     .toBeVisible();
-  await page.getByRole("menuitem", { name: "granite3-1-8b" }).click();
+  await page.getByRole("menuitem", { name: "granite3-8b" }).click();
 
   await sendMessage("Hello");
   await expect

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -30,8 +30,8 @@ const botName =
   document.getElementById("bot_name")?.innerText ?? "Ansible Lightspeed";
 
 export const modelsSupported: LLMModel[] = [
-  { model: "granite3-8b", provider: "my_rhoai_g3" },
   { model: "granite3-1-8b", provider: "my_rhoai_g31" },
+  { model: "granite3-8b", provider: "my_rhoai_g3" },
 ];
 
 export const readCookie = (name: string): string | null => {
@@ -145,7 +145,7 @@ export const useChatbot = () => {
   const [conversationId, setConversationId] = useState<
     string | null | undefined
   >(undefined);
-  const [selectedModel, setSelectedModel] = useState("granite3-8b");
+  const [selectedModel, setSelectedModel] = useState("granite3-1-8b");
   const [systemPrompt, setSystemPrompt] = useState(QUERY_SYSTEM_INSTRUCTION);
   const [hasStopButton, setHasStopButton] = useState<boolean>(false);
   const [abortController, setAbortController] = useState(new AbortController());


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-40371>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Change the default LLM defined in chatbot UI to granite 3.1. It is used only in the debug mode, which is enabled in STAGE.  In non-debug mode, which is used in PROD, there would be no changes in the behaviors.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit test

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
