### PR TITLE
AAP-42324: Legacy configuration: Defaults are used when ANSIBLE_AI_MODEL_MESH_CONFIG is an empty string

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/config_loader.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_loader.py
@@ -37,7 +37,7 @@ def load_config_from_str(model_pipeline_config: str) -> Configuration:
     result = {}
     errors: [Exception] = []
 
-    if model_pipeline_config != "":
+    if model_pipeline_config:
         result = load_json(model_pipeline_config)
         if isinstance(result, Exception):
             errors.append(result)

--- a/ansible_ai_connect/ai/api/model_pipelines/config_loader.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/config_loader.py
@@ -28,20 +28,27 @@ logger = logging.getLogger(__name__)
 
 
 def load_config() -> Configuration:
+    return load_config_from_str(settings.ANSIBLE_AI_MODEL_MESH_CONFIG)
+
+
+def load_config_from_str(model_pipeline_config: str) -> Configuration:
     # yaml.safe_load(..) seems to also support loading JSON. Nice.
     # However, try to load JSON with the correct _loader_ first in case of corner cases
+    result = {}
     errors: [Exception] = []
-    result = load_json()
-    if isinstance(result, Exception):
-        errors.append(result)
-        result = load_yaml()
+
+    if model_pipeline_config != "":
+        result = load_json(model_pipeline_config)
         if isinstance(result, Exception):
             errors.append(result)
-        else:
-            errors = []
+            result = load_yaml(model_pipeline_config)
+            if isinstance(result, Exception):
+                errors.append(result)
+            else:
+                errors = []
 
-    if len(errors) > 0:
-        raise ExceptionGroup("Unable to parse ANSIBLE_AI_MODEL_MESH_CONFIG", errors)
+        if len(errors) > 0:
+            raise ExceptionGroup("Unable to parse ANSIBLE_AI_MODEL_MESH_CONFIG", errors)
 
     serializer = ConfigurationSerializer(data=result)
     serializer.is_valid(raise_exception=True)
@@ -49,20 +56,20 @@ def load_config() -> Configuration:
     return serializer.instance
 
 
-def load_json() -> str | Exception:
+def load_json(model_pipeline_config: str):
     try:
         logger.info("Attempting to parse ANSIBLE_AI_MODEL_MESH_CONFIG as JSON...")
-        return json.loads(settings.ANSIBLE_AI_MODEL_MESH_CONFIG)
+        return json.loads(model_pipeline_config)
     except JSONDecodeError as e:
-        logger.exception(f"An error occurring parsing ANSIBLE_AI_MODEL_MESH_CONFIG as JSON:\n{e}")
+        logger.debug(f"An error occurring parsing ANSIBLE_AI_MODEL_MESH_CONFIG as JSON:\n{e}")
         return e
 
 
-def load_yaml() -> str | Exception:
+def load_yaml(model_pipeline_config: str):
     try:
         logger.info("Attempting to parse ANSIBLE_AI_MODEL_MESH_CONFIG as YAML...")
-        y = yaml.safe_load(settings.ANSIBLE_AI_MODEL_MESH_CONFIG)
+        y = yaml.safe_load(model_pipeline_config)
         return y
     except YAMLError as e:
-        logger.exception(f"An error occurring parsing ANSIBLE_AI_MODEL_MESH_CONFIG as YAML:\n{e}")
+        logger.debug(f"An error occurring parsing ANSIBLE_AI_MODEL_MESH_CONFIG as YAML:\n{e}")
         return e

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_config_loader.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_config_loader.py
@@ -16,7 +16,6 @@ from json import JSONDecodeError
 
 import yaml
 from django.test import override_settings
-from rest_framework.exceptions import ValidationError
 from yaml import YAMLError
 
 from ansible_ai_connect.ai.api.model_pipelines.config_loader import load_config
