### PR TITLE
evaluate service_type value

### DIFF
--- a/ansible_ai_connect/ai/resource_api.py
+++ b/ansible_ai_connect/ai/resource_api.py
@@ -18,11 +18,19 @@ from ansible_base.resource_registry.registry import (
     SharedResource,
 )
 from ansible_base.resource_registry.shared_types import UserType
+from django.conf import settings
 from django.contrib.auth import get_user_model
 
 
-class APIConfig(ServiceAPIConfig):
+def get_service_type():
     service_type = "lightspeed"
+    if not getattr(settings, "RESOURCE_SERVER", None):
+        service_type = "aap"
+    return service_type
+
+
+class APIConfig(ServiceAPIConfig):
+    service_type = get_service_type()
 
 
 RESOURCE_LIST = [

--- a/ansible_ai_connect/ai/tests/test_resourse_api.py
+++ b/ansible_ai_connect/ai/tests/test_resourse_api.py
@@ -1,0 +1,18 @@
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+
+from ansible_ai_connect.ai.resource_api import get_service_type
+
+
+class TestResourceAPI(APITransactionTestCase):
+
+    def test_service_type_when_resource_service_not_defined(self):
+        self.assertEqual(get_service_type(), "aap")
+
+    @override_settings(RESOURCE_SERVER={})
+    def test_service_type_when_resource_service_is_empty(self):
+        self.assertEqual(get_service_type(), "aap")
+
+    @override_settings(RESOURCE_SERVER={"URL": "https://localhost"})
+    def test_service_type_when_resource_service_has_value(self):
+        self.assertEqual(get_service_type(), "lightspeed")


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-NNNN>

## Description
evaluate the service_type is the resource_server settings is defined the service_type is "lightspeed" otherwise it's "aap"

this will allow to not fail in environment that are not using the integration and using old ansible-django-base


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
