### PR TITLE
Referenced Documents support on llama-stack agentic RAG chatbot

### DIFF
--- a/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/aap_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -269,7 +269,10 @@ export const AnsibleChatbot: React.FunctionComponent<ChatbotContext> = (
                         )}
                         {collapse ? (
                           <div key={`m_div_${index}`}>
-                            <ExpandableSection toggleText="Show more">
+                            <ExpandableSection
+                              toggleTextCollapsed="Show more"
+                              toggleTextExpanded="Show less"
+                            >
                               <Message
                                 key={`m_msg_${index}`}
                                 {...message}

--- a/aap_chatbot/src/App.test.tsx
+++ b/aap_chatbot/src/App.test.tsx
@@ -784,6 +784,7 @@ test("Agent chat streaming test", async () => {
     .not.toBeVisible();
   const showMoreLink = await screen.findByRole("button", { name: "Show more" });
   await showMoreLink.click();
+  await expect.element(view.getByText("Show less")).toBeVisible();
   await expect
     .element(view.getByText("EDA stands for Event Driven Ansible."))
     .toBeVisible();

--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -363,7 +363,10 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                         )}
                         {collapse ? (
                           <div key={`m_div_${index}`}>
-                            <ExpandableSection toggleText="Show more">
+                            <ExpandableSection
+                              toggleTextCollapsed="Show more"
+                              toggleTextExpanded="Show less"
+                            >
                               <Message
                                 key={`m_msg_${index}`}
                                 {...message}

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -783,6 +783,7 @@ test("Agent chat streaming test", async () => {
     .not.toBeVisible();
   const showMoreLink = await screen.findByRole("button", { name: "Show more" });
   await showMoreLink.click();
+  await expect.element(view.getByText("Show less")).toBeVisible();
   await expect
     .element(view.getByText("EDA stands for Event Driven Ansible."))
     .toBeVisible();


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-45771>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Referenced Documents support on llama-stack agentic RAG chatbot. 

https://github.com/user-attachments/assets/15367185-639f-45c7-b730-0fb2344402ab




## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Modify the following line of `ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py` so that UI recognizes the streaming chatbot is available:
```
    def self_test(self) -> HealthCheckSummary:
        return HealthCheckSummary(
            {
                MODEL_MESH_HEALTH_CHECK_PROVIDER: "llama-stack",
                MODEL_MESH_HEALTH_CHECK_MODELS: "ok", # "skipped", <== THIS LINE
            }
        )
```
3. Run MCP server, llama-stack, Lightspeed server dependencies (postgres) and Lightspeed server
4. Open chatbot and send some queries.  See the video attached above for sample queries.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Manual test and unit test (for UI change)

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
