### PR TITLE
req: bump to DAB 25.3.7 and use pypi version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   'uwsgi-readiness-check~=0.2.0',
   'django-allow-cidr',
   'django-csp~=3.7',
-  'django-ansible-base[jwt-consumer,resource-registry] @ git+https://github.com/ansible/django-ansible-base@2025.1.31',
+  'django-ansible-base[jwt-consumer,resource-registry]>=2025.1.31',
 ]
 readme = "README.rst"
 license = {text = "Apache-2.0"}

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -125,7 +125,7 @@ django==4.2.20
     #   social-auth-app-django
 django-allow-cidr==0.6.0
     # via -r requirements.in
-django-ansible-base[jwt-consumer,resource-registry] @ git+https://github.com/ansible/django-ansible-base@2025.1.31
+django-ansible-base[jwt-consumer,resource-registry]==2025.3.7
     # via -r requirements.in
 django-crum==0.7.9
     # via django-ansible-base
@@ -143,8 +143,6 @@ django-oauth-toolkit==3.0.1
     # via -r requirements.in
 django-prometheus==2.2.0
     # via -r requirements.in
-django-split-settings==1.3.2
-    # via django-ansible-base
 django-test-migrations==1.3.0
     # via -r requirements.in
 djangorestframework==3.15.2
@@ -154,6 +152,8 @@ djangorestframework==3.15.2
     #   drf-spectacular
 drf-spectacular==0.27.2
     # via -r requirements.in
+dynaconf==3.2.10
+    # via django-ansible-base
 et-xmlfile==1.1.0
     # via openpyxl
 executing==2.0.1

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -125,7 +125,7 @@ django==4.2.20
     #   social-auth-app-django
 django-allow-cidr==0.6.0
     # via -r requirements.in
-django-ansible-base[jwt-consumer,resource-registry] @ git+https://github.com/ansible/django-ansible-base@2025.1.31
+django-ansible-base[jwt-consumer,resource-registry]==2025.3.7
     # via -r requirements.in
 django-crum==0.7.9
     # via django-ansible-base
@@ -143,8 +143,6 @@ django-oauth-toolkit==3.0.1
     # via -r requirements.in
 django-prometheus==2.2.0
     # via -r requirements.in
-django-split-settings==1.3.2
-    # via django-ansible-base
 django-test-migrations==1.3.0
     # via -r requirements.in
 djangorestframework==3.15.2
@@ -154,6 +152,8 @@ djangorestframework==3.15.2
     #   drf-spectacular
 drf-spectacular==0.27.2
     # via -r requirements.in
+dynaconf==3.2.10
+    # via django-ansible-base
 et-xmlfile==1.1.0
     # via openpyxl
 executing==2.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -70,4 +70,4 @@ uwsgi==2.0.22
 uwsgi-readiness-check==0.2.0
 django-allow-cidr==0.6.0
 django-csp==3.7
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@2025.1.31#egg=django-ansible-base[jwt_consumer,resource-registry]
+django-ansible-base[jwt-consumer,resource-registry]==2025.3.7


### PR DESCRIPTION
`pyproject.toml` remains with 25.1.31 by default since we don't have
breaking change forcing the upgrade yet.
