### PR TITLE
Adds X-Request-LightspeedUser to all WCA requests

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/tests/test_wca_client.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/test_wca_client.py
@@ -58,6 +58,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
 from ansible_ai_connect.ai.api.model_pipelines.tests import mock_pipeline_config
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     WCA_REQUEST_ID_HEADER,
+    WCA_REQUEST_USER_UUID_HEADER,
     ibm_cloud_identity_token_hist,
     ibm_cloud_identity_token_retry_counter,
     wca_codegen_hist,
@@ -826,6 +827,7 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
     ):
         model_id = "zavala"
         api_key = "abc123"
+        user_uuid = str(uuid.uuid4())
         context = ""
         prompt = prompt if prompt else "- name: install ffmpeg on Red Hat Enterprise Linux"
 
@@ -854,13 +856,14 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         response = MockResponse(
             json=predictions,
             status_code=200,
-            headers={WCA_REQUEST_ID_HEADER: request_id},
+            headers={WCA_REQUEST_ID_HEADER: request_id, WCA_REQUEST_USER_UUID_HEADER: user_uuid},
         )
 
         requestHeaders = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {token['access_token']}",
             WCA_REQUEST_ID_HEADER: suggestion_id,
+            WCA_REQUEST_USER_UUID_HEADER: user_uuid,
         }
 
         model_client = WCASaaSCompletionsPipeline(self.config)
@@ -869,9 +872,13 @@ class TestWCACodegen(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCase):
         model_client.get_model_id = Mock(return_value=model_id)
         model_client.get_api_key = Mock(return_value=api_key)
 
