### PR TITLE
tekton/pr-deployment: always push the tag

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -277,11 +277,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      when:
-        - input: $(tasks.sast-snyk-check.results.TEST_OUTPUT)
-          operator: in
-          values:
-            - '"result":"SUCCESS"'
     - name: git-metadata
       runAfter:
       - clone-repository


### PR DESCRIPTION
The check was broken and the `apply-tags` task was never run, despite the `sast-snyk-check` success.

This pipeline is only used to build the PR images, not for production nor stage. We can safely apply the
pr-XXX label on the image, even if a problem was spotted in the image by Snyk.
