### PR TITLE
AAP-42164: roleGen: properly pass the "name" parameter

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -121,6 +121,7 @@ PlaybookGenerationResponse = tuple[str, str, list]
 @define
 class RoleGenerationParameters:
     request: Request
+    name: str | None
     text: str
     additional_context: dict
     create_outline: bool
@@ -133,6 +134,7 @@ class RoleGenerationParameters:
     def init(
         cls,
         request,
+        name: Optional[str] = None,
         text: str = "",
         create_outline: bool = False,
         file_types: list = [],
@@ -143,6 +145,7 @@ class RoleGenerationParameters:
     ):
         return cls(
             request=request,
+            name=name,
             text=text,
             file_types=file_types,
             additional_context=additional_context,

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -360,6 +360,7 @@ class WCASaaSRoleGenerationPipeline(
             raise FeatureNotAvailable
 
         request = params.request
+        name = params.name
         text = params.text
         create_outline = params.create_outline
         outline = params.outline
@@ -376,6 +377,8 @@ class WCASaaSRoleGenerationPipeline(
             "text": text,
             "create_outline": create_outline,
         }
+        if name:
+            data["name"] = name
         if outline:
             data["outline"] = outline
 

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -553,6 +553,13 @@ class GenerationPlaybookRequestSerializer(serializers.Serializer):
 
 
 class GenerationRoleRequestSerializer(serializers.Serializer):
+    name = AnonymizedCharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        label="the name of the role",
+        help_text=("You can force a specific role name for the role with this key."),
+    )
     text = AnonymizedCharField(
         required=True,
         label="the goal of the role",

--- a/ansible_ai_connect/ai/api/tests/test_role_generation_view.py
+++ b/ansible_ai_connect/ai/api/tests/test_role_generation_view.py
@@ -98,7 +98,7 @@ class TestRoleGenerationView(
         self.assertEqual(r.data["format"], "plaintext")
         self.assertEqual(r.data["generationId"], generation_id)
         self.assertEqual(r.data["outline"], "")
-        self.assertEqual(r.data["role"], "install_nginx")
+        self.assertEqual(r.data["name"], "install_nginx")
         self.assertEqual(roleGenEvent["event"], "codegenRole")
         self.assertEqual(roleGenEvent["properties"]["generationId"], str(generation_id))
 
@@ -148,12 +148,12 @@ class TestRoleGenerationView(
                 self.api_version_reverse("generations/role"), payload, format="json"
             )
             self.assertEqual(r.status_code, HTTPStatus.OK)
-            self.assertIsNotNone(r.data["role"])
+            self.assertIsNotNone(r.data["name"])
             self.assertEqual(len(r.data["files"]), 1)
             self.assertIsNotNone(r.data["outline"])
-            self.assertTrue("mysql" in r.data["role"])
+            self.assertTrue("mysql" in r.data["name"])
             self.assertTrue("mysql" in r.data["outline"])
-            self.assertFalse("admin@redhat.com" in r.data["role"])
+            self.assertFalse("admin@redhat.com" in r.data["name"])
             self.assertFalse("admin@redhat.com" in r.data["outline"])
             for file in r.data["files"]:
                 self.assertFalse("admin@redhat.com" in file["content"])

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -998,6 +998,7 @@ class GenerationRole(AACSAPIView):
         roles, files, outline, warnings = llm.invoke(
             RoleGenerationParameters.init(
                 request=request,
+                name=self.validated_data["name"],
                 text=self.validated_data["text"],
                 outline=self.validated_data["outline"],
                 model_id=self.req_model_id,
@@ -1021,7 +1022,7 @@ class GenerationRole(AACSAPIView):
         )
 
         answer = {
-            "role": anonymized_role,
+            "name": anonymized_role,
             "outline": anonymized_outline,
             "files": anonymized_files,
             "format": "plaintext",

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -1822,6 +1822,12 @@
             "GenerationRoleRequest": {
                 "type": "object",
                 "properties": {
+                    "name": {
+                        "type": "string",
+                        "default": "",
+                        "title": "the name of the role",
+                        "description": "You can force a specific role name for the role with this key."
+                    },
                     "text": {
                         "type": "string",
                         "title": "the goal of the role",

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1206,6 +1206,11 @@ components:
     GenerationRoleRequest:
       type: object
       properties:
+        name:
+          type: string
+          default: ''
+          title: the name of the role
+          description: You can force a specific role name for the role with this key.
         text:
           type: string
           title: the goal of the role


### PR DESCRIPTION
The `name` parameter was ignored. We need it if the user wants to overwrite
the default name returned by the LLM.

See: https://github.com/ansible/vscode-ansible/pull/1888