@@ -65,8 +64,7 @@ class TestConfigLoader(WisdomTestCase):
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG="")
     def test_config_empty_string(self):
-        with self.assertRaises(ValidationError):
-            self.assert_config()
+        self.assert_config()
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG='{"MetaData" : {')
     def test_config_invalid_json(self):

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_config_loader.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_config_loader.py
@@ -55,8 +55,7 @@ class TestConfigLoader(WisdomTestCase):
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=None)
     def test_config_undefined(self):
-        with self.assertRaises(TypeError):
-            load_config()
+        self.assert_config()
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=json.dumps(EMPTY))
     def test_config_empty(self):

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
@@ -20,6 +20,7 @@ from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
 from ansible_ai_connect.ai.api.model_pipelines.nop.pipelines import (
     NopContentMatchPipeline,
+    NopMetaData,
     NopPlaybookExplanationPipeline,
     NopPlaybookGenerationPipeline,
     NopRoleExplanationPipeline,
@@ -40,8 +41,10 @@ class TestModelPipelineFactory(WisdomServiceAPITestCaseBaseOIDC):
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=None)
     def test_config_undefined(self):
-        with self.assertRaises(TypeError):
-            ModelPipelineFactory()
+        factory = ModelPipelineFactory()
+        pipeline = factory.get_pipeline(MetaData)
+        self.assertIsNotNone(pipeline)
+        self.assertIsInstance(pipeline, NopMetaData)
 
     @override_settings(ANSIBLE_AI_MODEL_MESH_CONFIG=mock_config("dummy"))
     def test_caching(self):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -574,7 +574,10 @@ ANSIBLE_AI_ENABLE_PLAYBOOK_ENDPOINT = (
 # ==========================================
 # Pipeline configuration
 # ------------------------------------------
-ANSIBLE_AI_MODEL_MESH_CONFIG = os.getenv("ANSIBLE_AI_MODEL_MESH_CONFIG") or load_from_env_vars()
+model_pipeline_config = os.getenv("ANSIBLE_AI_MODEL_MESH_CONFIG")
+ANSIBLE_AI_MODEL_MESH_CONFIG = (
+    load_from_env_vars() if model_pipeline_config is None else model_pipeline_config
+)
 # ==========================================
 
 # ==========================================

--- a/ansible_ai_connect/main/settings/tests/test_legacy.py
+++ b/ansible_ai_connect/main/settings/tests/test_legacy.py
@@ -21,6 +21,7 @@ import django.conf
 from django.test import SimpleTestCase
 
 import ansible_ai_connect.main.settings.base
+from ansible_ai_connect.ai.api.model_pipelines.config_loader import load_config_from_str
 from ansible_ai_connect.test_utils import WisdomLogAwareMixin
 
 
@@ -257,3 +258,17 @@ class TestLegacySettings(SimpleTestCase, WisdomLogAwareMixin):
         )
         self.assertEqual(config["ModelPipelineCompletions"]["config"]["model_id"], "model-id")
         self.assertEqual(config["ModelPipelineCompletions"]["config"]["timeout"], 999)
+
+    def test_empty_configuration(self):
+        config = load_config_from_str("")
+
+        # Lazy import to avoid circular dependencies
+        from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData  # noqa
+        from ansible_ai_connect.ai.api.model_pipelines.registry import (  # noqa
+            REGISTRY_ENTRY,
+        )
+
+        pipelines = [i for i in REGISTRY_ENTRY.keys() if issubclass(i, MetaData)]
+        for k in pipelines:
+            self.assertTrue(k.__name__ in config)
+            self.assertEqual(config[k.__name__].provider, "nop")


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-42324

## Description
When `ANSIBLE_AI_MODEL_MESH_CONFIG` is provided, but an empty string use it to define Model Pipeline configuration.

## Testing
Run the service with `ANSIBLE_AI_MODEL_MESH_CONFIG` set to `""`.

All features should show as disabled in `/check/status`.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
