### PR TITLE
AAP-42978: Chatobot package is now part of the @ansible org.

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ansible-ai-connect-chatbot",
+  "name": "@ansible/ansible-ai-connect-chatbot",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ansible-ai-connect-chatbot",
+      "name": "@ansible/ansible-ai-connect-chatbot",
       "version": "0.1.0",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ansible-ai-connect-chatbot",
+  "name": "@ansible/ansible-ai-connect-chatbot",
   "type": "module",
   "version": "0.1.0",
   "main": "./dist/ansible-chatbot.umd.cjs",


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-42978>

## Description
Chatobot package is now part of the @ansible org.

First package version now published: https://www.npmjs.com/package/@ansible/ansible-ai-connect-chatbot

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
