### PR TITLE
To remove the chat_prompt from Chatbot being sent to segment for logs analysis

### DIFF
--- a/ansible_ai_connect/ai/api/telemetry/schema1.py
+++ b/ansible_ai_connect/ai/api/telemetry/schema1.py
@@ -217,6 +217,13 @@ class ChatBotBaseEvent(Schema1Event):
         self.chat_prompt = anonymize_struct(self.chat_prompt)
         self.chat_response = anonymize_struct(self.chat_response)
 
+    def as_dict(self):
+        result = super().as_dict()
+        # Exclude chat_prompt if setting is enabled
+        if getattr(settings, 'SEGMENT_EXCLUDE_CHAT_PROMPTS', True):
+            result.pop('chat_prompt', None)
+        return result
+
 
 @define
 class ChatBotFeedbackEvent(ChatBotBaseEvent):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -213,6 +213,9 @@ ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION = os.environ.get(
     "ANALYTICS_MIN_ANSIBLE_EXTENSION_VERSION", "v2.12.143"
 )
 
+# Control what data is sent to telemetry, by default we exclude chat_prompt
+SEGMENT_EXCLUDE_CHAT_PROMPTS = os.environ.get("SEGMENT_EXCLUDE_CHAT_PROMPTS", "true")
+
 OAUTH2_PROVIDER = {
     "SCOPES": {
         "read": "Read basic user information",


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-39508>
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Cursor AI 
Generated by: Unit tests

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
To remove the chat_prompt from Chatbot being sent to segment for logs analysis. Confirmed from Marty that we can disable the chat_prompts from being sent to segment and thus Amplitude to avoid leaking any user sensitive information. Please look at the latest comment over the issue: AAP-39508, for more reference

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Verified running the unit tests

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
NA

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
