### PR TITLE
To add FAISS db readiness health check

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamastack/pipelines.py
@@ -45,6 +45,7 @@ from ansible_ai_connect.ai.api.model_pipelines.pipelines import (
 )
 from ansible_ai_connect.ai.api.model_pipelines.registry import Register
 from ansible_ai_connect.healthcheck.backends import (
+    MODEL_MESH_HEALTH_CHECK_INDEX,
     MODEL_MESH_HEALTH_CHECK_MODELS,
     MODEL_MESH_HEALTH_CHECK_PROVIDER,
     HealthCheckSummary,
@@ -98,8 +99,8 @@ RAG_TOOL_GROUP = ToolgroupAgentToolGroupWithArgs(
 )
 
 # Default provider ID for Llama Stack is rhosai_vllm_dev, from ansible-chatbot-stack
-LLAMA_STACK_PROVIDER_ID = os.getenv("LLAMA_STACK_PROVIDER_ID", "ollama")
-LLAMA_STACK_DB_PROVIDER = os.getenv("LLAMA_STACK_DB_PROVIDER", "faiss")
+LLAMA_STACK_PROVIDER_ID = os.getenv("LLAMA_STACK_PROVIDER_ID", "rhosai_vllm_dev")
+LLAMA_STACK_DB_PROVIDER_ID = os.getenv("LLAMA_STACK_DB_PROVIDER_ID", "aap_faiss")
 HEALTH_STATUS_OK = "OK"
 
 
@@ -139,7 +140,7 @@ class LlamaStackMetaData(MetaData[LlamaStackConfiguration]):
     def index_health(self) -> bool:
         try:
             client = LlamaStackClient(base_url=self.config.inference_url)
-            response = client.providers.retrieve(LLAMA_STACK_DB_PROVIDER)
+            response = client.providers.retrieve(LLAMA_STACK_DB_PROVIDER_ID)
             health_status = response.health.get("status")
             if health_status == HEALTH_STATUS_OK:
                 return True
@@ -170,15 +171,15 @@ class LlamaStackMetaData(MetaData[LlamaStackConfiguration]):
             {
                 MODEL_MESH_HEALTH_CHECK_PROVIDER: "llama-stack",
                 MODEL_MESH_HEALTH_CHECK_MODELS: "ok",
+                MODEL_MESH_HEALTH_CHECK_INDEX: "ok",
             }
         )
         if not self.index_health():
-            reason = f"Provider {LLAMA_STACK_DB_PROVIDER} health status: Not ready"
+            reason = f"Provider {LLAMA_STACK_DB_PROVIDER_ID} health status: Not ready"
             summary.add_exception(
-                MODEL_MESH_HEALTH_CHECK_MODELS,
+                MODEL_MESH_HEALTH_CHECK_INDEX,
                 HealthCheckSummaryException(ServiceUnavailable(reason)),
             )
-            return summary
         if not self.llm_health():
             reason = f"Provider {LLAMA_STACK_PROVIDER_ID} health status: Not ready"
             summary.add_exception(

--- a/ansible_ai_connect/healthcheck/backends.py
+++ b/ansible_ai_connect/healthcheck/backends.py
@@ -24,6 +24,7 @@ from ansible_ai_connect.ai.api.model_pipelines.types import PIPELINE_TYPE
 ERROR_MESSAGE = "An error occurred"
 MODEL_MESH_HEALTH_CHECK_MODELS = "models"
 MODEL_MESH_HEALTH_CHECK_PROVIDER = "provider"
+MODEL_MESH_HEALTH_CHECK_INDEX = "index"
 
 
 class HealthCheckSummaryException:


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue:  NA
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
To add FAISS db readiness health check

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Check for readiness of Faiss DB via llama-stack ollama run
3. `/check/status` should correctly display llm readiness and vector db index readiness

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
llama-stack faiss db and llama llm readiness health checked

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
