### PR TITLE
Insert textArea.click() before sending messages by enter key

### DIFF
--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -58,7 +58,8 @@ async function renderApp(debug = false, stream = false) {
 
 async function sendMessage(message: string) {
   const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
+  await textArea.fill(message);
+  await textArea.click();
   await userEvent.keyboard("{Enter}");
 }
 
@@ -342,11 +343,8 @@ beforeEach(() => {
 test("Basic chatbot interaction", async () => {
   const spy = mockAxios(200);
   const view = await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
 
-  await userEvent.keyboard("{Enter}");
-
+  await sendMessage("Hello");
   expect(spy).toHaveBeenCalledWith(
     expect.anything(),
     expect.objectContaining({
@@ -393,8 +391,7 @@ test("Basic chatbot interaction", async () => {
     .element(view.getByText("Create variables"))
     .not.toBeInTheDocument();
 
-  await textArea.fill("Tell me about Ansible.");
-  await userEvent.keyboard("{Enter}");
+  await sendMessage("Tell me about Ansible.");
   await expect
     .element(
       view.getByText(
@@ -427,10 +424,8 @@ test("ThumbsDown icon test", async () => {
   });
   mockAxios(200);
   const view = await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
 
-  await userEvent.keyboard("{Enter}");
+  await sendMessage("Hello");
   await expect
     .element(
       view.getByText(
@@ -473,11 +468,8 @@ test("Too many reference documents for the GU issue creation query param.", asyn
   }
   mockAxios(200, false, false, lotsOfRefDocs);
   const view = await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
 
-  await userEvent.keyboard("{Enter}");
-
+  await sendMessage("Hello");
   await expect
     .element(
       page.getByText(
@@ -511,10 +503,8 @@ test("Too many reference documents for the GU issue creation query param.", asyn
 test("Chat service returns 500", async () => {
   mockAxios(500);
   const view = await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
 
-  await userEvent.keyboard("{Enter}");
+  await sendMessage("Hello");
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
   expect(textContent).toEqual("Bot returned status_code 500");
@@ -523,10 +513,8 @@ test("Chat service returns 500", async () => {
 test("Chat service returns a timeout error", async () => {
   mockAxios(-1, true, true);
   await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
-  await userEvent.keyboard("{Enter}");
 
+  await sendMessage("Hello");
   await expect
     .element(
       page.getByText(
@@ -541,9 +529,8 @@ test("Chat service returns a timeout error", async () => {
 test("Chat service returns 429 Too Many Requests error", async () => {
   mockAxios(429, true);
   await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
-  await userEvent.keyboard("{Enter}");
+
+  await sendMessage("Hello");
 
   // Insert an artificial 3s delay, which is inserted in useChatbot.ts.
   await delay(3000);
@@ -561,10 +548,8 @@ test("Chat service returns 429 Too Many Requests error", async () => {
 test("Chat service returns an unexpected error", async () => {
   mockAxios(-1, true);
   const view = await renderApp();
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
-  await userEvent.keyboard("{Enter}");
 
+  await sendMessage("Hello");
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
   expect(textContent).toEqual(
@@ -681,10 +666,7 @@ test("Test system prompt override", async () => {
   const systemPromptButton = page.getByLabelText("system-prompt-form-button");
   await systemPromptButton.click();
 
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello with system prompt override");
-
-  await userEvent.keyboard("{Enter}");
+  await sendMessage("Hello with system prompt override");
   expect(spy).toHaveBeenCalledWith(
     expect.anything(),
     expect.objectContaining({
@@ -702,13 +684,9 @@ test("Chat streaming test", async () => {
     ghIssueLinkSpy++;
   });
   mockAxios(200, false, false, referencedDocumentExample, true);
-
   const view = await renderApp(false, true);
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("Hello");
 
-  await userEvent.keyboard("{Enter}");
-
+  await sendMessage("Hello");
   await expect
     .element(
       view.getByText(
@@ -737,10 +715,8 @@ test("Agent chat streaming test", async () => {
   mockAxios(200, false, false, referencedDocumentExample, true);
 
   const view = await renderApp(false, true);
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("agent test");
 
-  await userEvent.keyboard("{Enter}");
+  await sendMessage("agent test");
 
   await expect.element(view.getByText("Turn complete")).toBeVisible();
 
@@ -767,13 +743,9 @@ test("Agent chat streaming test", async () => {
 
 test("Chat streaming error at API call", async () => {
   mockAxios(200, false, false, referencedDocumentExample, true);
-
   const view = await renderApp(false, true);
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("status=400");
 
-  await userEvent.keyboard("{Enter}");
-
+  await sendMessage("status=400");
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
   expect(textContent).toEqual("Bot returned status_code 400");
@@ -781,13 +753,9 @@ test("Chat streaming error at API call", async () => {
 
 test("Chat streaming error in streaming data", async () => {
   mockAxios(200, false, false, referencedDocumentExample, true);
-
   const view = await renderApp(false, true);
-  const textArea = page.getByLabelText("Send a message...");
-  await textArea.fill("error in stream");
 
-  await userEvent.keyboard("{Enter}");
-
+  await sendMessage("error in stream");
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
   expect(textContent).toEqual(


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Insert `await textArea.click()` before calling `await userEvent.keyboard("{Enter}")` to send a message to chatbot service in unit tests. Occasionally, `userEvent.keyboard("{Enter}")` seems to fail to send a message. By insterting `await textArea.click()`, we can make sure the focus is on the `textArea`.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
This is a test PR.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
