### PR TITLE
AAP-43986: AAP Gateway Operator: Fix Lightspeed service_index_path

### DIFF
--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -292,6 +292,20 @@ API_VERSION = "1.0.0"
 # ------------------------------------------
 ANSIBLE_BASE_ORGANIZATION_MODEL = "ansible_ai_connect.organizations.models.Organization"
 ANSIBLE_BASE_RESOURCE_CONFIG_MODULE = "ansible_ai_connect.ai.resource_api"
+ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES = (
+    "page",
+    "page_size",
+    "format",
+    "order",
+    "order_by",
+    "search",
+    "type",
+    "host_filter",
+    "count_disabled",
+    "no_truncate",
+    "limit",
+    "validate",
+)
 
 ANSIBLE_BASE_JWT_KEY = os.getenv("ANSIBLE_BASE_JWT_KEY")
 ANSIBLE_BASE_JWT_VALIDATE_CERT = (


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-43986

## Description
Lightspeed service shows:
```
ERROR 2025-04-14 16:14:57,851 log.py:log_response Internal Server Error: /api/v1/service-index/resources/
Traceback (most recent call last):
  File "/var/www/venv/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
...
  File "/var/www/venv/lib64/python3.11/site-packages/ansible_base/rest_filters/rest_framework/field_lookup_backend.py", line 170, in filter_queryset
    if key in self.reserved_names(view):
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/venv/lib64/python3.11/site-packages/ansible_base/rest_filters/rest_framework/field_lookup_backend.py", line 148, in reserved_names
    reserved_set = set(settings.ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/venv/lib64/python3.11/site-packages/django/conf/__init__.py", line 104, in __getattr__
    val = getattr(_wrapped, name)
          ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Settings' object has no attribute 'ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES'
```
This PR ensures the `ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES` setting is set.

The value is copied from `ansible_base/lib/dynamic_config/settings_logic.py` [here](https://github.com/ansible/django-ansible-base/blob/devel/ansible_base/lib/dynamic_config/settings_logic.py#L94-L108).

## Testing
Deploy an instance of Lightspeed using the AAP Operator 2.6, from the `fast-2.6` channel.

Towards the end of the reconcile loop the above exception is noticed.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
