### PR TITLE
AAP-42800: trial: give better 403 errors

### DIFF
--- a/ansible_ai_connect/users/tests/test_views.py
+++ b/ansible_ai_connect/users/tests/test_views.py
@@ -237,12 +237,14 @@ class TestTrial(WisdomAppsBackendMocking, APITransactionTestCase):
     def test_no_aap_subscription__no_trial_for_you(self):
         r = self.client.get(reverse("trial"))
         self.assertEqual(r.status_code, 403)
+        self.assertIn("an active Ansible Automation Platform subscription.", str(r.content))
 
     @override_settings(WCA_SECRET_DUMMY_SECRETS="1234567:valid")
     def test_wca_ready_org__no_trial_for_you(self):
         self.assertEqual(self.user.organization.id, 1234567)
         r = self.client.get(reverse("trial"))
         self.assertEqual(r.status_code, 403)
+        self.assertIn("Trial because an api_key was set.", str(r.content))
 
     def test_redirect_when_admin(self):
         self.user.rh_user_is_org_admin = True

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -185,10 +185,16 @@ class TrialView(TemplateView):
             return HttpResponseForbidden()
 
         if not self.request.user.rh_org_has_subscription:
-            return HttpResponseForbidden()
+            return HttpResponseForbidden(
+                "Your organization doesn't have an active "
+                "Ansible Automation Platform subscription."
+            )
 
         if request.user.organization.has_api_key:
-            return HttpResponseForbidden()
+            return HttpResponseForbidden(
+                "You and the user of your organization cannot "
+                "use the Trial because an api_key was set."
+            )
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Return better 403 errors to help the user to understand why the Trial
was refused.

![image](https://github.com/user-attachments/assets/a39a2f63-f61f-4128-8bae-cabbfca43c4d)
