### PR TITLE
Do not apply "round" CSS on a square avatar image

### DIFF
--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -363,6 +363,30 @@ test("Basic chatbot interaction", async () => {
     .toBeVisible();
   await expect.element(view.getByText("Create variables")).toBeVisible();
 
+  // Verify avatar CSS class
+  let foundUserAvatar = false;
+  let foundBotAvatar = false;
+  for (const section of document.getElementsByTagName("section")) {
+    const aria_label = section.getAttribute("aria-label");
+    if (aria_label?.startsWith("Message from user")) {
+      const avatar = section.getElementsByTagName("img")[0];
+      assert(avatar);
+      const cls = avatar.getAttribute("class");
+      assert(cls);
+      assert(cls.includes("pf-chatbot__message-avatar--round "));
+      foundUserAvatar = true;
+    } else if (aria_label?.startsWith("Message from bot")) {
+      const avatar = section.getElementsByTagName("img")[0];
+      assert(avatar);
+      const cls = avatar.getAttribute("class");
+      assert(cls);
+      assert(!cls.includes("pf-chatbot__message-avatar--round "));
+      foundBotAvatar = true;
+    }
+  }
+  assert(foundUserAvatar);
+  assert(foundBotAvatar);
+
   const copyIcon = await screen.findByRole("button", {
     name: "Copy",
   });

--- a/aap_chatbot/src/useChatbot/useChatbot.test.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.test.ts
@@ -4,6 +4,8 @@ import type { MessageProps } from "@patternfly/chatbot/dist/dynamic/Message";
 import { Sentiment } from "../Constants";
 import type { ChatFeedback } from "../types/Message";
 
+const CONVERSATION_ID = "123e4567-e89b-12d3-a456-426614174000";
+
 describe("feedbackMessage", () => {
   it("should return a message with a thank you note for positive feedback", () => {
     const feedback: ChatFeedback = {
@@ -24,7 +26,7 @@ describe("feedbackMessage", () => {
         referenced_documents: [],
       },
     };
-    const message: MessageProps = feedbackMessage(feedback);
+    const message: MessageProps = feedbackMessage(feedback, CONVERSATION_ID);
 
     expect(message.role).toBe("bot");
     expect(message.content).toBe("Thank you for your feedback!");
@@ -50,7 +52,7 @@ describe("feedbackMessage", () => {
         referenced_documents: [],
       },
     };
-    const message: MessageProps = feedbackMessage(feedback);
+    const message: MessageProps = feedbackMessage(feedback, CONVERSATION_ID);
 
     expect(message.role).toBe("bot");
     expect(message.content).toMatch(

--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -278,6 +278,7 @@ export const useChatbot = () => {
       content: typeof response === "object" ? response.response : response,
       name: botName,
       avatar: logo,
+      hasRoundAvatar: false,
       timestamp: getTimestamp(),
       referenced_documents: [],
     };

--- a/aap_chatbot/vite.config.ts
+++ b/aap_chatbot/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       exclude: [
         ...configDefaults.exclude,
         "**/*.d.ts",
+        "**/*.test.ts",
         "**/*.test.tsx",
         "src/index.tsx",
         "src/reportWebVitals.ts",

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -311,6 +311,30 @@ test("Basic chatbot interaction", async () => {
     .toBeVisible();
   await expect.element(view.getByText("Create variables")).toBeVisible();
 
+  // Verify avatar CSS class
+  let foundUserAvatar = false;
+  let foundBotAvatar = false;
+  for (const section of document.getElementsByTagName("section")) {
+    const aria_label = section.getAttribute("aria-label");
+    if (aria_label?.startsWith("Message from user")) {
+      const avatar = section.getElementsByTagName("img")[0];
+      assert(avatar);
+      const cls = avatar.getAttribute("class");
+      assert(cls);
+      assert(cls.includes("pf-chatbot__message-avatar--round "));
+      foundUserAvatar = true;
+    } else if (aria_label?.startsWith("Message from bot")) {
+      const avatar = section.getElementsByTagName("img")[0];
+      assert(avatar);
+      const cls = avatar.getAttribute("class");
+      assert(cls);
+      assert(!cls.includes("pf-chatbot__message-avatar--round "));
+      foundBotAvatar = true;
+    }
+  }
+  assert(foundUserAvatar);
+  assert(foundBotAvatar);
+
   const copyIcon = await screen.findByRole("button", {
     name: "Copy",
   });

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -243,6 +243,7 @@ export const useChatbot = () => {
       content: typeof response === "object" ? response.response : response,
       name: botName,
       avatar: logo,
+      hasRoundAvatar: false,
       timestamp: getTimestamp(),
       referenced_documents: [],
     };

--- a/ansible_ai_connect_chatbot/vite.config.ts
+++ b/ansible_ai_connect_chatbot/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       exclude: [
         ...configDefaults.exclude,
         "**/*.d.ts",
+        "**/*.test.ts",
         "**/*.test.tsx",
         "src/index.tsx",
         "src/reportWebVitals.ts",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-44433>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Do not apply "--round" CSS for lightspeed avatar icon.

This PR also includes small changes for `useChatbot.test.ts`.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run unit test

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Unit test + manual test (standalone lightspeed server)
![image](https://github.com/user-attachments/assets/ed04c90c-7842-4738-9f85-3a53d68d2dde)


## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
