### PR TITLE
WCABaseConfiguration: honor the inference_url key

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
@@ -79,12 +79,14 @@ class WCASaaSConfiguration(WCABaseConfiguration):
         self.idp_url = idp_url
         self.idp_login = idp_login
         self.idp_password = idp_password
+        self.inference_url = inference_url
         self.one_click_default_api_key = one_click_default_api_key
         self.one_click_default_model_id = one_click_default_model_id
 
     idp_url: str
     idp_login: str
     idp_password: str
+    inference_url: str
     one_click_default_api_key: str
     one_click_default_model_id: str
 


### PR DESCRIPTION
Properly expose the `inference_url` value that was used during the
instance creation.
