### PR TITLE
AAP-44422: Chatbot history not cleared across logout/login as different user.

### DIFF
--- a/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -42,7 +42,12 @@ const footnoteProps: ChatbotFootnoteProps = {
 const conversationList: { [key: string]: Conversation[] } = {};
 conversationList[CHAT_HISTORY_HEADER] = [];
 
-const conversationStore: Map<string, ExtendedMessage[]> = new Map();
+export const conversationStore: Map<string, ExtendedMessage[]> = new Map();
+
+const resetConversationState = () => {
+  conversationList[CHAT_HISTORY_HEADER] = [];
+  conversationStore.clear();
+};
 
 const findMatchingItems = (targetValue: string) => {
   let filteredConversations = Object.entries(conversationList).reduce(
@@ -119,6 +124,17 @@ export const AnsibleChatbot: React.FunctionComponent<ChatbotContext> = (
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
+
+  useEffect(
+    () =>
+      // Fired on component mount (componentDidMount)
+      () => {
+        // Anything in here is fired on component unmount (componentWillUnmount)
+        resetConversationState();
+      },
+    [],
+  );
+
   useEffect(() => {
     scrollToBottom();
   }, [messages]);

--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -18,6 +18,7 @@ import { userEvent, page } from "@vitest/browser/context";
 import axios, { AxiosError, AxiosHeaders } from "axios";
 // See: https://github.com/vitest-dev/vitest/issues/6965
 import "@vitest/browser/matchers.d.ts";
+import { conversationStore } from "./AnsibleChatbot/AnsibleChatbot";
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -840,4 +841,11 @@ test("Chat service returns 429 Too Many Requests error in streaming", async () =
       { timeout: 15000 },
     )
     .toBeVisible();
+});
+
+test("Test reset conversation state once unmounting the component.", async () => {
+  const view = await renderApp();
+  conversationStore.set("1", []);
+  view.unmount();
+  assert(conversationStore.size === 0);
 });

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -84,7 +84,12 @@ const footnoteProps: ChatbotFootnoteProps = {
 const conversationList: { [key: string]: Conversation[] } = {};
 conversationList[CHAT_HISTORY_HEADER] = [];
 
-const conversationStore: Map<string, ExtendedMessage[]> = new Map();
+export const conversationStore: Map<string, ExtendedMessage[]> = new Map();
+
+const resetConversationState = () => {
+  conversationList[CHAT_HISTORY_HEADER] = [];
+  conversationStore.clear();
+};
 
 const findMatchingItems = (targetValue: string) => {
   let filteredConversations = Object.entries(conversationList).reduce(
@@ -156,6 +161,17 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
+
+  useEffect(
+    () =>
+      // Fired on component mount (componentDidMount)
+      () => {
+        // Anything in here is fired on component unmount (componentWillUnmount)
+        resetConversationState();
+      },
+    [],
+  );
+
   useEffect(() => {
     scrollToBottom();
   }, [messages]);

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -18,6 +18,7 @@ import { userEvent, page } from "@vitest/browser/context";
 import axios, { AxiosError, AxiosHeaders } from "axios";
 // See: https://github.com/vitest-dev/vitest/issues/6965
 import "@vitest/browser/matchers.d.ts";
+import { conversationStore } from "./AnsibleChatbot/AnsibleChatbot";
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -785,4 +786,11 @@ test("Chat service returns 429 Too Many Requests error in streaming", async () =
       { timeout: 15000 },
     )
     .toBeVisible();
+});
+
+test("Test reset conversation state once unmounting the component.", async () => {
+  const view = await renderApp();
+  conversationStore.set("1", []);
+  view.unmount();
+  assert(conversationStore.size === 0);
 });


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-44422>

## Description
The goal is to clean the conversation state once un-mounting the component, which will happen on AAP-UI once either closing panel, logging out or refreshing the page.

Initially I tried to move the `conversationList` and `conversationStore` into the `AnsibleChatbot` as managed state, but I got into weird issues, so just decided to create a function to clean those objects once un-mounting the component.  Works properly. Test added.

## Testing
Tested both `ansible_ai_connect_chatbot` and `aap_chatbot` apps, by using a local chatbot service. 

### Scenarios tested
Tested also the AAP-UI integration, conversations are cleared after logging out.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