+        mock_request = Mock()
+        mock_request.user = Mock()
+        mock_request.user.uuid = user_uuid
+
         result = model_client.invoke(
             CompletionsParameters.init(
-                request=Mock(),
+                request=mock_request,
                 model_input=model_input,
                 model_id=model_id,
                 suggestion_id=suggestion_id,
@@ -1465,6 +1472,7 @@ class TestWCAClientOnPrem(WisdomAppsBackendMocking, WisdomServiceLogAwareTestCas
 class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
     prompt = "- name: install ffmpeg on Red Hat Enterprise Linux"
     suggestion_id = "suggestion_id"
+    user_uuid = str(uuid.uuid4())
     token = base64.b64encode(bytes("username:12345", "ascii")).decode("ascii")
     codegen_data = {
         "model_id": "model-name",
@@ -1473,6 +1481,7 @@ class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
     request_headers = {
         "Authorization": f"ZenApiKey {token}",
         WCA_REQUEST_ID_HEADER: suggestion_id,
+        WCA_REQUEST_USER_UUID_HEADER: user_uuid,
     }
     model_input = {
         "instances": [
@@ -1499,9 +1508,13 @@ class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
         self.model_client.session.post = Mock(return_value=MockResponse(json={}, status_code=200))
 
     def test_headers(self):
+        mock_request = Mock()
+        mock_request.user = Mock()
+        mock_request.user.uuid = self.user_uuid
+
         self.model_client.invoke(
             CompletionsParameters.init(
-                request=Mock(), model_input=self.model_input, suggestion_id=self.suggestion_id
+                request=mock_request, model_input=self.model_input, suggestion_id=self.suggestion_id
             ),
         )
         self.model_client.session.post.assert_called_once_with(
@@ -1513,10 +1526,13 @@ class TestWCAOnPremCodegen(WisdomServiceLogAwareTestCase):
         )
 
     def test_disabled_model_server_ssl(self):
+        mock_request = Mock()
+        mock_request.user = Mock()
+        mock_request.user.uuid = self.user_uuid
         self.config.verify_ssl = False
         self.model_client.invoke(
             CompletionsParameters.init(
-                request=Mock(), model_input=self.model_input, suggestion_id=self.suggestion_id
+                request=mock_request, model_input=self.model_input, suggestion_id=self.suggestion_id
             ),
         )
         self.model_client.session.post.assert_called_once_with(

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -81,6 +81,8 @@ MODEL_MESH_HEALTH_CHECK_TOKENS = "tokens"
 
 WCA_REQUEST_ID_HEADER = "X-Request-ID"
 
+WCA_REQUEST_USER_UUID_HEADER = "X-Request-LightspeedUser"
+
 # from django_prometheus.middleware.DEFAULT_LATENCY_BUCKETS
 DEFAULT_LATENCY_BUCKETS = (
     0.01,
@@ -243,6 +245,20 @@ class WCABasePipeline(
     def __init__(self, config: WCA_PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    def _prepare_request_headers(
+        self, request_user: Optional[User], api_key: str, identifier: Optional[str]
+    ) -> dict[str, Optional[str]]:
+        """
+        Helper method to extract user UUID and get request headers.
+        """
+        lightspeed_user_uuid_str: Optional[str] = None
+        if request_user and hasattr(request_user, "uuid"):
+            lightspeed_user_uuid_str = str(request_user.uuid)
+
+        return self.get_request_headers(
+            api_key, identifier, lightspeed_user_uuid=lightspeed_user_uuid_str
+        )
+
     @staticmethod
     def log_backoff_exception(details):
         _, exc, _ = sys.exc_info()
@@ -284,7 +300,7 @@ class WCABasePipeline(
 
     @abstractmethod
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         raise NotImplementedError
 
@@ -318,7 +334,12 @@ class WCABaseCompletionsPipeline(
         try:
             api_key = self.get_api_key(request.user)
             model_id = self.get_model_id(request.user, model_id)
-            result = self.infer_from_parameters(api_key, model_id, context, prompt, suggestion_id)
+
+            headers = self._prepare_request_headers(request.user, api_key, suggestion_id)
+
+            result = self.infer_from_parameters(
+                api_key, model_id, context, prompt, suggestion_id, headers
+            )
 
             response = result.json()
             response["model_id"] = model_id
@@ -328,14 +349,15 @@ class WCABaseCompletionsPipeline(
         except requests.exceptions.Timeout:
             raise ModelTimeoutError(model_id=model_id)
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(
+        self, api_key, model_id, context, prompt, suggestion_id=None, headers=None
+    ):
         data = {
             "model_id": model_id,
             "prompt": f"{context}{prompt}",
         }
         logger.debug(f"Inference API request payload: {json.dumps(data)}")
 
-        headers = self.get_request_headers(api_key, suggestion_id)
         task_count = len(get_task_names_from_prompt(prompt))
         prediction_url = f"{self.config.inference_url}/v1/wca/codegen/ansible"
 
@@ -471,7 +493,8 @@ class WCABasePlaybookGenerationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, generation_id)
+        headers = self._prepare_request_headers(request.user, api_key, generation_id)
+
         data = {
             "model_id": model_id,
             "text": text,
@@ -553,7 +576,8 @@ class WCABaseRoleGenerationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, generation_id)
+        headers = self._prepare_request_headers(request.user, api_key, generation_id)
+
         data = {
             "model_id": model_id,
             "text": text,
@@ -632,7 +656,8 @@ class WCABasePlaybookExplanationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, explanation_id)
+        headers = self._prepare_request_headers(request.user, api_key, explanation_id)
+
         data = {
             "model_id": model_id,
             "playbook": content,
@@ -694,7 +719,8 @@ class WCABaseRoleExplanationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, explanation_id)
+        headers = self._prepare_request_headers(request.user, api_key, explanation_id)
+
         data = {
             "role_name": params.role_name,
             "model_id": model_id,

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -47,6 +47,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_onprem import (
 )
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     WCA_REQUEST_ID_HEADER,
+    WCA_REQUEST_USER_UUID_HEADER,
     WCABaseCompletionsPipeline,
     WCABaseContentMatchPipeline,
     WCABaseMetaData,
@@ -114,12 +115,13 @@ class WCAOnPremPipeline(
         # User may provide an override value if the setting is not defined.
 
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
             WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
+            WCA_REQUEST_USER_UUID_HEADER: lightspeed_user_uuid if lightspeed_user_uuid else None,
         }
 
     def _get_base_headers(self, api_key: str) -> dict[str, str]:

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -57,6 +57,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_saas import (
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     MODEL_MESH_HEALTH_CHECK_TOKENS,
     WCA_REQUEST_ID_HEADER,
+    WCA_REQUEST_USER_UUID_HEADER,
     WCABaseCompletionsPipeline,
     WCABaseContentMatchPipeline,
     WCABaseMetaData,
@@ -229,12 +230,13 @@ class WCASaaSPipeline(
         super().__init__(config=config)
 
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
             WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
+            WCA_REQUEST_USER_UUID_HEADER: lightspeed_user_uuid if lightspeed_user_uuid else None,
         }
 
     def _get_base_headers(self, api_key: str) -> dict[str, str]:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-46219

## Description
Updates the WCA Pipelines to include a new X-Request-LightspeedUser header which contains the requesting users uuid.  This is an iteration of https://github.com/ansible/ansible-ai-connect-service/pull/1662.

## Testing
Updated unit tests in this repo to account for new header

### Scenarios tested
Examine WCA requests and expect to see new header

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
