### PR TITLE
Add missing llama_stack_client dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   'langchain~=0.3.10',
   'langchain-ollama~=0.2.1',
   'launchdarkly-server-sdk~=8.3.0',
+  'llama-stack-client>=0.1.8',
   'protobuf~=5.28.2',
   'psycopg~=3.1.8',
   'PyDrive2~=1.20.0',


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Further to https://github.com/ansible/ansible-ai-connect-service/pull/1587 this PR adds `llama_stack_client` to `pyproject.toml`.

Downstream builds are failing to deploy....

## Testing
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
