### PR TITLE
Do not display duplicated inference output

### DIFF
--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -67,6 +67,16 @@ const isTimeoutError = (e: any) =>
 const isTooManyRequestsError = (e: any) =>
   axios.isAxiosError(e) && e.response?.status === 429;
 
+const INFERENCE_MESSAGE_PROMPT = "\n\n`inference>`";
+const INFERENCE_MESSAGE_PROMPT_REGEX = new RegExp(INFERENCE_MESSAGE_PROMPT, "mg");
+
+const countInferenceMessagePrompts = (content: string | undefined): number => {
+  if (!content) {
+    return 0;
+  }
+  return (content.match(INFERENCE_MESSAGE_PROMPT_REGEX) || []).length;
+};
+
 export const fixedMessage = (content: string): MessageProps => ({
   role: "bot",
   content,
@@ -539,9 +549,17 @@ export const useChatbot = () => {
               } else if (message.event === "turn_complete") {
                 setMessages((msgs: ExtendedMessage[]) => {
                   const lastMessage = msgs[msgs.length - 1];
+                  const n = countInferenceMessagePrompts(lastMessage.content);
+                  if (n === 1) {
+                    lastMessage.content = lastMessage.content?.replace(INFERENCE_MESSAGE_PROMPT, "").replace("<noinput>", "");
+                    return [...msgs];
+                  } else if (n > 1) {
+                    const i = lastMessage.content?.lastIndexOf(INFERENCE_MESSAGE_PROMPT);
+                    lastMessage.content = lastMessage.content?.substring(0, i);
+                  }
                   lastMessage.collapse = true;
-                  msgs.push(botMessage(message.data.token, query.toString()));
-                  return msgs;
+                  const newMessage  = botMessage(message.data.token, query.toString());
+                  return [...msgs, newMessage];
                 });
               }
             },

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -249,7 +249,7 @@ function mockFetchEventSource() {
     },
     {
       event: "token",
-      data: { id: 0, token: "Let me search for " },
+      data: { id: 0, token: "\n\n`inference>`Let me search for " },
     },
     {
       event: "token",
@@ -265,15 +265,34 @@ function mockFetchEventSource() {
     },
     {
       event: "token",
-      data: { id: 4, token: "EDA stands for " },
+      data: { id: 5, token: "Some output" },
     },
     {
       event: "token",
-      data: { id: 5, token: "Event Driven Ansible." },
+      data: { id: 6, token: "\n\n`inference>`EDA stands for " },
+    },
+    {
+      event: "token",
+      data: { id: 7, token: "Event Driven Ansible." },
     },
     {
       event: "step_complete",
-      data: { id: 6, token: '{ "key":"value"}' },
+      data: { id: 8, token: '{ "key":"value"}' },
+    },
+    {
+      event: "turn_complete",
+      data: { id: 0, token: "Turn complete." },
+    },
+  ];
+
+  const streamAgentGreetingData: object[] = [
+    {
+      event: "start",
+      data: { conversation_id: "6e33a46e-2b15-4128-8e5c-c6f637ebfbb4" },
+    },
+    {
+      event: "token",
+      data: { id: 0, token: "\n\n`inference>` Hello! How can I assist you with Ansible today?" },
     },
     {
       event: "turn_complete",
@@ -285,12 +304,15 @@ function mockFetchEventSource() {
     let status = 200;
     let errorCase = false;
     let agent = false;
+    let agent_greeting = false;
     let skipClose = false;
     const o = JSON.parse(init.body);
     if (o.query.startsWith("status=")) {
       status = parseInt(o.query.substring(7));
     } else if (o.query.startsWith("error in stream")) {
       errorCase = true;
+    } else if (o.query.startsWith("agent_greeting")) {
+      agent_greeting = true;
     } else if (o.query.startsWith("agent")) {
       agent = true;
     } else if (o.query.startsWith("skip close")) {
@@ -302,11 +324,13 @@ function mockFetchEventSource() {
     await init.onopen({ status, ok });
     if (status === 200) {
       // eslint-disable-next-line no-nested-ternary
-      const streamData = agent
-        ? streamAgentNormalData
-        : errorCase
-          ? streamErrorData
-          : streamNormalData;
+      const streamData = agent_greeting
+        ? streamAgentGreetingData
+        : agent
+          ? streamAgentNormalData
+          : errorCase
+            ? streamErrorData
+            : streamNormalData;
       for (const data of streamData) {
         init.onmessage({ data: JSON.stringify(data) });
       }
@@ -779,14 +803,35 @@ test("Agent chat streaming test", async () => {
   expect(ghIssueLinkSpy).toEqual(1);
 
   await expect
-    .element(view.getByText("EDA stands for Event Driven Ansible."))
+    .element(view.getByText("Some output"))
     .not.toBeVisible();
   const showMoreLink = await screen.findByRole("button", { name: "Show more" });
   await showMoreLink.click();
   await expect.element(view.getByText("Show less")).toBeVisible();
   await expect
-    .element(view.getByText("EDA stands for Event Driven Ansible."))
+    .element(view.getByText("Some output"))
     .toBeVisible();
+  await expect
+    .element(view.getByText("EDA stands for Event Driven Ansible."))
+    .not.exist;
+});
+
+test("Agent chat streaming test with a general greeting", async () => {
+  let ghIssueLinkSpy = 0;
+  vi.stubGlobal("open", () => {
+    ghIssueLinkSpy++;
+  });
+  mockAxios(200, false, false, referencedDocumentExample, true);
+
+  const view = await renderApp(false, true);
+
+  await sendMessage("agent_greeting test");
+
+  await expect
+    .element(view.getByText("Hello! How can I assist you with Ansible today?"))
+    .toBeVisible();
+  await expect
+    .element(view.getByText("Show more")).not.exist;
 });
 
 test("Chat streaming error at API call", async () => {

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -68,6 +68,16 @@ const isTimeoutError = (e: any) =>
 const isTooManyRequestsError = (e: any) =>
   axios.isAxiosError(e) && e.response?.status === 429;
 
+const INFERENCE_MESSAGE_PROMPT = "\n\n`inference>`";
+const INFERENCE_MESSAGE_PROMPT_REGEX = new RegExp(INFERENCE_MESSAGE_PROMPT, "mg");
+
+const countInferenceMessagePrompts = (content: string | undefined): number => {
+  if (!content) {
+    return 0;
+  }
+  return (content.match(INFERENCE_MESSAGE_PROMPT_REGEX) || []).length;
+};
+
 export const fixedMessage = (content: string): MessageProps => ({
   role: "bot",
   content,
@@ -537,9 +547,17 @@ export const useChatbot = () => {
               } else if (message.event === "turn_complete") {
                 setMessages((msgs: ExtendedMessage[]) => {
                   const lastMessage = msgs[msgs.length - 1];
+                  const n = countInferenceMessagePrompts(lastMessage.content);
+                  if (n === 1) {
+                    lastMessage.content = lastMessage.content?.replace(INFERENCE_MESSAGE_PROMPT, "").replace("<noinput>", "");
+                    return [...msgs];
+                  } else if (n > 1) {
+                    const i = lastMessage.content?.lastIndexOf(INFERENCE_MESSAGE_PROMPT);
+                    lastMessage.content = lastMessage.content?.substring(0, i);
+                  }
                   lastMessage.collapse = true;
-                  msgs.push(botMessage(message.data.token, query.toString()));
-                  return msgs;
+                  const newMessage  = botMessage(message.data.token, query.toString());
+                  return [...msgs, newMessage];
                 });
               }
             },


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
When the agentic chatbot makes tool calls, the inference API is called to process outputs from tool calls and the last output is displayed as the final output.

With the current implementation of our chatbot UI, intermediate outputs are hidden in a collapible section.  However, when the section is expanded, the last inference output shows up as the duplicated information. We want to get rid of that.
![Screenshot From 2025-06-13 12-11-26](https://github.com/user-attachments/assets/2a73ada0-54d1-4788-afe4-415784b53c03)
![Screenshot From 2025-06-13 12-08-49](https://github.com/user-attachments/assets/29d76512-2c73-4caa-b500-7fe9e8db9f7c)




When the agentic chat does not make tool calls, a single inference call generates the final output. In such cases, we do not need to have a collapsible section. We'd like to take it out as well.  Also sometimes Granite model inserts the string `<noinput>` and we want to remove it.
![Screenshot From 2025-06-13 12-10-41](https://github.com/user-attachments/assets/028ffa09-09bc-4d13-86ea-f1c445d457ab)
![Screenshot From 2025-06-13 12-07-14](https://github.com/user-attachments/assets/0f2888f2-017d-4cf7-bc87-0d4346a25980)



## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
