### PR TITLE
Set default chatbot display mode to fullscreen

### DIFF
--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -131,7 +131,7 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   } = useChatbot();
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
   const [displayMode, setDisplayMode] = useState<ChatbotDisplayMode>(
-    ChatbotDisplayMode.default,
+    ChatbotDisplayMode.fullscreen,
   );
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const [conversations, setConversations] = React.useState<


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-49560
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: N/A
Generated by: N/A

## Description
This pull request includes a single change to the `AnsibleChatbot` component in `AnsibleChatbot.tsx`. The default value of the `displayMode` state has been updated to use `ChatbotDisplayMode.fullscreen` instead of `ChatbotDisplayMode.default`.Changed the initial state of the chatbot display mode from 'default' to 'fullscreen' to improve user experience by opening the chatbot in fullscreen mode by default.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
