### PR TITLE
requirements: bump Django to 4.2.21

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -108,7 +108,7 @@ diff-match-patch==20230430
     # via django-import-export
 distro==1.9.0
     # via llama-stack-client
-django==4.2.20
+django==4.2.21
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -108,7 +108,7 @@ diff-match-patch==20230430
     # via django-import-export
 distro==1.9.0
     # via llama-stack-client
-django==4.2.20
+django==4.2.21
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ black==24.3.0
 certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 cryptography==43.0.1
 daphne==4.1.2
-Django==4.2.20
+Django==4.2.21
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
This to address a regression caused by the CVE-2025-26699 fix and CVE-2025-32873.

See: https://docs.djangoproject.com/en/5.2/releases/4.2.21/