### PR TITLE
Fixes for llama-stack 0.2.12

### DIFF
--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -270,7 +270,7 @@ langsmith==0.1.138
     #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
-llama-stack-client==0.2.9
+llama-stack-client==0.2.12
     # via -r requirements.in
 markdown-it-py==3.0.0
     # via rich

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -270,7 +270,7 @@ langsmith==0.1.138
     #   langchain-core
 launchdarkly-server-sdk==8.3.0
     # via -r requirements.in
-llama-stack-client==0.2.9
+llama-stack-client==0.2.12
     # via -r requirements.in
 markdown-it-py==3.0.0
     # via rich


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Update other dependencies files following upgrade of `llama-stack` to `0.2.12`.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
