### PR TITLE
Fixes service_type name

### DIFF
--- a/ansible_ai_connect/ai/resource_api.py
+++ b/ansible_ai_connect/ai/resource_api.py
@@ -24,7 +24,9 @@ from django.contrib.auth import get_user_model
 
 def get_service_type():
     service_type = "lightspeed"
-    if not getattr(settings, "RESOURCE_SERVER__URL", None):
+    if not getattr(settings, "RESOURCE_SERVER__URL", None) and not getattr(
+        settings, "RESOURCE_SERVER", None
+    ):
         service_type = "aap"
     return service_type
 

--- a/ansible_ai_connect/ai/tests/test_resourse_api.py
+++ b/ansible_ai_connect/ai/tests/test_resourse_api.py
@@ -10,9 +10,17 @@ class TestResourceAPI(APITransactionTestCase):
         self.assertEqual(get_service_type(), "aap")
 
     @override_settings(RESOURCE_SERVER__URL=None)
+    def test_service_type_when_resource_service_url_is_empty(self):
+        self.assertEqual(get_service_type(), "aap")
+
+    @override_settings(RESOURCE_SERVER=None)
     def test_service_type_when_resource_service_is_empty(self):
         self.assertEqual(get_service_type(), "aap")
 
     @override_settings(RESOURCE_SERVER__URL="https://localhost")
+    def test_service_type_when_resource_service_url_has_value(self):
+        self.assertEqual(get_service_type(), "lightspeed")
+
+    @override_settings(RESOURCE_SERVER=dict(URL="https://localhost"))
     def test_service_type_when_resource_service_has_value(self):
         self.assertEqual(get_service_type(), "lightspeed")


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAP-43542 

## Description
in local development for integration we use tools that use templates with RESOURCE_SERVICE as a dictionary, that is causing the local dev integration not working.


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. run make lightspeed_up 
2. request /v1/service-index/meta-data
3. 

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
