### PR TITLE
AAP-41234: AAP Chatbot assets bundling.

### DIFF
--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -10,7 +10,8 @@
       "import": "./dist/ansible-chatbot.js",
       "require": "./dist/ansible-chatbot.umd.cjs"
     },
-    "./dist": "./dist/*"
+    "./dist": "./dist/*",
+    "./style.css": "./dist/ansible-chatbot.css"
   },
   "files": [
     "dist"

--- a/aap_chatbot/src/index.tsx
+++ b/aap_chatbot/src/index.tsx
@@ -1,30 +1,5 @@
-// import React from "react";
-//
-// import ReactDOM from "react-dom/client";
-// import "./index.css";
-// import { App } from "./App";
-// import { ColorThemeSwitch } from "./ColorThemeSwitch/ColorThemeSwitch";
-// import reportWebVitals from "./reportWebVitals";
-// import "@patternfly/react-core/dist/styles/base.css";
-// // import '@patternfly/patternfly/patternfly-addons.css';
-//
-// // Add your extension CSS below
-// import "@patternfly/chatbot/dist/css/main.css";
-// const root = ReactDOM.createRoot(
-//   document.getElementById("root") as HTMLElement,
-// );
-//
-// root.render(
-//   <React.StrictMode>
-//     <div className="pf-v6-l-flex pf-m-column pf-m-gap-lg ws-full-page-utils pf-v6-m-dir-ltr ">
-//       <ColorThemeSwitch />
-//     </div>
-//     <App />
-//   </React.StrictMode>,
-// );
-//
-// // If you want to start measuring performance in your app, pass a function
-// // to log results (for example: reportWebVitals(console.log))
-// // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-// reportWebVitals();
+import "./index.css";
+import "@patternfly/react-core/dist/styles/base.css";
+import "@patternfly/chatbot/dist/css/main.css";
+
 export { App } from "./App";

--- a/aap_chatbot/vite.config.ts
+++ b/aap_chatbot/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
       external: ["react"],
     },
   },
+  define: {
+    global: "globalThis",
+  },
   test: {
     browser: {
       name: "chromium",


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-41234>

## Description
Bundling style sheets, fonts and other static resources into a single `style.css` file. This can be now imported by the chatbot wrapper (iframe) in AAP-UI.

## Testing
Follow https://github.com/ansible/aap-ui/blob/AAP-39059-ansible-chatbot-ui/frontend/chatbot/README.md

### Scenarios tested
Tested locally.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

**After this PR is merged, I will create a new commit**, on top of our custom [AAP-UI chatbot branch](https://github.com/ansible/aap-ui/tree/AAP-39059-ansible-chatbot-ui), for using this bundle and changing the proper imports, also dropping static files folder for chatbot.