### PR TITLE
remove the deprecated CIAMCheck class from the authz_check

### DIFF
--- a/ansible_ai_connect/ai/apps.py
+++ b/ansible_ai_connect/ai/apps.py
@@ -24,7 +24,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import MetaData
 from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 from ansible_ai_connect.ansible_lint import lintpostprocessing
 from ansible_ai_connect.ari import postprocessing
-from ansible_ai_connect.users.authz_checker import AMSCheck, CIAMCheck, DummyCheck
+from ansible_ai_connect.users.authz_checker import AMSCheck, DummyCheck
 from ansible_ai_connect.users.reports.postman import (
     BasePostman,
     GoogleDrivePostman,
@@ -88,7 +88,6 @@ class AiConfig(AppConfig):
     def get_seat_checker(self):
         backends = {
             "ams": AMSCheck,
-            "ciam": CIAMCheck,
             "dummy": DummyCheck,
         }
         if not settings.AUTHZ_BACKEND_TYPE:

--- a/ansible_ai_connect/users/authz_checker.py
+++ b/ansible_ai_connect/users/authz_checker.py
@@ -202,21 +202,6 @@ class Token:
         return self.access_token
 
 
-class CIAMCheck(BaseCheck):  # TODO: To be removed
-    def __init__(self, client_id, client_secret, sso_server, api_server):
-        self._session = requests.Session()
-        self._token = Token(client_id, client_secret, sso_server)
-        self._api_server = api_server
-
-    def self_test(self):
-        self._session.headers.update({"Authorization": f"Bearer {self._token.get()}"})
-        r = self._session.post(
-            self._api_server + "/v1alpha/healthcheck",
-            timeout=0.8,
-        )
-        r.raise_for_status()
-
-
 # NOTE: we should probably rename the class to reflect it's current purpose
 class AMSCheck(BaseCheck):
     # An AMS Organization ID that should never match anything

--- a/ansible_ai_connect/users/tests/test_authz_checker.py
+++ b/ansible_ai_connect/users/tests/test_authz_checker.py
@@ -27,7 +27,6 @@ from requests.exceptions import HTTPError
 from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 from ansible_ai_connect.users.authz_checker import (
     AMSCheck,
-    CIAMCheck,
     DummyCheck,
     Token,
     authz_ams_get_metrics_hist,
@@ -149,31 +148,6 @@ class TestToken(WisdomServiceLogAwareTestCase):
         exc.response = response
         b = fatal_exception(exc)
         self.assertTrue(b)
-
-    def test_ciam_self_test_success(self):
-        m_r = Mock()
-        m_r.status_code = 200
-
-        checker = CIAMCheck("foo", "bar", "https://sso.redhat.com", "https://some-api.server.host")
-        checker._token = Mock()
-        checker._session = Mock()
-        checker._session.post.return_value = m_r
-        try:
-            checker.self_test()
-        except HTTPError:
-            self.fail("self_test() should not have raised an exception.")
-
-    def test_ciam_self_test_failure(self):
-        r = requests.models.Response()
-        r.status_code = 500
-
-        checker = CIAMCheck("foo", "bar", "https://sso.redhat.com", "https://some-api.server.host")
-        checker._token = Mock()
-        checker._session = Mock()
-        checker._session.post.return_value = r
-
-        with self.assertRaises(HTTPError):
-            checker.self_test()
 
     @assert_call_count_metrics(metric=authz_ams_org_cache_hit_counter)
     @assert_call_count_metrics(metric=authz_ams_get_organization_hist)


### PR DESCRIPTION
We've never used it in production and the CIAM team doesn't support it anymore.

See: AAP-20347
