### PR TITLE
Upgrade protobuf to 5.29.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'langchain-ollama~=0.2.1',
   'launchdarkly-server-sdk~=8.3.0',
   'llama-stack-client>=0.2.9',
-  'protobuf~=5.28.2',
+  'protobuf~=5.29.5',
   'psycopg~=3.1.8',
   'PyDrive2~=1.20.0',
   'pydantic==2.*',

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -340,7 +340,7 @@ propcache==0.2.0
     # via yarl
 proto-plus==1.24.0
     # via google-api-core
-protobuf==5.28.2
+protobuf==5.29.5
     # via
     #   -r requirements.in
     #   google-api-core

--- a/requirements-dev-aarch64.txt
+++ b/requirements-dev-aarch64.txt
@@ -186,7 +186,7 @@ propcache==0.2.0
     # via
     #   -c requirements-aarch64.txt
     #   yarl
-protobuf==5.28.2
+protobuf==5.29.5
     # via
     #   -c requirements-aarch64.txt
     #   grpcio-tools

--- a/requirements-dev-x86_64.txt
+++ b/requirements-dev-x86_64.txt
@@ -186,7 +186,7 @@ propcache==0.2.0
     # via
     #   -c requirements-x86_64.txt
     #   yarl
-protobuf==5.28.2
+protobuf==5.29.5
     # via
     #   -c requirements-x86_64.txt
     #   grpcio-tools

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -340,7 +340,7 @@ propcache==0.2.0
     # via yarl
 proto-plus==1.24.0
     # via google-api-core
-protobuf==5.28.2
+protobuf==5.29.5
     # via
     #   -r requirements.in
     #   google-api-core

--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ langchain==0.3.10
 langchain-ollama==0.2.1
 launchdarkly-server-sdk==8.3.0
 llama-stack-client>=0.2.9
-protobuf==5.28.2
+protobuf==5.29.5
 psycopg[binary]==3.1.8
 pydantic==2.9.2
 PyDrive2==1.20.0


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
```
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
protobuf | 5.28.2 | GHSA-8qvm-5x2c-j2w7 | 4.25.8,5.29.5,6.31.1 | ### Summary Any project that uses Protobuf pure-Python backend to parse untrusted Protocol Buffers data containing an arbitrary number of **recursive groups**, **recursive messages** or **a series of [`SGROUP`](https://protobuf.dev/programming-guides/encoding/#groups) tags** can be corrupted by exceeding the Python recursion limit.  Reporter: Alexis Challande, Trail of Bits Ecosystem Security Team [ecosystem@trailofbits.com](mailto:ecosystem@trailofbits.com)  Affected versions: This issue only affects the [pure-Python implementation](https://github.com/protocolbuffers/protobuf/tree/main/python#implementation-backends) of protobuf-python backend. This is the implementation when `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` environment variable is set or the default when protobuf is used from Bazel or pure-Python PyPi wheels. CPython PyPi wheels do not use pure-Python by default.  This is a Python variant of a [previous issue affecting protobuf-java](https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8).  ### Severity This is a potential Denial of Service. Parsing nested protobuf data creates unbounded recursions that can be abused by an attacker.  ### Proof of Concept For reproduction details, please refer to the unit tests [decoder_test.py](https://github.com/protocolbuffers/protobuf/blob/main/python/google/protobuf/internal/decoder_test.py#L87-L98) and [message_test](https://github.com/protocolbuffers/protobuf/blob/main/python/google/protobuf/internal/message_test.py#L1436-L1478)  ### Remediation and Mitigation A mitigation is available now. Please update to the latest available versions of the following packages: * protobuf-python(4.25.8, 5.29.5, 6.31.1)
```

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
