### PR TITLE
Add support for redirecting to /chatbot after login via ?next param

### DIFF
--- a/ansible_ai_connect/main/base_views.py
+++ b/ansible_ai_connect/main/base_views.py
@@ -58,7 +58,7 @@ class ProtectedTemplateView(TemplateView):
             return handler(request, *args, **kwargs)
 
         except exceptions.NotAuthenticated:
-            return HttpResponseRedirect("/login")
+            return HttpResponseRedirect(f"/login?next={request.path}")
 
         except Exception as exc:
             # Map _internal_ errors to a generic PermissionDenied error

--- a/ansible_ai_connect/main/tests/test_views.py
+++ b/ansible_ai_connect/main/tests/test_views.py
@@ -130,6 +130,16 @@ class AlreadyAuth(TestCase):
         self.assertTrue(isinstance(response, HttpResponseRedirect))
         self.assertEqual(response.url, "/")
 
+    def test_no_login_for_auth_user_with_next(self):
+        class MockUser:
+            is_authenticated = True
+
+        request = RequestFactory().get("/login?next=/chatbot")
+        request.user = MockUser()
+        response = LoginView.as_view()(request)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(response.url, "/chatbot")
+
 
 @override_settings(ALLOW_METRICS_FOR_ANONYMOUS_USERS=False)
 class TestMetricsView(APITransactionTestCase):
@@ -343,7 +353,7 @@ class TestChatbotView(TestCase):
     def test_chatbot_view_with_anonymous_user(self):
         r = self.client.get(reverse("chatbot"))
         self.assertEqual(r.status_code, HTTPStatus.FOUND)
-        self.assertEqual(r.url, "/login")
+        self.assertEqual(r.url, "/login?next=/chatbot/")
 
     def test_chatbot_view_with_non_rh_user(self):
         self.client.force_login(user=self.non_rh_user)

--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 class LoginView(auth_views.LoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["next"] = self.request.GET.get("next")
         context["deployment_mode"] = settings.DEPLOYMENT_MODE
         context["project_name"] = settings.ANSIBLE_AI_PROJECT_NAME
         context["aap_api_provider_name"] = settings.AAP_API_PROVIDER_NAME
@@ -58,7 +59,7 @@ class LoginView(auth_views.LoginView):
 
     def dispatch(self, request, *args, **kwargs):
         if self.request.user.is_authenticated:
-            return HttpResponseRedirect("/")
+            return HttpResponseRedirect(self.request.GET.get("next", "/"))
         return super().dispatch(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-49579

Assisted-by: Cursor (gemini-2.5-pro)

## Description
This pull request enhances the login redirection logic by adding support for a `next` parameter, ensuring users are redirected to their intended destination after authentication. It also updates related test cases and modifies the login view to include the `next` parameter in the context.

### Enhancements to login redirection:

* Updated `dispatch` method in `ansible_ai_connect/main/base_views.py` to append the `next` parameter to the `/login` URL when redirecting unauthenticated users.
* Modified `dispatch` method in `ansible_ai_connect/main/views.py` to redirect authenticated users to the URL specified in the `next` parameter, defaulting to `/` if not provided.

### Updates to test cases:

* Added a new test case `test_no_login_for_auth_user_with_next` in `ansible_ai_connect/main/tests/test_views.py` to verify that authenticated users are redirected to the `next` URL.
* Updated the `test_chatbot_view_with_anonymous_user` test case to check for the `next` parameter in the redirection URL for anonymous users accessing the chatbot view.

### Context improvements in login view:

* Enhanced `get_context_data` in `ansible_ai_connect/main/views.py` to include the `next` parameter in the context, allowing it to be used in login templates.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
