### PR TITLE
Streaming Chat telemetry enhancement

### DIFF
--- a/ansible_ai_connect/ai/api/telemetry/schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema1.py
@@ -234,3 +234,4 @@ class ChatBotOperationalEvent(ChatBotBaseEvent):
 @define
 class StreamingChatBotOperationalEvent(ChatBotBaseEvent):
     event_name: str = "streamingChatOperationalEvent"
+    phase: str = "init"


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-41452>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
When chatbot is used in streaming mode, some data, which sent in the API response in non-streaming mode, are sent through streaming. For sending them to Segment/Amplitude, `StreamingChatBotOperationalEvent` will be sent three times.

The new `phase` property identifies the timing of each event:

1. `phase`=`init` -- Events sent at the receipt of API response
(Sample) Note that `conversation_id` is set to `None` here.
```
analytics.track('30d6316f-b0fb-4818-946d-f1bbbd84faf4', 'streamingChatOperationalEvent', {
    'chat_prompt': 'What is EDA?',
    'chat_referenced_documents': [],
    'chat_response': '',
    'chat_system_prompt': 'None',
    'chat_truncated': false,
    'conversation_id': 'None',
    'duration': 1150943.44,
    'exception': false,
    'groups': [],
    'hostname': 'ttakamiy-type1productconfigid.durham.csb',
    'imageTags': 'i***-t***-n***-d***',
    'modelName': 'granite3-1-8b',
    'phase': 'init',
    'plan_ids': [],
    'plans': [],
    'problem': '',
    'provider_id': 'my_rhoai_g31',
    'request': {
        'method': 'POST',
        'path': '/api/v1/ai/streaming_chat/'
    },
    'response': {
        'error_type': null,
        'status_code': 200,
        'status_text': null
    },
    'rh_user_has_seat': true,
    'rh_user_org_id': 11009103,
    'timestamp': '2025-04-02T03:20:04.774Z'
})
```

2. `phase`=`start` -- Events sent when `start` chunk is received in streaming
(Sample) `conversation_id` is set here.
```
analytics.track('unknown', 'streamingChatOperationalEvent', {
    'chat_prompt': 'What is EDA?',
    'chat_referenced_documents': [],
    'chat_response': '',
    'chat_system_prompt': 'None',
    'chat_truncated': false,
    'conversation_id': 'c51b5122-2889-463d-97df-030b63010188',
    'duration': 1151305.19,
    'exception': false,
    'groups': [],
    'hostname': 'ttakamiy-type1productconfigid.durham.csb',
    'imageTags': 'i***-t***-n***-d***',
    'modelName': 'granite3-1-8b',
    'phase': 'start',
    'plan_ids': [],
    'plans': [],
    'problem': '',
    'provider_id': 'my_rhoai_g31',
    'request': {
        'method': '',
        'path': ''
    },
    'response': {
        'error_type': '',
        'exception': '',
        'message': '',
        'status_code': 0,
        'status_text': ''
    },
    'rh_user_has_seat': false,
    'rh_user_org_id': null,
    'timestamp': '2025-04-02T03:20:05.136Z'
})
```
3. `phase`=`end` -- Events sent when `end` chunk is received in streaming
(Sample) `chat_referenced_documents` are set.
```
analytics.track('unknown', 'streamingChatOperationalEvent', {
    'chat_prompt': 'What is EDA?',
    'chat_referenced_documents': [
        {
            'docs_url': 'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/containerized_installation/index#proc-hs-eda-setup',
            'title': 'Setting up horizontal scaling for Event-Driven Ansible controller'
        },
        {
            'docs_url': 'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-user-guide-overview',
            'title': 'Event-Driven Ansible controller overview'
        },
        {
            'docs_url': 'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-activation-stuck-pending',
            'title': 'Activation stuck in Pending state'
        },
        {
            'docs_url': 'https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-logging-samples',
            'title': 'Logging samples'
        }
    ],
    'chat_response': '',
    'chat_system_prompt': 'None',
    'chat_truncated': false,
    'conversation_id': 'c51b5122-2889-463d-97df-030b63010188',
    'duration': 1154693.65,
    'exception': false,
    'groups': [],
    'hostname': 'ttakamiy-type1productconfigid.durham.csb',
    'imageTags': 'i***-t***-n***-d***',
    'modelName': 'granite3-1-8b',
    'phase': 'end',
    'plan_ids': [],
    'plans': [],
    'problem': '',
    'provider_id': 'my_rhoai_g31',
    'request': {
        'method': '',
        'path': ''
    },
    'response': {
        'error_type': '',
        'exception': '',
        'message': '',
        'status_code': 0,
        'status_text': ''
    },
    'rh_user_has_seat': false,
    'rh_user_org_id': null,
    'timestamp': '2025-04-02T03:20:08.524Z'
})
```

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit tests and manual tests with local server

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
