### PR TITLE
AACSAPIView: don't raise exception is user is Anonymous

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -82,7 +82,7 @@ class HttpCompletionsPipeline(HttpMetaData, ModelPipelineCompletions[HttpConfigu
         request = params.request
         model_id = params.model_id
         model_input = params.model_input
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
         self._prediction_url = f"{self.config.inference_url}/predictions/{model_id}"
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -198,7 +198,7 @@ class LangchainCompletionsPipeline(
         request = params.request
         model_id = params.model_id
         model_input = params.model_input
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")
         context = model_input.get("instances", [{}])[0].get("context", "")
@@ -287,7 +287,7 @@ class LangchainPlaybookGenerationPipeline(
         )
         human_template = HUMAN_MESSAGE_TEMPLATE_WITH_OUTLINE if outline else HUMAN_MESSAGE_TEMPLATE
 
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
         llm = self.get_chat_model(model_id)
 
         chat_template = ChatPromptTemplate.from_messages(
@@ -354,7 +354,7 @@ class LangchainRoleGenerationPipeline(
         This is what the role should do: {text}
         """
 
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
         llm = self.get_chat_model(model_id)
 
         chat_template = self.create_template(SYSTEM_MESSAGE_ROLE_REQUEST, HUMAN_MESSAGE_TEMPLATE)
@@ -419,7 +419,7 @@ class LangchainPlaybookExplanationPipeline(
         if custom_prompt:
             logger.info("custom_prompt is not supported for explain_playbook and will be ignored.")
 
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
         llm = self.get_chat_model(model_id)
 
         chat_template = ChatPromptTemplate.from_messages(

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -64,7 +64,7 @@ class LlamaCppCompletionsPipeline(
         request = params.request
         model_id = params.model_id
         model_input = params.model_input
-        model_id = self.get_model_id(request.user, None, model_id)
+        model_id = self.get_model_id(request.user, model_id)
         self._prediction_url = f"{self.config.inference_url}/completion"
 
         prompt = model_input.get("instances", [{}])[0].get("prompt", "")

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -281,9 +281,7 @@ class MetaData(Generic[PIPELINE_CONFIGURATION], metaclass=ABCMeta):
     def __init__(self, config: PIPELINE_CONFIGURATION):
         self.config = config
 
-    def get_model_id(
-        self, user, organization_id: Optional[int] = None, requested_model_id: Optional[str] = None
-    ) -> str:
+    def get_model_id(self, user, requested_model_id: Optional[str] = None) -> str:
         return requested_model_id or self.config.model_id
 
     def supports_ari_postprocessing(self):

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -318,7 +318,7 @@ class WCABaseCompletionsPipeline(
 
         try:
             api_key = self.get_api_key(request.user, organization_id)
-            model_id = self.get_model_id(request.user, organization_id, model_id)
+            model_id = self.get_model_id(request.user, model_id)
             result = self.infer_from_parameters(api_key, model_id, context, prompt, suggestion_id)
 
             response = result.json()
@@ -404,7 +404,7 @@ class WCABaseContentMatchPipeline(
         suggestions = model_input.get("suggestions", "")
         organization_id = model_input.get("organization_id", None)
 
-        model_id = self.get_model_id(request.user, organization_id, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         data = {
             "model_id": model_id,
@@ -473,7 +473,7 @@ class WCABasePlaybookGenerationPipeline(
 
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         headers = self.get_request_headers(api_key, generation_id)
         data = {
@@ -567,7 +567,7 @@ class WCABasePlaybookExplanationPipeline(
 
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         headers = self.get_request_headers(api_key, explanation_id)
         data = {
@@ -630,7 +630,7 @@ class WCABaseRoleExplanationPipeline(
 
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         headers = self.get_request_headers(api_key, explanation_id)
         data = {

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_dummy.py
@@ -52,7 +52,6 @@ class WCADummyMetaData(MetaData[WCADummyConfiguration]):
     def get_model_id(
         self,
         user: User,
-        organization_id: Optional[int] = None,
         requested_model_id: Optional[str] = None,
     ) -> str:
         return requested_model_id or ""

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -85,7 +85,6 @@ class WCAOnPremMetaData(WCABaseMetaData[WCAOnPremConfiguration]):
     def get_model_id(
         self,
         user,
-        organization_id: Optional[int] = None,
         requested_model_id: Optional[str] = None,
     ) -> str:
         if requested_model_id:

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -181,13 +181,12 @@ class WCASaaSMetaData(WCABaseMetaData[WCASaaSConfiguration]):
     def get_model_id(
         self,
         user,
-        organization_id: Optional[int] = None,
         requested_model_id: Optional[str] = None,
     ) -> str:
         logger.debug(f"requested_model_id={requested_model_id}")
-        if not organization_id and user.organization:
-            # The organization_id parameter should be removed
-            organization_id = user.organization.id  # type: ignore[reportAttributeAccessIssue]
+        organization_id = (
+            hasattr(user, "organization") and user.organization and user.organization.id
+        )
         secret_manager = apps.get_app_config("ai").get_wca_secret_manager()  # type: ignore
         if (
             settings.ANSIBLE_AI_ENABLE_ONE_CLICK_TRIAL
@@ -369,7 +368,7 @@ class WCASaaSRoleGenerationPipeline(
 
         organization_id = request.user.organization.id if request.user.organization else None
         api_key = self.get_api_key(request.user, organization_id)
-        model_id = self.get_model_id(request.user, organization_id, model_id)
+        model_id = self.get_model_id(request.user, model_id)
 
         headers = self.get_request_headers(api_key, generation_id)
         data = {

--- a/ansible_ai_connect/ai/api/tests/test_completion_view.py
+++ b/ansible_ai_connect/ai/api/tests/test_completion_view.py
@@ -126,7 +126,6 @@ class MockedPipelineCompletions(ModelPipelineCompletions[MockedConfig]):
     def get_model_id(
         self,
         user: User = None,
-        organization_id: Optional[int] = None,
         requested_model_id: str = "",
     ) -> str:
         return requested_model_id or ""

--- a/ansible_ai_connect/ai/api/tests/test_views_aacsapiview.py
+++ b/ansible_ai_connect/ai/api/tests/test_views_aacsapiview.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+import unittest
+from unittest.mock import Mock
+
+from django.contrib.auth.models import AnonymousUser
+
+from ansible_ai_connect.ai.api.views import AACSAPIView
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
+
+
+class TestAACSAPIViewAnonymousUser(unittest.TestCase):
+
+    def test_get_model_name_anonymous(self):
+
+        m_request = Mock()
+        m_request.user = AnonymousUser()
+        model_name = AACSAPIView.get_model_name(m_request, None)
+        self.assertIsNone(model_name)
+
+
+class TestAACSAPIViewRegularUser(WisdomServiceAPITestCaseBaseOIDC):
+
+    def test_get_model_name(self):
+
+        m_request = Mock()
+        m_request.user = self.user
+        model_name = AACSAPIView.get_model_name(m_request, "my_req_model_id")
+        self.assertEqual(model_name, "my_req_model_id")

--- a/ansible_ai_connect/test_utils.py
+++ b/ansible_ai_connect/test_utils.py
@@ -240,6 +240,12 @@ class WisdomServiceAPITestCaseBase(APITransactionTestCase, WisdomServiceLogAware
 class WisdomServiceAPITestCaseBaseOIDC(WisdomServiceAPITestCaseBase):
     """This class should ultimately replace WisdomServiceAPITestCaseBase"""
 
+    api_version: str = "v0"
+
+    @classmethod
+    def api_version_reverse(cls, view_name, **kwargs):
+        return api_version_reverse(view_name, api_version=cls.api_version, **kwargs)
+
     def create_user(self):
         self.user = create_user_with_provider(
             username=self.username,


### PR DESCRIPTION
Handle the situation where the user is from the `AnonymousUser` class and
so, has no `organization` attribute.

Also remove the second parameter of `get_model_id()` which was superfluous considering the `user` object already provide access the organization and its ID.
