### PR TITLE
pyright: install aiohttp

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -21,5 +21,5 @@ jobs:
         python-version: '3.11'
     - name: install
       run: |
-        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain langchain-ollama grpcio django-health-check
+        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain langchain-ollama grpcio django-health-check aiohttp
         pyright


### PR DESCRIPTION
Ensure `aiohttp` is available before we run `pyright`.

e.g: https://github.com/ansible/ansible-ai-connect-service/actions/runs/13706765631/job/38333817348?pr=1551