### PR TITLE
wca:model validate, drop deprecated argument

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -21,5 +21,6 @@ jobs:
         python-version: '3.11'
     - name: install
       run: |
-        pip install pyright django boto3 requests prometheus_client backoff django_prometheus langchain langchain-ollama django-health-check aiohttp ansible-lint
+        pip install .
+        pip install pyright
         pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ include = [
   "ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_onprem.py",
   "ansible_ai_connect/users/authz_checker.py",
   "ansible_ai_connect/main/settings/legacy.py",
-  "ansible_ai_connect/ansible_lint"
+  "ansible_ai_connect/ansible_lint",
+  "ansible_ai_connect/ai/api/wca/"
 ]
 exclude = ["**/test_*.py", "ansible_ai_connect/*/migrations/*.py"]
 


### PR DESCRIPTION
Remove the deprecated `user` argument from the `infer_from_parameters()`
call.
