### PR TITLE
AAP-45044: Chatbot: Add new status check endpoint

### DIFF
--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -179,23 +179,21 @@ export const useChatbot = () => {
     const checkStatus = async () => {
       const csrfToken = readCookie("csrftoken");
       try {
-        const resp = await axios.get("/api/lightspeed/v1/health/status/", {
-          headers: {
-            "Content-Type": "application/json",
-            "X-CSRFToken": csrfToken,
+        const resp = await axios.get(
+          "/api/lightspeed/v1/health/status/chatbot/",
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRFToken": csrfToken,
+            },
           },
-        });
+        );
         if (resp.status === 200) {
-          const dependencies = resp.data?.dependencies;
-          if (dependencies) {
-            for (const d of dependencies) {
-              if (d.name === "streaming-chatbot-service") {
-                if (d.status !== "disabled") {
-                  // If streaming is enabled on the service side, use it.
-                  setStream(true);
-                  break;
-                }
-              }
+          const data = resp.data || {};
+          if ("streaming-chatbot-service" in data) {
+            if (data["streaming-chatbot-service"] === "ok") {
+              // If streaming is enabled on the service side, use it.
+              setStream(true);
             }
           }
         }

--- a/ansible_ai_connect/ai/api/model_pipelines/factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/factory.py
@@ -22,8 +22,8 @@ from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
 )
 from ansible_ai_connect.ai.api.model_pipelines.config_providers import Configuration
 from ansible_ai_connect.ai.api.model_pipelines.nop.pipelines import NopMetaData
-from ansible_ai_connect.ai.api.model_pipelines.pipelines import PIPELINE_TYPE
 from ansible_ai_connect.ai.api.model_pipelines.registry import REGISTRY, REGISTRY_ENTRY
+from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 
 logger = logging.getLogger(__name__)
 

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -14,7 +14,7 @@
 
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, Optional
 
 from attrs import define
 from django.conf import settings
@@ -25,13 +25,13 @@ from rest_framework.response import Response
 from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
     PIPELINE_CONFIGURATION,
 )
+from ansible_ai_connect.ai.api.model_pipelines.types import (
+    PIPELINE_PARAMETERS,
+    PIPELINE_RETURN,
+)
 from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 
 logger = logging.getLogger(__name__)
-
-PIPELINE_PARAMETERS = TypeVar("PIPELINE_PARAMETERS")
-PIPELINE_RETURN = TypeVar("PIPELINE_RETURN")
-PIPELINE_TYPE = TypeVar("PIPELINE_TYPE")
 
 
 @define

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_factory.py
@@ -19,8 +19,9 @@ from django.test import override_settings
 from ansible_ai_connect.ai.api.exceptions import FeatureNotAvailable
 from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
 from ansible_ai_connect.ai.api.model_pipelines.nop.pipelines import NopMetaData
-from ansible_ai_connect.ai.api.model_pipelines.pipelines import PIPELINE_TYPE, MetaData
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData
 from ansible_ai_connect.ai.api.model_pipelines.tests import mock_config
+from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_healthcheck.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_healthcheck.py
@@ -15,10 +15,8 @@
 from typing import Type
 
 from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
-from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
-    PIPELINE_TYPE,
-    ModelPipeline,
-)
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import ModelPipeline
+from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 from ansible_ai_connect.healthcheck.backends import HealthCheckSummary
 from ansible_ai_connect.main.settings.types import t_model_mesh_api_type
 from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBaseOIDC

--- a/ansible_ai_connect/ai/api/model_pipelines/types.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/types.py
@@ -1,0 +1,18 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import TypeVar
+
+PIPELINE_PARAMETERS = TypeVar("PIPELINE_PARAMETERS")
+PIPELINE_RETURN = TypeVar("PIPELINE_RETURN")
+PIPELINE_TYPE = TypeVar("PIPELINE_TYPE")

--- a/ansible_ai_connect/ai/api/versions/v1/tests/test_health.py
+++ b/ansible_ai_connect/ai/api/versions/v1/tests/test_health.py
@@ -11,18 +11,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import json
 from http import HTTPStatus
 from unittest import mock
 
 from django.apps import apps
 from django.core.cache import cache
+from requests.exceptions import HTTPError
 
 from ansible_ai_connect.ai.api.model_pipelines.dummy.pipelines import (
     DummyCompletionsPipeline,
 )
+from ansible_ai_connect.ai.api.model_pipelines.http.pipelines import HttpChatBotPipeline
 from ansible_ai_connect.ai.api.model_pipelines.tests import mock_pipeline_config
 from ansible_ai_connect.ai.api.versions.v1.test_base import API_VERSION
+from ansible_ai_connect.healthcheck.tests.test_healthcheck import BaseTestHealthCheck
 from ansible_ai_connect.main.tests.test_views import (
     APITransactionTestCase,
     APIVersionTestCaseBase,
@@ -54,3 +57,72 @@ class TestHealthAnonymousUser(APIVersionTestCaseBase, APITransactionTestCase):
             self.assertEqual(data.get("status"), "ok")
             self.assertTrue("dependencies" in data)
             self.assertTrue(len(data["dependencies"]) > 0)
+
+
+class TestHealthChatbotView(APIVersionTestCaseBase, APITransactionTestCase):
+    api_version = API_VERSION
+
+    @mock.patch(
+        "requests.get",
+        side_effect=lambda *args, **kwargs: BaseTestHealthCheck.mocked_requests_succeed(
+            content=b'{ "ready": true, "reason": "service is ready" }'
+        ),
+    )
+    def test_health_check_chatbot_service(self, mock_get):
+        cache.clear()
+        with mock.patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            mock.Mock(
+                return_value=HttpChatBotPipeline(
+                    mock_pipeline_config("http", enable_health_check=True)
+                )
+            ),
+        ):
+            r = self.client.get(self.api_version_reverse("health_status_chatbot"))
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            data = json.loads(r.content)
+            self.assertEqual(data["chatbot-service"], "ok")
+            self.assertEqual(data["streaming-chatbot-service"], "ok")
+
+    @mock.patch(
+        "requests.get",
+        side_effect=HTTPError,
+    )
+    def test_health_check_chatbot_service_error(self, mock_get):
+        cache.clear()
+        with mock.patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            mock.Mock(
+                return_value=HttpChatBotPipeline(
+                    mock_pipeline_config("http", enable_health_check=True)
+                )
+            ),
+        ):
+            r = self.client.get(self.api_version_reverse("health_status_chatbot"))
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            data = json.loads(r.content)
+            self.assertEqual(data["chatbot-service"], "unavailable: An error occurred")
+            self.assertEqual(data["streaming-chatbot-service"], "unavailable: An error occurred")
+
+    @mock.patch(
+        "requests.get",
+        side_effect=BaseTestHealthCheck.mocked_requests_succeed,
+    )
+    def test_health_check_chatbot_service_disabled(self, mock_get):
+        cache.clear()
+        with mock.patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            mock.Mock(
+                return_value=HttpChatBotPipeline(
+                    mock_pipeline_config("http", enable_health_check=False)
+                )
+            ),
+        ):
+            r = self.client.get(self.api_version_reverse("health_status_chatbot"))
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            data = json.loads(r.content)
+            self.assertEqual(data["chatbot-service"], "disabled")
+            self.assertEqual(data["streaming-chatbot-service"], "disabled")

