### PR TITLE
AAP Auth issue with local setup

### DIFF
--- a/ansible_ai_connect/users/auth.py
+++ b/ansible_ai_connect/users/auth.py
@@ -69,7 +69,12 @@ class AAPOAuth2(BaseOAuth2):
     def user_has_valid_license(self, access_token):
         url = self.get_config_endpoint(settings.AAP_API_URL)
         data = self.get_json(url, headers={"Authorization": f"bearer {access_token}"})
-        return not data["license_info"]["date_expired"] if "license_info" in data else False
+        license_info = data.get("license_info")
+        if not license_info:
+            return False
+        if license_info.get("license_type", "UNLICENSED") == "open":
+            return True
+        return not license_info.get("date_expired")
 
     def get_me_endpoint(self, api_url):
         """Creates me link to the AAP API depending on the Auth platform"""


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->

This issue was found in the AAP Gateway integration work performed by @ldjebran.

In local AAP setup, Lightspeed OAuth authentication code makes a call to retrieve the license information. The received data contains license information in the following form:
```json
    "license_info": {
        "license_type": "open",
        "valid_key": true,
        "subscription_name": "OPEN",
        "product_name": "AWX"
    },
```
The current AAP Authentication code assumes that `license_info` always contains the key `date_expired` and fails
in the `user_has_valid_license()` method of the `AAPOAuth2` class.

According to [AWX source code](https://github.com/ansible/awx/blob/devel/awx/main/access.py#L355-L358), when `license_type` is `open`, we can assume that the user has a valid license. We also need to modify our logic to accept `license_info` with  `license_type` = `open` as a valid one.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit test

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests + manual test w/ local AAP setup

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
