### PR TITLE
Update Django to fix CVE

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -108,7 +108,7 @@ diff-match-patch==20230430
     # via django-import-export
 distro==1.9.0
     # via llama-stack-client
-django==4.2.21
+django==4.2.22
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -108,7 +108,7 @@ diff-match-patch==20230430
     # via django-import-export
 distro==1.9.0
     # via llama-stack-client
-django==4.2.21
+django==4.2.22
     # via
     #   -r requirements.in
     #   django-allow-cidr

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ black==24.3.0
 certifi@git+https://github.com/ansible/system-certifi@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
 cryptography==43.0.1
 daphne==4.1.2
-Django==4.2.21
+Django==4.2.22
 django-deprecate-fields==0.1.1
 django-extensions==3.2.1
 django-health-check==3.17.0


### PR DESCRIPTION
Jira Issue: None
<!-- This PR does not need a corresponding Jira item. -->

## Description
Fixes: --- | --- | --- | --- | ---
django | 4.2.21 | PYSEC-2025-47 | 4.2.22,5.1.10,5.2.2 | An issue was discovered in Django 5.2 before 5.2.2, 5.1 before 5.1.10, and 4.2 before 4.2.22. Internal HTTP response logging does not escape request.path, which allows remote attackers to potentially manipulate log output via crafted URLs. This may lead to log injection or forgery when logs are viewed in terminals or processed by external systems.


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Green build

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