--- a/ansible_ai_connect/ai/api/versions/v1/urls.py
+++ b/ansible_ai_connect/ai/api/versions/v1/urls.py
@@ -15,6 +15,7 @@
 from django.urls import include, path
 
 from ansible_ai_connect.healthcheck.views import (
+    WisdomServiceHealthChatbotView,
     WisdomServiceHealthView,
     WisdomServiceLivenessProbeView,
 )
@@ -31,4 +32,9 @@ urlpatterns = [
     path("wca/", include(wca_urls)),
     path("health/", WisdomServiceLivenessProbeView.as_view(), name="health"),
     path("health/status/", WisdomServiceHealthView.as_view(), name="health_status"),
+    path(
+        "health/status/chatbot/",
+        WisdomServiceHealthChatbotView.as_view(),
+        name="health_status_chatbot",
+    ),
 ]

--- a/ansible_ai_connect/ai/apps.py
+++ b/ansible_ai_connect/ai/apps.py
@@ -20,7 +20,8 @@ from django.apps import AppConfig
 from django.conf import settings
 
 from ansible_ai_connect.ai.api.model_pipelines.factory import ModelPipelineFactory
-from ansible_ai_connect.ai.api.model_pipelines.pipelines import PIPELINE_TYPE, MetaData
+from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData
+from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 from ansible_ai_connect.ansible_lint import lintpostprocessing
 from ansible_ai_connect.ari import postprocessing
 from ansible_ai_connect.users.authz_checker import AMSCheck, CIAMCheck, DummyCheck

