### PR TITLE
Adds X-Request-LightspeedUser to all WCA requests (again)

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/dummy/pipelines.py
@@ -83,7 +83,7 @@ class DummyCompletionsPipeline(DummyMetaData, ModelPipelineCompletions[DummyConf
         response_body["model_id"] = "_"
         return response_body
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -122,7 +122,7 @@ class HttpCompletionsPipeline(HttpMetaData, ModelPipelineCompletions[HttpConfigu
             )
         return summary
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -233,7 +233,7 @@ class LangchainCompletionsPipeline(
     def get_chat_model(self, model_id):
         raise NotImplementedError
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -126,7 +126,7 @@ class LlamaCppCompletionsPipeline(
         except requests.exceptions.Timeout:
             raise ModelTimeoutError
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/nop/pipelines.py
@@ -64,7 +64,7 @@ class NopCompletionsPipeline(NopMetaData, ModelPipelineCompletions[NopConfigurat
     def invoke(self, params: CompletionsParameters) -> CompletionsResponse:
         raise FeatureNotAvailable
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -53,7 +53,7 @@ class OllamaCompletionsPipeline(LangchainCompletionsPipeline[OllamaConfiguration
     def __init__(self, config: OllamaConfiguration):
         super().__init__(config=config)
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> HealthCheckSummary:

--- a/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/pipelines.py
@@ -335,7 +335,7 @@ class ModelPipelineCompletions(
         return "model-server"
 
     @abstractmethod
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -81,6 +81,8 @@ MODEL_MESH_HEALTH_CHECK_TOKENS = "tokens"
 
 WCA_REQUEST_ID_HEADER = "X-Request-ID"
 
+WCA_REQUEST_USER_UUID_HEADER = "X-Request-LightspeedUser"
+
 # from django_prometheus.middleware.DEFAULT_LATENCY_BUCKETS
 DEFAULT_LATENCY_BUCKETS = (
     0.01,
@@ -243,6 +245,20 @@ class WCABasePipeline(
     def __init__(self, config: WCA_PIPELINE_CONFIGURATION):
         super().__init__(config=config)
 
+    def _prepare_request_headers(
+        self, request_user: Optional[User], api_key: str, identifier: Optional[str]
+    ) -> dict[str, Optional[str]]:
+        """
+        Helper method to extract user UUID and get request headers.
+        """
+        lightspeed_user_uuid_str: Optional[str] = None
+        if request_user and hasattr(request_user, "uuid"):
+            lightspeed_user_uuid_str = str(request_user.uuid)
+
+        return self.get_request_headers(
+            api_key, identifier, lightspeed_user_uuid=lightspeed_user_uuid_str
+        )
+
     @staticmethod
     def log_backoff_exception(details):
         _, exc, _ = sys.exc_info()
@@ -284,7 +300,7 @@ class WCABasePipeline(
 
     @abstractmethod
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         raise NotImplementedError
 
@@ -318,7 +334,10 @@ class WCABaseCompletionsPipeline(
         try:
             api_key = self.get_api_key(request.user)
             model_id = self.get_model_id(request.user, model_id)
-            result = self.infer_from_parameters(api_key, model_id, context, prompt, suggestion_id)
+
+            headers = self._prepare_request_headers(request.user, api_key, suggestion_id)
+
+            result = self.infer_from_parameters(model_id, context, prompt, suggestion_id, headers)
 
             response = result.json()
             response["model_id"] = model_id
@@ -328,14 +347,13 @@ class WCABaseCompletionsPipeline(
         except requests.exceptions.Timeout:
             raise ModelTimeoutError(model_id=model_id)
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         data = {
             "model_id": model_id,
             "prompt": f"{context}{prompt}",
         }
         logger.debug(f"Inference API request payload: {json.dumps(data)}")
 
-        headers = self.get_request_headers(api_key, suggestion_id)
         task_count = len(get_task_names_from_prompt(prompt))
         prediction_url = f"{self.config.inference_url}/v1/wca/codegen/ansible"
 
@@ -471,7 +489,8 @@ class WCABasePlaybookGenerationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, generation_id)
+        headers = self._prepare_request_headers(request.user, api_key, generation_id)
+
         data = {
             "model_id": model_id,
             "text": text,
@@ -553,7 +572,8 @@ class WCABaseRoleGenerationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, generation_id)
+        headers = self._prepare_request_headers(request.user, api_key, generation_id)
+
         data = {
             "model_id": model_id,
             "text": text,
@@ -634,7 +654,8 @@ class WCABasePlaybookExplanationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, explanation_id)
+        headers = self._prepare_request_headers(request.user, api_key, explanation_id)
+
         data = {
             "model_id": model_id,
             "playbook": content,
@@ -696,7 +717,8 @@ class WCABaseRoleExplanationPipeline(
         api_key = self.get_api_key(request.user)
         model_id = self.get_model_id(request.user, model_id)
 
-        headers = self.get_request_headers(api_key, explanation_id)
+        headers = self._prepare_request_headers(request.user, api_key, explanation_id)
+
         data = {
             "role_name": params.role_name,
             "model_id": model_id,

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py
@@ -47,6 +47,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_onprem import (
 )
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     WCA_REQUEST_ID_HEADER,
+    WCA_REQUEST_USER_UUID_HEADER,
     WCABaseCompletionsPipeline,
     WCABaseContentMatchPipeline,
     WCABaseMetaData,
@@ -114,12 +115,13 @@ class WCAOnPremPipeline(
         # User may provide an override value if the setting is not defined.
 
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
             WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
+            WCA_REQUEST_USER_UUID_HEADER: lightspeed_user_uuid if lightspeed_user_uuid else None,
         }
 
     def _get_base_headers(self, api_key: str) -> dict[str, str]:
@@ -150,11 +152,14 @@ class WCAOnPremCompletionsPipeline(
             }
         )
         try:
+            headers = self.get_request_headers(wca_api_key, None)
+
             self.infer_from_parameters(
-                wca_api_key,
                 wca_model_id,
                 "",
                 "- name: install ffmpeg on Red Hat Enterprise Linux",
+                None,
+                headers,
             )
         except Exception as e:
             logger.exception(str(e))

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_saas.py
@@ -57,6 +57,7 @@ from ansible_ai_connect.ai.api.model_pipelines.wca.configuration_saas import (
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
     MODEL_MESH_HEALTH_CHECK_TOKENS,
     WCA_REQUEST_ID_HEADER,
+    WCA_REQUEST_USER_UUID_HEADER,
     WCABaseCompletionsPipeline,
     WCABaseContentMatchPipeline,
     WCABaseMetaData,
@@ -229,12 +230,13 @@ class WCASaaSPipeline(
         super().__init__(config=config)
 
     def get_request_headers(
-        self, api_key: str, identifier: Optional[str]
+        self, api_key: str, identifier: Optional[str], lightspeed_user_uuid: Optional[str] = None
     ) -> dict[str, Optional[str]]:
         base_headers = self._get_base_headers(api_key)
         return {
             **base_headers,
             WCA_REQUEST_ID_HEADER: str(identifier) if identifier else None,
+            WCA_REQUEST_USER_UUID_HEADER: lightspeed_user_uuid if lightspeed_user_uuid else None,
         }
 
     def _get_base_headers(self, api_key: str) -> dict[str, str]:
@@ -265,11 +267,14 @@ class WCASaaSCompletionsPipeline(
             }
         )
         try:
+            headers = self.get_request_headers(wca_api_key, None)
+
             self.infer_from_parameters(
-                wca_api_key,
                 wca_model_id,
                 "",
                 "- name: install ffmpeg on Red Hat Enterprise Linux",
+                None,
+                headers=headers,
             )
         except WcaInferenceFailure as e:
             logger.exception(str(e))

--- a/ansible_ai_connect/ai/api/tests/test_completion_view.py
+++ b/ansible_ai_connect/ai/api/tests/test_completion_view.py
@@ -138,7 +138,7 @@ class MockedPipelineCompletions(ModelPipelineCompletions[MockedConfig]):
         # i.e., still receives 200 after 10 API calls...
         return self.response_data
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> Optional[HealthCheckSummary]:

--- a/ansible_ai_connect/ai/api/tests/test_views.py
+++ b/ansible_ai_connect/ai/api/tests/test_views.py
@@ -165,7 +165,7 @@ class MockedPipelineCompletions(ModelPipelineCompletions[MockedConfig]):
         # i.e., still receives 200 after 10 API calls...
         return self.response_data
 
-    def infer_from_parameters(self, api_key, model_id, context, prompt, suggestion_id=None):
+    def infer_from_parameters(self, model_id, context, prompt, suggestion_id=None, headers=None):
         raise NotImplementedError
 
     def self_test(self) -> Optional[HealthCheckSummary]:

--- a/ansible_ai_connect/ai/api/wca/model_id_views.py
+++ b/ansible_ai_connect/ai/api/wca/model_id_views.py
@@ -218,7 +218,7 @@ def validate(api_key, model_id):
         ModelPipelineCompletions
     )
     model_mesh_client.infer_from_parameters(
-        api_key, model_id, "", "---\n- hosts: all\n  tasks:\n  - name: install ssh\n"
+        model_id, "", "---\n- hosts: all\n  tasks:\n  - name: install ssh\n"
     )
 
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-46219

## Description
Original: https://github.com/ansible/ansible-ai-connect-service/pull/1667
Reverted: https://github.com/ansible/ansible-ai-connect-service/pull/1669

The problem with the original implementation was that I had not updated the health check code to generate request headers before calling `infer_from_parameters`.  As a result, those requests were failing in stage.  I've updated both the on-prem and saas `self_test` methods to include generating headers and passing them in correctly.  I've also added some additional test logic which inspects the arguments we call `infer_from_parameters` with to ensure that the auth header is included.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
