### PR TITLE
AAP-41813: Health checks: Show status as "skipped" when "self_test" is not implemented

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -16,7 +16,6 @@ import json
 import logging
 import secrets
 import time
-from typing import Optional
 
 import requests
 
@@ -153,7 +152,7 @@ class DummyCompletionsPipeline(DummyMetaData, ModelPipelineCompletions[DummyConf
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         return HealthCheckSummary(
             {
                 MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
@@ -174,8 +173,13 @@ class DummyPlaybookGenerationPipeline(
         create_outline = params.create_outline
         return PLAYBOOK, PLAYBOOK_OUTLINE.strip() if create_outline else "", []
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+            }
+        )
 
 
 @Register(api_type="dummy")
@@ -188,8 +192,13 @@ class DummyRoleGenerationPipeline(DummyMetaData, ModelPipelineRoleGeneration[Dum
         create_outline = params.create_outline
         return "install_nginx", ROLE_FILES, ROLE_OUTLINE.strip() if create_outline else "", []
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+            }
+        )
 
 
 @Register(api_type="dummy")
@@ -203,8 +212,13 @@ class DummyPlaybookExplanationPipeline(
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         return EXPLANATION
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+            }
+        )
 
 
 @Register(api_type="dummy")
@@ -216,5 +230,10 @@ class DummyRoleExplanationPipeline(DummyMetaData, ModelPipelineRoleExplanation[D
     def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
         return ROLE_EXPLANATION
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/tests/test_healthcheck.py
@@ -1,0 +1,54 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("dummy"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    def test_completions_healthcheck(self):
+        self.assert_ok(ModelPipelineCompletions, "dummy")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_ok(ModelPipelinePlaybookGeneration, "dummy")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_ok(ModelPipelineRoleGeneration, "dummy")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_ok(ModelPipelinePlaybookExplanation, "dummy")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_ok(ModelPipelineRoleExplanation, "dummy")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/grpc/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/grpc/tests/test_healthcheck.py
@@ -1,0 +1,58 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_wca_client import MockResponse
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("grpc"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    @mock.patch("requests.get", return_value=MockResponse(None, 200))
+    def test_completions_healthcheck(self, *args, **kwargs):
+        self.assert_ok(ModelPipelineCompletions, "grpc")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "nop")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "nop")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "nop")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -15,7 +15,7 @@
 import json
 import logging
 from json import JSONDecodeError
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator
 
 import aiohttp
 import requests
@@ -131,7 +131,7 @@ class HttpChatBotMetaData(HttpMetaData):
     def __init__(self, config: HttpConfiguration):
         super().__init__(config=config)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         summary: HealthCheckSummary = HealthCheckSummary(
             {
                 MODEL_MESH_HEALTH_CHECK_PROVIDER: "http",

--- a/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_healthcheck.py
@@ -1,0 +1,59 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_wca_client import MockResponse
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("http"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    @mock.patch("requests.get", return_value=MockResponse(None, 200))
+    def test_completions_healthcheck(self, *args, **kwargs):
+        self.assert_ok(ModelPipelineCompletions, "http")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "nop")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "nop")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "nop")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    @mock.patch("requests.get", return_value=MockResponse({"ready": True}, 200))
+    def test_chatbot_healthcheck(self, *args, **kwargs):
+        self.assert_ok(ModelPipelineChatBot, "http")

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -16,7 +16,7 @@ import logging
 import re
 from abc import ABCMeta
 from textwrap import dedent
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 import requests
 from langchain_core.messages import BaseMessage
@@ -227,7 +227,7 @@ class LangchainCompletionsPipeline(
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -310,7 +310,7 @@ class LangchainPlaybookGenerationPipeline(
 
         return playbook, outline, []
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -376,7 +376,7 @@ class LangchainRoleGenerationPipeline(
 
         return role, files, outline, []
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):
@@ -438,7 +438,7 @@ class LangchainPlaybookExplanationPipeline(
         explanation = chain.invoke({"playbook": content})
         return explanation
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         raise NotImplementedError
 
     def get_chat_model(self, model_id):

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/tests/test_pipeline.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/tests/test_pipeline.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from unittest.mock import Mock
 
 from django.test import TestCase
-from langchain_community.llms import FakeListLLM
+from langchain_core.language_models.fake import FakeListLLM
 from langchain_core.messages.base import BaseMessage
 
 from ansible_ai_connect.ai.api.model_pipelines.langchain.configuration import (

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -14,7 +14,6 @@
 
 import json
 import logging
-from typing import Optional
 
 import requests
 
@@ -30,7 +29,11 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     ModelPipelineCompletions,
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
-from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
+from ansible_ai_connect.healthcheck.backends import (
+    MODEL_MESH_HEALTH_CHECK_MODELS,
+    MODEL_MESH_HEALTH_CHECK_PROVIDER,
+    HealthCheckSummary,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,5 +129,10 @@ class LlamaCppCompletionsPipeline(
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "llamacpp",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/tests/test_healthcheck.py
@@ -1,0 +1,54 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("llamacpp"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    def test_completions_healthcheck(self):
+        self.assert_skipped(ModelPipelineCompletions, "llamacpp")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "nop")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "nop")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "nop")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
@@ -11,8 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional
-
 from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.nop.configuration import NopConfiguration
 from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
@@ -43,7 +41,11 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
     StreamingChatBotResponse,
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
-from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
+from ansible_ai_connect.healthcheck.backends import (
+    MODEL_MESH_HEALTH_CHECK_MODELS,
+    MODEL_MESH_HEALTH_CHECK_PROVIDER,
+    HealthCheckSummary,
+)
 
 
 @Register(api_type="nop")
@@ -65,8 +67,13 @@ class NopCompletionsPipeline(NopMetaData, ModelPipelineCompletions[NopConfigurat
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -78,8 +85,13 @@ class NopContentMatchPipeline(NopMetaData, ModelPipelineContentMatch[NopConfigur
     def invoke(self, params: ContentMatchParameters) -> ContentMatchResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -91,8 +103,13 @@ class NopPlaybookGenerationPipeline(NopMetaData, ModelPipelinePlaybookGeneration
     def invoke(self, params: PlaybookGenerationParameters) -> PlaybookGenerationResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -104,8 +121,13 @@ class NopRoleGenerationPipeline(NopMetaData, ModelPipelineRoleGeneration[NopConf
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -119,8 +141,13 @@ class NopPlaybookExplanationPipeline(
     def invoke(self, params: PlaybookExplanationParameters) -> PlaybookExplanationResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -132,8 +159,13 @@ class NopRoleExplanationPipeline(NopMetaData, ModelPipelineRoleExplanation[NopCo
     def invoke(self, params: RoleExplanationParameters) -> RoleExplanationResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -145,8 +177,13 @@ class NopChatBotPipeline(NopMetaData, ModelPipelineChatBot[NopConfiguration]):
     def invoke(self, params: ChatBotParameters) -> ChatBotResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="nop")
@@ -158,5 +195,10 @@ class NopStreamingChatBotPipeline(NopMetaData, ModelPipelineStreamingChatBot[Nop
     def invoke(self, params: StreamingChatBotParameters) -> StreamingChatBotResponse:
         raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "nop",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/tests/test_healthcheck.py
@@ -1,0 +1,54 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("nop"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    def test_completions_healthcheck(self):
+        self.assert_skipped(ModelPipelineCompletions, "nop")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "nop")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "nop")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "nop")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -31,6 +31,11 @@ from ansible_ai_connect.ai.api.model_pipelines.ollama.configuration import (
     OllamaConfiguration,
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
+from ansible_ai_connect.healthcheck.backends import (
+    MODEL_MESH_HEALTH_CHECK_MODELS,
+    MODEL_MESH_HEALTH_CHECK_PROVIDER,
+    HealthCheckSummary,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +56,14 @@ class OllamaCompletionsPipeline(LangchainCompletionsPipeline[OllamaConfiguration
     def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
         raise NotImplementedError
 
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "ollama",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
+
     def get_chat_model(self, model_id):
         return OllamaLLM(
             base_url=self.config.inference_url,
@@ -64,6 +77,14 @@ class OllamaPlaybookGenerationPipeline(LangchainPlaybookGenerationPipeline[Ollam
     def __init__(self, config: OllamaConfiguration):
         super().__init__(config=config)
 
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "ollama",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
+
     def get_chat_model(self, model_id):
         return OllamaLLM(
             base_url=self.config.inference_url,
@@ -76,6 +97,14 @@ class OllamaRoleGenerationPipeline(LangchainRoleGenerationPipeline[OllamaConfigu
 
     def __init__(self, config: OllamaConfiguration):
         super().__init__(config=config)
+
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "ollama",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
     def get_chat_model(self, model_id):
         return OllamaLLM(
@@ -102,6 +131,14 @@ class OllamaPlaybookExplanationPipeline(LangchainPlaybookExplanationPipeline[Oll
 
     def __init__(self, config: OllamaConfiguration):
         super().__init__(config=config)
+
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "ollama",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
     def get_chat_model(self, model_id):
         return OllamaLLM(

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_healthcheck.py
@@ -1,0 +1,54 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("ollama"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    def test_completions_healthcheck(self):
+        self.assert_skipped(ModelPipelineCompletions, "ollama")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "ollama")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "ollama")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "ollama")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -306,7 +306,7 @@ class ModelPipeline(
         raise NotImplementedError
 
     @abstractmethod
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         raise NotImplementedError
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
@@ -26,6 +26,7 @@ from ansible_ai_connect.ai.api.model_pipelines.http.configuration import (
 from ansible_ai_connect.ai.api.model_pipelines.llamacpp.configuration import (
     LlamaCppConfiguration,
 )
+from ansible_ai_connect.ai.api.model_pipelines.nop.configuration import NopConfiguration
 from ansible_ai_connect.ai.api.model_pipelines.ollama.configuration import (
     OllamaConfiguration,
 )
@@ -97,6 +98,8 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 enable_health_check=extract("enable_health_check", False, **kwargs),
                 verify_ssl=extract("verify_ssl", False, **kwargs),
             )
+        case "nop":
+            return NopConfiguration()
         case "ollama":
             return OllamaConfiguration(
                 inference_url=extract("inference_url", "http://localhost", **kwargs),

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_healthcheck.py
@@ -1,0 +1,46 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Type
+
+from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    PIPELINE_TYPE,
+    ModelPipeline,
+)
+from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
+from ansible_ai_connect.main.settings.types import t_model_mesh_api_type
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+
+
+class TestModelPipelineHealthCheck(WisdomServiceAPITestCaseBaseOIDC):
+
+    def assert_ok(self, pipeline_type: Type[PIPELINE_TYPE], provider: t_model_mesh_api_type):
+        self._assert_status(pipeline_type, provider, "ok")
+
+    def assert_skipped(self, pipeline_type: Type[PIPELINE_TYPE], provider: t_model_mesh_api_type):
+        self._assert_status(pipeline_type, provider, "skipped")
+
+    def _assert_status(
+        self, pipeline_type: Type[PIPELINE_TYPE], provider: t_model_mesh_api_type, status: str
+    ):
+        factory = ModelPipelineFactory()
+
+        pipeline: ModelPipeline = factory.get_pipeline(pipeline_type)
+        summary: HealthCheckSummary = pipeline.self_test()
+        self.assertIsNotNone(summary)
+        self.assertTrue("provider" in summary.items)
+        self.assertEqual(provider, summary.items["provider"])
+        self.assertTrue("models" in summary.items)
+        self.assertEqual(status, summary.items["models"])

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
@@ -80,10 +80,10 @@ class WCADummyCompletionsPipeline(
     def infer_from_parameters(self, *args, **kwargs):
         return ""
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
+    def self_test(self) -> HealthCheckSummary:
         return HealthCheckSummary(
             {
-                MODEL_MESH_HEALTH_CHECK_PROVIDER: "dummy",
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-dummy",
                 MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
             }
         )
@@ -100,5 +100,10 @@ class WCADummyRoleGenerationPipeline(
     def invoke(self, params: RoleGenerationParameters) -> RoleGenerationResponse:
         return "wca_dummy_role", [], "wca_dummy_outline", []
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-dummy",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -179,8 +179,13 @@ class WCAOnPremContentMatchPipeline(
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
         return self._get_base_headers(api_key)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-onprem",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca-onprem")
@@ -198,8 +203,13 @@ class WCAOnPremPlaybookGenerationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-onprem",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca-onprem")
@@ -211,8 +221,13 @@ class WCAOnPremRoleGenerationPipeline(
     def __init__(self, config: WCAOnPremConfiguration):
         super().__init__(config=config)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-onprem",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca-onprem")
@@ -224,8 +239,13 @@ class WCAOnPremRoleExplanationPipeline(
     def __init__(self, config: WCAOnPremConfiguration):
         super().__init__(config=config)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-onprem",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca-onprem")
@@ -243,5 +263,10 @@ class WCAOnPremPlaybookExplanationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca-onprem",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -312,8 +312,13 @@ class WCASaaSContentMatchPipeline(
     def get_codematch_headers(self, api_key: str) -> dict[str, str]:
         return self._get_base_headers(api_key)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca")
@@ -331,8 +336,13 @@ class WCASaaSPlaybookGenerationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca")
@@ -414,8 +424,13 @@ class WCASaaSRoleGenerationPipeline(
 
         return name, files, outline, warnings
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca")
@@ -432,8 +447,13 @@ class WCASaaSRoleExplanationPipeline(
             raise FeatureNotAvailable
         return super().invoke(params)
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )
 
 
 @Register(api_type="wca")
@@ -451,5 +471,10 @@ class WCASaaSPlaybookExplanationPipeline(
         else:
             raise FeatureNotAvailable
 
-    def self_test(self) -> Optional[HealthCheckSummary]:
-        raise NotImplementedError
+    def self_test(self) -> HealthCheckSummary:
+        return HealthCheckSummary(
+            {
+                MODEL_MESH_HEALTH_CHECK_PROVIDER: "wca",
+                MODEL_MESH_HEALTH_CHECK_MODELS: "skipped",
+            }
+        )

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_dummy.py
@@ -1,0 +1,54 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("wca-dummy"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    def test_completions_healthcheck(self):
+        self.assert_ok(ModelPipelineCompletions, "wca-dummy")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "nop")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "nop")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_ok(ModelPipelineRoleGeneration, "wca-dummy")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "nop")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "nop")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_onprem.py
@@ -1,0 +1,58 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_wca_client import MockResponse
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("wca-onprem"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    @mock.patch("requests.Session.post", return_value=MockResponse({"access_token": "token"}, 200))
+    def test_completions_healthcheck(self, *args, **kwargs):
+        self.assert_ok(ModelPipelineCompletions, "wca-onprem")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "wca-onprem")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "wca-onprem")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "wca-onprem")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "wca-onprem")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "wca-onprem")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_healthcheck_saas.py
@@ -1,0 +1,58 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest import mock
+
+from django.test import override_settings
+
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
+    ModelPipelineChatBot,
+    ModelPipelineCompletions,
+    ModelPipelineContentMatch,
+    ModelPipelinePlaybookExplanation,
+    ModelPipelinePlaybookGeneration,
+    ModelPipelineRoleExplanation,
+    ModelPipelineRoleGeneration,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_healthcheck import (
+    TestModelPipelineHealthCheck,
+)
+from ansible_ai_connect.ai.api.model_pipelines.tests.test_wca_client import MockResponse
+
+
+@override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("wca"))
+class TestModelPipelineFactory(TestModelPipelineHealthCheck):
+
+    @mock.patch("requests.Session.post", return_value=MockResponse({"access_token": "token"}, 200))
+    def test_completions_healthcheck(self, *args, **kwargs):
+        self.assert_ok(ModelPipelineCompletions, "wca")
+
+    def test_content_match_healthcheck(self):
+        self.assert_skipped(ModelPipelineContentMatch, "wca")
+
+    def test_playbook_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookGeneration, "wca")
+
+    def test_role_generation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleGeneration, "wca")
+
+    def test_playbook_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelinePlaybookExplanation, "wca")
+
+    def test_role_explanation_healthcheck(self):
+        self.assert_skipped(ModelPipelineRoleExplanation, "wca")
+
+    def test_chatbot_healthcheck(self):
+        self.assert_skipped(ModelPipelineChatBot, "nop")


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-41813

## Description
Ensures the response from `/check/status` correctly reflects both configuration and implementation of the `ModelPipelines`.

## Testing
See below.

### Steps to test
1. Pull down the PR
2. Run `ansible-ai-connect-service` locally
3. Check `/check/status`
4. All features should have a status reflecting both provider and status.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
