### PR TITLE
Add auth headers to infer_from_parameters when validating model id and api key

### DIFF
--- a/ansible_ai_connect/ai/api/wca/model_id_views.py
+++ b/ansible_ai_connect/ai/api/wca/model_id_views.py
@@ -217,8 +217,15 @@ def validate(api_key, model_id):
     model_mesh_client: ModelPipelineCompletions = apps.get_app_config("ai").get_model_pipeline(
         ModelPipelineCompletions
     )
+    headers = model_mesh_client.get_request_headers(
+        api_key=api_key, identifier=None, lightspeed_user_uuid=None
+    )
     model_mesh_client.infer_from_parameters(
-        model_id, "", "---\n- hosts: all\n  tasks:\n  - name: install ssh\n"
+        model_id,
+        "",
+        "---\n- hosts: all\n  tasks:\n  - name: install ssh\n",
+        user=None,
+        headers=headers,
     )
 
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-46219

## Description
Followup to https://github.com/ansible/ansible-ai-connect-service/pull/1672
