### PR TITLE
Chat copy button is not working in streaming mode

### DIFF
--- a/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -28,7 +28,11 @@ import {
   ChatbotToggle,
   Conversation,
 } from "@patternfly/chatbot";
-import { CHAT_HISTORY_HEADER, FOOTNOTE_LABEL } from "../Constants";
+import {
+  CHAT_HISTORY_HEADER,
+  FOOTNOTE_LABEL,
+  REFERENCED_DOCUMENTS_CAPTION,
+} from "../Constants";
 import { SystemPromptModal } from "../SystemPromptModal/SystemPromptModal";
 
 const footnoteProps: ChatbotFootnoteProps = {
@@ -252,7 +256,7 @@ export const AnsibleChatbot: React.FunctionComponent<ChatbotContext> = (
                               <Message key={`m_msg_${index}`} {...message} />
                               <ReferencedDocuments
                                 key={`m_docs_${index}`}
-                                caption="Refer to the following for more information:"
+                                caption={REFERENCED_DOCUMENTS_CAPTION}
                                 referenced_documents={referenced_documents}
                               />
                             </ExpandableSection>
@@ -262,7 +266,7 @@ export const AnsibleChatbot: React.FunctionComponent<ChatbotContext> = (
                             <Message key={`m_msg_${index}`} {...message} />
                             <ReferencedDocuments
                               key={`m_docs_${index}`}
-                              caption="Refer to the following for more information:"
+                              caption={REFERENCED_DOCUMENTS_CAPTION}
                               referenced_documents={referenced_documents}
                             />
                           </div>

--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -8,7 +8,7 @@ import React from "react";
 // vitest-browser-react documentation
 /* eslint-disable testing-library/prefer-screen-queries */
 
-import { beforeEach, expect, test, vi } from "vitest";
+import { assert, beforeEach, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { MemoryRouter } from "react-router-dom";
 import { screen } from "@testing-library/react";
@@ -367,11 +367,14 @@ test("Basic chatbot interaction", async () => {
     name: "Copy",
   });
   await copyIcon.click();
-  expect(
+  assert(
     copiedString.startsWith(
       "In Ansible, the precedence of variables is determined by the order...",
     ),
   );
+  assert(copiedString.includes("Refer to the following for more information:"));
+  assert(copiedString.includes("Create variables"));
+  assert(copiedString.includes("https://"));
 
   await page.getByLabelText("Toggle menu").click();
   const newChatButton = page
@@ -694,6 +697,15 @@ test("Chat streaming test", async () => {
       ),
     )
     .toBeVisible();
+
+  const copyIcon = await screen.findByRole("button", {
+    name: "Copy",
+  });
+  await copyIcon.click();
+  assert(copiedString.startsWith("The Full Support Phase for AAP 2.4"));
+  assert(copiedString.includes("Refer to the following for more information:"));
+  assert(copiedString.includes("Ansible Components Versions"));
+  assert(copiedString.includes("https://"));
 
   const thumbsDownIcon = await screen.findByRole("button", {
     name: "Bad response",

--- a/aap_chatbot/src/Constants.ts
+++ b/aap_chatbot/src/Constants.ts
@@ -56,6 +56,9 @@ Here are some basic facts about Ansible and AAP:
 
 export const CHAT_HISTORY_HEADER = "Chat History";
 
+export const REFERENCED_DOCUMENTS_CAPTION =
+  "Refer to the following for more information:";
+
 export const INITIAL_NOTICE: AlertMessage = {
   title: "Important",
   message:

--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -20,6 +20,7 @@ import {
   GITHUB_NEW_ISSUE_BASE_URL,
   INITIAL_NOTICE,
   QUERY_SYSTEM_INSTRUCTION,
+  REFERENCED_DOCUMENTS_CAPTION,
   Sentiment,
   TIMEOUT_MSG,
   TOO_MANY_REQUESTS_MSG,
@@ -310,26 +311,15 @@ export const useChatbot = () => {
       copy: {
         onClick: () => {
           if (message.actions) {
-            message.actions.copy.className = "action-button-clicked";
-            const ref_docs =
-              typeof response === "object"
-                ? response.referenced_documents?.slice(0, 5)
-                : response;
-            if (ref_docs) {
-              const llmResponse = [
-                typeof response === "object" ? response.response : response,
-                ",\n",
-                typeof response === "object"
-                  ? response.referenced_documents
-                      ?.slice(0, 5)
-                      .map((doc) => doc.docs_url)
-                      .join(",\n")
-                  : response,
-              ];
-              setClipboard(
-                llmResponse?.map((llmResponse) => llmResponse).join(""),
+            const contents = [message.content];
+            if (message.referenced_documents.length > 0) {
+              contents.push(`\n${REFERENCED_DOCUMENTS_CAPTION}`);
+              const ref_docs = message.referenced_documents.map(
+                (doc) => `- [${doc.title}](${doc.docs_url})`,
               );
+              contents.push(...ref_docs);
             }
+            setClipboard(contents.join("\n"));
           }
         },
       },

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -57,6 +57,7 @@ import {
   FOOTNOTE_DESCRIPTION,
   FOOTNOTE_LABEL,
   FOOTNOTE_TITLE,
+  REFERENCED_DOCUMENTS_CAPTION,
 } from "../Constants";
 import { SystemPromptModal } from "../SystemPromptModal/SystemPromptModal";
 
@@ -366,7 +367,7 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                               <Message key={`m_msg_${index}`} {...message} />
                               <ReferencedDocuments
                                 key={`m_docs_${index}`}
-                                caption="Refer to the following for more information:"
+                                caption={REFERENCED_DOCUMENTS_CAPTION}
                                 referenced_documents={referenced_documents}
                               />
                             </ExpandableSection>
@@ -376,7 +377,7 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                             <Message key={`m_msg_${index}`} {...message} />
                             <ReferencedDocuments
                               key={`m_docs_${index}`}
-                              caption="Refer to the following for more information:"
+                              caption={REFERENCED_DOCUMENTS_CAPTION}
                               referenced_documents={referenced_documents}
                             />
                           </div>

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -8,7 +8,7 @@ import React from "react";
 // vitest-browser-react documentation
 /* eslint-disable testing-library/prefer-screen-queries */
 
-import { beforeEach, expect, test, vi } from "vitest";
+import { assert, beforeEach, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { MemoryRouter } from "react-router-dom";
 import { screen } from "@testing-library/react";
@@ -317,11 +317,14 @@ test("Basic chatbot interaction", async () => {
     name: "Copy",
   });
   await copyIcon.click();
-  expect(
+  assert(
     copiedString.startsWith(
       "In Ansible, the precedence of variables is determined by the order...",
     ),
   );
+  assert(copiedString.includes("Refer to the following for more information:"));
+  assert(copiedString.includes("Create variables"));
+  assert(copiedString.includes("https://"));
 
   await page.getByLabelText("Toggle menu").click();
   const newChatButton = page
@@ -675,6 +678,15 @@ test("Chat streaming test", async () => {
       ),
     )
     .toBeVisible();
+
+  const copyIcon = await screen.findByRole("button", {
+    name: "Copy",
+  });
+  await copyIcon.click();
+  assert(copiedString.startsWith("The Full Support Phase for AAP 2.4"));
+  assert(copiedString.includes("Refer to the following for more information:"));
+  assert(copiedString.includes("Ansible Components Versions"));
+  assert(copiedString.includes("https://"));
 
   const thumbsDownIcon = await screen.findByRole("button", {
     name: "Bad response",

--- a/ansible_ai_connect_chatbot/src/Constants.ts
+++ b/ansible_ai_connect_chatbot/src/Constants.ts
@@ -52,6 +52,9 @@ Here are some basic facts about Ansible and AAP:
 
 export const CHAT_HISTORY_HEADER = "Chat History";
 
+export const REFERENCED_DOCUMENTS_CAPTION =
+  "Refer to the following for more information:";
+
 export const INITIAL_NOTICE: AlertMessage = {
   title: "Important",
   message: `The Red Hat Ansible Automation Platform Lightspeed service provides

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -19,6 +19,7 @@ import {
   GITHUB_NEW_ISSUE_BASE_URL,
   INITIAL_NOTICE,
   QUERY_SYSTEM_INSTRUCTION,
+  REFERENCED_DOCUMENTS_CAPTION,
   Sentiment,
   TIMEOUT_MSG,
   TOO_MANY_REQUESTS_MSG,
@@ -275,26 +276,15 @@ export const useChatbot = () => {
       copy: {
         onClick: () => {
           if (message.actions) {
-            message.actions.copy.className = "action-button-clicked";
-            const ref_docs =
-              typeof response === "object"
-                ? response.referenced_documents?.slice(0, 5)
-                : response;
-            if (ref_docs) {
-              const llmResponse = [
-                typeof response === "object" ? response.response : response,
-                ",\n",
-                typeof response === "object"
-                  ? response.referenced_documents
-                      ?.slice(0, 5)
-                      .map((doc) => doc.docs_url)
-                      .join(",\n")
-                  : response,
-              ];
-              setClipboard(
-                llmResponse?.map((llmResponse) => llmResponse).join(""),
+            const contents = [message.content];
+            if (message.referenced_documents.length > 0) {
+              contents.push(`\n${REFERENCED_DOCUMENTS_CAPTION}`);
+              const ref_docs = message.referenced_documents.map(
+                (doc) => `- [${doc.title}](${doc.docs_url})`,
               );
+              contents.push(...ref_docs);
             }
+            setClipboard(contents.join("\n"));
           }
         },
       },


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-44267>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
The copy icon on the Chatbot UI was not working when the chatbot was running in the streaming mode because the code was expecting that response text was included in the API response while the response text is sent through a stream in the streaming mode.

This PR also contains a change in the logic to copy referenced documents. In the existing code, only document URLs were copied. With this PR, both title and URL are copied in the markdown format.

Another small change in PR is the removal of  "action-button-clicked", which was introduced for ThumbsUp/Down icons what are not clicked more than once. Since the copy icon may be clicked more than once, it should not be applied to it.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

Unit tests + manual tests with local servers both in AAP-integration and standalone environments.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