--- a/ansible_ai_connect/healthcheck/backends.py
+++ b/ansible_ai_connect/healthcheck/backends.py
@@ -19,9 +19,7 @@ from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import HealthCheckException, ServiceUnavailable
 
 from ansible_ai_connect.ai.api.aws.wca_secret_manager import Suffixes
-from ansible_ai_connect.ai.api.model_pipelines.config_pipelines import (
-    PIPELINE_CONFIGURATION,
-)
+from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 
 ERROR_MESSAGE = "An error occurred"
 MODEL_MESH_HEALTH_CHECK_MODELS = "models"
@@ -118,11 +116,9 @@ class ModelPipelineHealthCheck(BaseLightspeedHealthCheck):
     # status code even if the check errors.
     critical_service = True
 
-    def __init__(self, pipeline_type: Type[PIPELINE_CONFIGURATION]):
+    def __init__(self, pipeline_type: Type[PIPELINE_TYPE]):
         super().__init__()
-        pipeline_config: PIPELINE_CONFIGURATION = apps.get_app_config("ai").get_model_pipeline(
-            pipeline_type
-        )
+        pipeline_config: PIPELINE_TYPE = apps.get_app_config("ai").get_model_pipeline(pipeline_type)
         self.pipeline_type = pipeline_type
         self.enabled = pipeline_config.config.enable_health_check
 

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -702,6 +702,27 @@
                 }
             }
         },
+        "/api/v1/health/status/chatbot/": {
+            "get": {
+                "operationId": "health_status_chatbot_retrieve",
+                "description": "Chatbot health check",
+                "summary": "Chatbot health check",
+                "tags": [
+                    "health"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/v1/me/": {
             "get": {
                 "operationId": "me_retrieve",

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -442,6 +442,19 @@ paths:
           description: ''
         '500':
           description: One or more backend services are unavailable.
+  /api/v1/health/status/chatbot/:
+    get:
+      operationId: health_status_chatbot_retrieve
+      description: Chatbot health check
+      summary: Chatbot health check
+      tags:
+      - health
+      security:
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          description: OK
   /api/v1/me/:
     get:
       operationId: me_retrieve


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-45044

## Description
This PR adds a dedicated endpoint to check the Chatbot status/health.

The existing code uses the `/health/status` endpoint that returns the status of *all* components.

If one of these is mis-configured the endpoint returns HTTP500 and the Chatbot UI code assumes it is unavailable.

## Testing

### Testing the service
1. Run `ansible-ai-connect-service` locally
2. Check the `api/v1/health/status/chatbot` endpoint.

Example response:
```
HTTP/1.1 200 OK
Content-Type: application/json

{
  "chatbot-service": "disabled",
  "streaming-chatbot-service": "ok"
}
```

### Testing AAP UI
1. `cd aap-ui`
2. `npm ci`
3. You will need to change `frontend/chatbot/ChatbotState.tsx`:
```
...
const LIGHTSPEED_HEALTH_STATUS_PATH = `/api/lightspeed/v1/health/status/chatbot/`;
  ...
  const setChatbotEnablementState = useCallback(async () => {
    try {
      const lightspeedStatusResponse = await get(LIGHTSPEED_HEALTH_STATUS_PATH, {});
      const state: string = lightspeedStatusResponse['chatbot-service'];
      if (state === 'disabled') {
        setChatbotState(ChatbotStateEnum.Disabled);
      } else if (state === 'ok') {
        setChatbotState(ChatbotStateEnum.Closed);
      } else {
        setChatbotState(ChatbotStateEnum.Disabled);
      }
    } catch (e) {
      setChatbotState(ChatbotStateEnum.Disabled);
    }
  }, [get, setChatbotState]);
  ...
```
4. You will need to change `frontend/chatbot/interfaces/LightspeedStatus.tsx`:
```
export interface LightspeedStatusResponse {
  'chatbot-service': string;
  'streaming-chatbot-service': string;
}
```
5. `export PLATFORM=<See JIRA for the URL>`
6. `cd ./platform`
7. `npm run start`
8. Login as `manstis` (See JIRA for password)

The above AAP instance uses the Lightspeed service container built by this PR.

A PR to `aap-ui` is in progress.. but I don't have access to create a PR yet.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
