### PR TITLE
Update port # for grafana in compose

### DIFF
--- a/tools/docker-compose/compose-prom-grafana.yaml
+++ b/tools/docker-compose/compose-prom-grafana.yaml
@@ -18,7 +18,7 @@ services:
     environment:
       - GF_LOG_LEVEL=warn
     ports:
-      - "13000:3000"
+      - "13100:3000"
     volumes:
       - $PWD/grafana:/var/lib/grafana
     networks:

--- a/tools/docker-compose/compose.yaml
+++ b/tools/docker-compose/compose.yaml
@@ -119,7 +119,7 @@ services:
     environment:
       - GF_LOG_LEVEL=warn
     ports:
-      - "13000:3000"
+      - "13100:3000"
     volumes:
       - $PWD/grafana:/var/lib/grafana:Z
     networks:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
After https://github.com/ansible/aap-gateway/pull/761, starting lightspeed in aap-dev environment by issuing `make lightspeed-up` in the `/aap-dev` directory of `aap-gateway` repo started failing due to the conflict of port # `13000`, which is used in lightspeed (docker|podman)-compose files for `grafana`.

I think almost no one is using `grafana` in when lightspeed is started using a compose file, let us change the port # from `13000` to `13100` to resolve the conflict.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
Run lightspeed in AAP integrated and standalone environments and make sure it starts up.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Manual tests only.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
