### PR TITLE
Feedback Github issue contains zero UUID

### DIFF
--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -422,7 +422,9 @@ test("Basic chatbot interaction", async () => {
 
 test("ThumbsDown icon test", async () => {
   let ghIssueLinkSpy = 0;
-  vi.stubGlobal("open", () => {
+  let ghIssueUrl = "";
+  vi.stubGlobal("open", (url: string) => {
+    ghIssueUrl = url;
     ghIssueLinkSpy++;
   });
   mockAxios(200);
@@ -449,6 +451,9 @@ test("ThumbsDown icon test", async () => {
   await sureButton.click();
 
   expect(ghIssueLinkSpy).toEqual(1);
+  expect(ghIssueUrl).toContain(
+    "conversation_id=123e4567-e89b-12d3-a456-426614174000",
+  );
 });
 
 const REF_DOCUMENT_EXAMPLE_REGEXP = new RegExp(
@@ -683,7 +688,9 @@ test("Test system prompt override", async () => {
 
 test("Chat streaming test", async () => {
   let ghIssueLinkSpy = 0;
-  vi.stubGlobal("open", () => {
+  let ghIssueUrl = "";
+  vi.stubGlobal("open", (url: string) => {
+    ghIssueUrl = url;
     ghIssueLinkSpy++;
   });
   mockAxios(200, false, false, referencedDocumentExample, true);
@@ -717,6 +724,9 @@ test("Chat streaming test", async () => {
   await sureButton.click();
 
   expect(ghIssueLinkSpy).toEqual(1);
+  expect(ghIssueUrl).toContain(
+    "conversation_id=1ec5ba5b-c12d-465b-a722-0b95fee55e8c",
+  );
 });
 
 test("Agent chat streaming test", async () => {

--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -75,7 +75,10 @@ export const fixedMessage = (content: string): MessageProps => ({
   timestamp: getTimestamp(),
 });
 
-export const feedbackMessage = (f: ChatFeedback): MessageProps => ({
+export const feedbackMessage = (
+  f: ChatFeedback,
+  conversation_id: string,
+): MessageProps => ({
   role: "bot",
   content:
     f.sentiment === Sentiment.THUMBS_UP
@@ -94,7 +97,9 @@ export const feedbackMessage = (f: ChatFeedback): MessageProps => ({
             content: "Sure!",
             id: "response",
             onClick: () =>
-              window.open(createGitHubIssueURL(f), "_blank")?.focus(),
+              window
+                .open(createGitHubIssueURL(f, conversation_id), "_blank")
+                ?.focus(),
           },
         ],
 });
@@ -105,13 +110,16 @@ export const tooManyRequestsMessage = (): MessageProps =>
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
-const createGitHubIssueURL = (f: ChatFeedback): string => {
+const createGitHubIssueURL = (
+  f: ChatFeedback,
+  conversation_id: string,
+): string => {
   const searchParams: URLSearchParams = new URLSearchParams();
   searchParams.append("assignees", "korenaren");
   searchParams.append("labels", "bug,triage");
   searchParams.append("projects", "");
   searchParams.append("template", "chatbot_feedback.yml");
-  searchParams.append("conversation_id", f.response.conversation_id);
+  searchParams.append("conversation_id", conversation_id);
   searchParams.append("prompt", f.query);
   searchParams.append("response", f.response.response);
   // Referenced documents may increase as more source documents being ingested,
@@ -140,6 +148,20 @@ export const useChatbot = () => {
   const [conversationId, setConversationId] = useState<
     string | null | undefined
   >(undefined);
+
+  // Workaround for the lag issue of the conversation_id state value.
+  const getConversationId = () => {
+    let id;
+    setConversationId((value) => {
+      id = value;
+      return value;
+    });
+    if (!id) {
+      id = "00000000-0000-0000-0000-000000000000";
+    }
+    return id;
+  };
+
   const [selectedModel, setSelectedModel] = useState("granite3-1-8b");
   const [systemPrompt, setSystemPrompt] = useState(QUERY_SYSTEM_INSTRUCTION);
   const [hasStopButton, setHasStopButton] = useState<boolean>(false);
@@ -266,9 +288,7 @@ export const useChatbot = () => {
     ) => {
       if (typeof response === "string") {
         const resp = {
-          conversation_id: conversationId
-            ? conversationId
-            : "00000000-0000-0000-0000-000000000000",
+          conversation_id: getConversationId(),
           response: content,
           referenced_documents,
           truncated: false,
@@ -347,7 +367,7 @@ export const useChatbot = () => {
       if (resp.status === 200) {
         const newBotMessage = {
           referenced_documents: [],
-          ...feedbackMessage(feedbackRequest),
+          ...feedbackMessage(feedbackRequest, getConversationId()),
         };
         addMessage(newBotMessage, feedbackRequest.message);
       } else {


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-44465>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
When a user clicks the thumbs up/down feedback icons after the chatbot provides a response, they are redirected to GitHub with a pre-populated feedback form. One of the fields, Conversation ID, is expected to be populated with a unique UUID identifying the specific chat session. However, the field is currently being populated with a default all-zero UUID, which prevents proper identification and traceability of the feedback.

This occurs in streaming mode only. Previously, the code assumed a conversation id is included in the API response. It is no longer true in streaming mode. In streaming mode, a conversation id is sent in a stream and stored in a React state.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit test + manual tests using local server (both standalone and AAP-UI integration environments)

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
