### PR TITLE
Add audit exclusions for urllib3

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -61,3 +61,7 @@ jobs:
             GHSA-79v4-65xg-pq4g
             # See don't use any .netrc
             GHSA-9hjg-9r4m-mvj7
+            # We don't use urllib3 from Node.js
+            GHSA-pq67-6m6q-mj2v
+            # We don't use urllib3 from Node.js
+            GHSA-48p4-8xcf-vxj5


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description

- https://github.com/advisories/GHSA-48p4-8xcf-vxj5

A vulnerability exists in `urllib3` versions `<2.5.0`.

We however do not use `urllib3` from `node.js` and hence are unaffected.

- https://github.com/advisories/GHSA-pq67-6m6q-mj2v

A vulnerability exists in `urllib3` versions `<2.5.0`.

By default, `requests` and `botocore` users are not affected.



We cannot upgrade `urllib3` to `2.5.0` as our `django-ansible-base` dependency uses `2.2.3`.

We would need to wait for them to upgrade first. 

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
