### PR TITLE
Open /chatbot view to users whose organization has an AAP sub

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -114,6 +114,7 @@ from .permissions import (
     BlockUserWithSeatButWCANotReady,
     BlockWCANotReadyButTrialAvailable,
     IsAAPLicensed,
+    IsOrganisationLightspeedSubscriber,
 )
 from .serializers import (
     ChatFeedback,
@@ -1051,7 +1052,7 @@ class Chat(AACSAPIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
-        IsRHInternalUser | IsTestUser | IsAAPUser,
+        IsRHInternalUser | IsTestUser | IsAAPUser | IsOrganisationLightspeedSubscriber,
     ]
     required_scopes = ["read", "write"]
     schema1_event = schema1.ChatBotOperationalEvent
@@ -1149,7 +1150,7 @@ class StreamingChat(AACSAPIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsAuthenticatedOrTokenHasScope,
-        IsRHInternalUser | IsTestUser | IsAAPUser,
+        IsRHInternalUser | IsTestUser | IsAAPUser | IsOrganisationLightspeedSubscriber,
     ]
     required_scopes = ["read", "write"]
     schema1_event = schema1.StreamingChatBotOperationalEvent

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -125,7 +125,8 @@ class ChatbotView(ProtectedTemplateView):
     template_name = "chatbot/index.html"
 
     permission_classes = [
-        IsRHInternalUser | IsTestUser | IsAAPUser,
+        IsAuthenticated,
+        IsRHInternalUser | IsTestUser | IsAAPUser | IsOrganisationLightspeedSubscriber,
     ]
 
     chatbot_enabled: bool

--- a/ansible_ai_connect/test_utils.py
+++ b/ansible_ai_connect/test_utils.py
@@ -45,6 +45,7 @@ def create_user(
     provider: str = None,
     social_auth_extra_data: any = {},
     rh_user_is_org_admin: Optional[bool] = None,
+    rh_org_has_subscription: Optional[bool] = None,
     rh_user_id: str = None,
     rh_org_id: int = 1234567,
     org_opt_out: bool = False,
@@ -65,6 +66,8 @@ def create_user(
         social_auth.set_extra_data(social_auth_extra_data)
         if rh_user_is_org_admin:
             user.rh_user_is_org_admin = rh_user_is_org_admin
+        if rh_org_has_subscription:
+            user.rh_org_has_subscription = rh_org_has_subscription
     user.save()
     return user
 

--- a/ansible_ai_connect/users/templates/users/home.html
+++ b/ansible_ai_connect/users/templates/users/home.html
@@ -131,7 +131,7 @@
                   {% if deployment_mode == 'saas' and user.is_authenticated and user.rh_user_is_org_admin %}
                   <a class="pf-l-level__item" href="/console"><span class="fas fa-solid fa-cog"></span> Admin Portal</a>
                   {% endif %}
-                  {% if chatbot_enabled and deployment_mode == 'saas' and user.is_authenticated and rh_internal_user_or_test_user %}
+                  {% if chatbot_enabled and deployment_mode == 'saas' and user.is_authenticated and can_access_chatbot %}
                   <a class="pf-l-level__item" href="/chatbot"><span class="fas fa-solid fa-comments"></span> Chatbot</a>
                   {% endif %}
                 </div>

--- a/ansible_ai_connect/users/views.py
+++ b/ansible_ai_connect/users/views.py
@@ -119,8 +119,10 @@ class HomeView(TemplateView):
         context["documentation_url"] = settings.COMMERCIAL_DOCUMENTATION_URL
 
         user = self.request.user
-        context["rh_internal_user_or_test_user"] = user.is_authenticated and (
-            user.rh_internal or user.groups.filter(name="test").exists()
+        context["can_access_chatbot"] = user.is_authenticated and (
+            user.rh_internal
+            or user.groups.filter(name="test").exists()
+            or user.rh_org_has_subscription
         )
 
         # Show chatbot link when the chatbot service is configured.


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-49639

Assisted-by: Cursor (gemini-2.5-pro-preview)

## Description
We already had a permission class (IsOrganisationLightspeedSubscriber) which keyed off of the user's `rh_org_has_subscription` attribute.  I'm leveraging that class and adding it to the mix of permission classes already applied to the chatbot view as well as the chatbot-related endpoints.  This change should only add to the existing matrix of scenarios that allow a user to access the chatbot (and see the chatbot link on the home page).

## Testing
Tested locally by programmatically hard coding my user to fit this new scenario (ie, ensuring that user.rh_internal is false and user.rh_org_has_subscription is true) so that I could verify that the chatbot link is present on the home page and the chatbot renders when the user navigates to /chatbot.

### Scenarios tested
Unit tests added around testing the presence of the link as well as the ability to navigate to the chatbot page

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
