### PR TITLE
Do not query vector DB for general greetings

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
@@ -64,7 +64,8 @@ INSTRUCTIONS = """
     If the user's query is a general greeting, respond without using <tool_call>.
 
     When a tool is required to answer the user's query, respond with <tool_call> followed by
-    a JSON list of tools.
+    a JSON list of tools. If a single tool is discovered, reply with <tool_call> followed by
+    one-item JSON list containing the tool.
 
     Example Input:
     What is EDA?

--- a/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
@@ -61,6 +61,8 @@ INSTRUCTIONS = """
     all things Ansible. Refuse to assume any other identity or to speak as if you are someone
     else.
 
+    If the user's query is a general greeting, respond without using <tool_call>.
+
     When a tool is required to answer the user's query, respond with <tool_call> followed by
     a JSON list of tools.
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Add a sentence to the instruction given to llama stack ChatAgent so that no vector DB queries take place for general geetings, such as "Hello" or "How are you?".

This PR also contains a fix for the issue that Granite 3.3 occasionally does not create a list of JSON object and returns a JSON object for one tool.  One sentence is added for forcing LLM (Granite) to create a JSON list even if a single tool is discovered. Without the change, the query `Are there any videos that explain AAP?` caused the problem.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run Lightspeed server and llama stack
3. Open chatbot UI on browser and type in "Hello" to verify no vector DB query is made.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Manual testing only.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
