### PR TITLE
pipeline/http: self_test() with a 5s timeout

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -140,7 +140,7 @@ class HttpChatBotMetaData(HttpMetaData):
         )
         try:
             headers = {"Content-Type": "application/json"}
-            r = requests.get(self.config.inference_url + "/readiness", headers=headers)
+            r = requests.get(self.config.inference_url + "/readiness", headers=headers, timeout=5)
             r.raise_for_status()
 
             data = r.json()


### PR DESCRIPTION
Ensure the `self_test()` won't take too much time and penalize the other
checks. `requests` doesn't have any default timeout and relies on the
settings of the system.

See: https://github.com/psf/requests/issues/3070
