### PR TITLE
Pass additional Django Ansible Base settings to Django

### DIFF
--- a/ansible_ai_connect/ai/resource_api.py
+++ b/ansible_ai_connect/ai/resource_api.py
@@ -24,7 +24,7 @@ from django.contrib.auth import get_user_model
 
 def get_service_type():
     service_type = "lightspeed"
-    if not getattr(settings, "RESOURCE_SERVER", None):
+    if not getattr(settings, "RESOURCE_SERVER__URL", None):
         service_type = "aap"
     return service_type
 

--- a/ansible_ai_connect/ai/tests/test_resourse_api.py
+++ b/ansible_ai_connect/ai/tests/test_resourse_api.py
@@ -9,10 +9,10 @@ class TestResourceAPI(APITransactionTestCase):
     def test_service_type_when_resource_service_not_defined(self):
         self.assertEqual(get_service_type(), "aap")
 
-    @override_settings(RESOURCE_SERVER={})
+    @override_settings(RESOURCE_SERVER__URL=None)
     def test_service_type_when_resource_service_is_empty(self):
         self.assertEqual(get_service_type(), "aap")
 
-    @override_settings(RESOURCE_SERVER={"URL": "https://localhost"})
+    @override_settings(RESOURCE_SERVER__URL="https://localhost")
     def test_service_type_when_resource_service_has_value(self):
         self.assertEqual(get_service_type(), "lightspeed")

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -285,8 +285,24 @@ REST_FRAMEWORK = {
 
 API_VERSION = "1.0.0"
 
+# ==========================================
+# Django Ansible Base configuration
+# ------------------------------------------
 ANSIBLE_BASE_ORGANIZATION_MODEL = "ansible_ai_connect.organizations.models.Organization"
 ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "ansible_ai_connect.ai.resource_api"
+
+ANSIBLE_BASE_JWT_KEY = os.getenv("ANSIBLE_BASE_JWT_KEY")
+ANSIBLE_BASE_JWT_VALIDATE_CERT = (
+    os.getenv("ANSIBLE_BASE_JWT_VALIDATE_CERT", "False").lower() == "true"
+) or False
+ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = json.loads(
+    os.getenv("ANSIBLE_BASE_MANAGED_ROLE_REGISTRY", "{}")
+)
+
+RESOURCE_SERVER__URL = os.getenv("RESOURCE_SERVER__URL")
+RESOURCE_SERVER__SECRET_KEY = os.getenv("RESOURCE_SERVER__SECRET_KEY")
+RESOURCE_SERVER__VALIDATE_HTTPS = os.getenv("RESOURCE_SERVER__VALIDATE_HTTPS")
+# ==========================================
 
 # Current RHSSOAuthentication implementation is incompatible with tech preview terms partial
 if not ANSIBLE_AI_ENABLE_TECH_PREVIEW:
@@ -587,3 +603,4 @@ ANSIBLE_AI_MODEL_MESH_CONFIG = (
 ANSIBLE_AI_ENABLE_ROLE_GEN_ENDPOINT = (
     os.getenv("ANSIBLE_AI_ENABLE_ROLE_GEN_ENDPOINT", "False").lower() == "true"
 ) or False
+# ==========================================


### PR DESCRIPTION
This PR does not need a corresponding Jira item. 

During testing of AAP *2.6* Operator authentication was failing in Lightspeed.

This was attributed to missing Django settings for DAB.