### PR TITLE
Add welcome prompts to chatbot and related tests

### DIFF
--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -129,6 +129,26 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
     handleStopButton,
     isStreamingSupported,
   } = useChatbot();
+
+  const welcomePrompts = [
+    {
+      title: "Using Ansible Automation Platform",
+      message: "I have a question about Ansible Automation Platform",
+    },
+    {
+      title: "Containerized Installation",
+      message: "I want to install AAP using the containerized installer",
+    },
+    {
+      title: "RPM Installation",
+      message: "I want to install AAP using the RPM installer",
+    },
+  ].map((prompt) => ({
+    title: prompt.title,
+    message: prompt.message,
+    onClick: () => handleSend(prompt.message),
+  }));
+
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
   const [displayMode, setDisplayMode] = useState<ChatbotDisplayMode>(
     ChatbotDisplayMode.fullscreen,
@@ -330,6 +350,7 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                   <ChatbotWelcomePrompt
                     title="Hello, Ansible User"
                     description="How may I help you today?"
+                    prompts={welcomePrompts}
                   />
                   {alertMessage && (
                     <ChatbotAlert

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -892,3 +892,35 @@ test("Test reset conversation state once unmounting the component.", async () =>
   view.unmount();
   assert(conversationStore.size === 0);
 });
+
+test("Clicking a welcome prompt sends the correct message", async () => {
+  const spy = mockAxios(200);
+  const view = await renderApp();
+
+  const promptButton = view.getByRole("button", {
+    name: "Using Ansible Automation Platform",
+  });
+  expect(promptButton).toBeVisible();
+
+  await userEvent.click(promptButton);
+
+  expect(spy).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      conversation_id: undefined,
+      query: "I have a question about Ansible Automation Platform",
+    }),
+    expect.anything(),
+  );
+});
+
+test("All welcome prompts are rendered", async () => {
+  const view = await renderApp();
+  await expect
+    .element(view.getByText("Using Ansible Automation Platform"))
+    .toBeVisible();
+  await expect
+    .element(view.getByText("Containerized Installation"))
+    .toBeVisible();
+  await expect(view.getByText("RPM Installation")).toBeVisible();
+});


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-49557
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Cursor / gemini-2.5-pro

## Description
Introduced predefined welcome prompts to the AnsibleChatbot component, allowing users to quickly send common queries. Added tests to verify that all welcome prompts are rendered and that clicking a prompt sends the correct message.

## Testing
Automated tests added ensuring that the cards render and that clicking one leads to the necessary network call

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
