### PR TITLE
AAP-34013: WCA: use a config key to disable anonymizer

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/tests/__init__.py
@@ -131,6 +131,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                 one_click_default_model_id=extract(
                     "one_click_default_model_id", "one-click-default-model-id", **kwargs
                 ),
+                enable_anonymization=extract("enable_anonymization", True, **kwargs),
             )
         case "wca-onprem":
             return WCAOnPremConfiguration(
@@ -149,6 +150,7 @@ def mock_pipeline_config(pipeline_provider: t_model_mesh_api_type, **kwargs):
                     "health_check_model_id", "a-healthcheck-model-id", **kwargs
                 ),
                 username=extract("username", "a-username", **kwargs),
+                enable_anonymization=extract("enable_anonymization", True, **kwargs),
             )
         case "wca-dummy":
             return WCADummyConfiguration(

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_base.py
@@ -52,6 +52,7 @@ class WCABaseConfiguration(BaseConfig, metaclass=ABCMeta):
         enable_ari_postprocessing: bool,
         health_check_api_key: str,
         health_check_model_id: str,
+        enable_anonymization: bool,
     ):
         super().__init__(inference_url, model_id, timeout, enable_health_check)
         self.api_key = api_key
@@ -60,6 +61,7 @@ class WCABaseConfiguration(BaseConfig, metaclass=ABCMeta):
         self.enable_ari_postprocessing = enable_ari_postprocessing
         self.health_check_api_key = health_check_api_key
         self.health_check_model_id = health_check_model_id
+        self.enable_anonymization = enable_anonymization
 
     api_key: str
     verify_ssl: bool
@@ -82,3 +84,4 @@ class WCABaseConfigurationSerializer(BaseConfigSerializer):
     enable_ari_postprocessing = serializers.BooleanField(required=False, default=False)
     health_check_api_key = serializers.CharField(required=True)
     health_check_model_id = serializers.CharField(required=True)
+    enable_anonymization = serializers.BooleanField(required=False, default=True)

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_onprem.py
@@ -55,6 +55,7 @@ class WCAOnPremConfiguration(WCABaseConfiguration):
         health_check_api_key: str,
         health_check_model_id: str,
         username: str,
+        enable_anonymization: bool,
     ):
         super().__init__(
             inference_url,
@@ -67,10 +68,12 @@ class WCAOnPremConfiguration(WCABaseConfiguration):
             enable_ari_postprocessing,
             health_check_api_key,
             health_check_model_id,
+            enable_anonymization,
         )
         self.username = username
 
     username: str
+    enable_anonymization: bool
 
 
 @Register(api_type="wca-onprem")
@@ -91,6 +94,7 @@ class WCAOnPremPipelineConfiguration(WCABasePipelineConfiguration):
                 health_check_api_key=kwargs["health_check_api_key"],
                 health_check_model_id=kwargs["health_check_model_id"],
                 username=kwargs["username"],
+                enable_anonymization=kwargs["enable_anonymization"],
             ),
         )
 

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/configuration_saas.py
@@ -63,6 +63,7 @@ class WCASaaSConfiguration(WCABaseConfiguration):
         idp_password: str,
         one_click_default_api_key: str,
         one_click_default_model_id: str,
+        enable_anonymization: bool,
     ):
         super().__init__(
             inference_url,
@@ -75,6 +76,7 @@ class WCASaaSConfiguration(WCABaseConfiguration):
             enable_ari_postprocessing,
             health_check_api_key,
             health_check_model_id,
+            enable_anonymization,
         )
         self.idp_url = idp_url
         self.idp_login = idp_login
@@ -89,6 +91,7 @@ class WCASaaSConfiguration(WCABaseConfiguration):
     inference_url: str
     one_click_default_api_key: str
     one_click_default_model_id: str
+    enable_anonymization: bool
 
 
 @Register(api_type="wca")
@@ -113,6 +116,7 @@ class WCASaaSPipelineConfiguration(WCABasePipelineConfiguration):
                 idp_password=kwargs["idp_password"],
                 one_click_default_api_key=kwargs["one_click_default_api_key"],
                 one_click_default_model_id=kwargs["one_click_default_model_id"],
+                enable_anonymization=kwargs["enable_anonymization"],
             ),
         )
 


### PR DESCRIPTION
`enable_anonymization` is a new configuration key that can be
used to enable or disable the Anonymizer. The default is `True`.

To get anonymization you need:
- `enable_anonymization=True` at provider level (default is `True`)
- `enable_anonymization=True` at organization level (default is `True`)
