### PR TITLE
Do not retrieve model name when user is not authenticated

### DIFF
--- a/ansible_ai_connect/ai/api/tests/test_chat_view.py
+++ b/ansible_ai_connect/ai/api/tests/test_chat_view.py
@@ -752,3 +752,16 @@ class TestStreamingChatView(APIVersionTestCaseBase, WisdomServiceAPITestCaseBase
         finally:
             if self.user2:
                 self.user2.delete()
+
+
+class TestStreamingChatViewWithAnonymousUser(APIVersionTestCaseBase, WisdomServiceAPITestCaseBase):
+    api_version = "v1"
+
+    def setUp(self):
+        super().setUp()
+
+    def test(self):
+        response = self.client.post(
+            self.api_version_reverse("streaming_chat"), TestChatView.VALID_PAYLOAD, format="json"
+        )
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-42058>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Some AI Connect Service APIs return `500` error when an anonymous user call them. They should return `401` instead.

Those `500` errors showed up in Splunk log. According to it, exceptions occur when the code tries to retrieve a model name configured. We should not attempt to retrieve a model name if the user is not authenticated.
![image](https://github.com/user-attachments/assets/e6a2deff-0087-4727-b5e9-0ff6e2c20ece)

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit test + manual test using local server

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
