### PR TITLE
http/check_test: force timeout to 1s

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -69,7 +69,7 @@ class HttpMetaData(MetaData[HttpConfiguration]):
         i = self.config.timeout
         self._timeout = int(i) if i is not None else None
 
-    def timeout(self, task_count=1):
+    def task_gen_timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None
 
 
@@ -94,7 +94,7 @@ class HttpCompletionsPipeline(HttpMetaData, ModelPipelineCompletions[HttpConfigu
                 self._prediction_url,
                 headers=self.headers,
                 json=model_input,
-                timeout=self.timeout(task_count),
+                timeout=self.task_gen_timeout(task_count),
                 verify=self.config.verify_ssl,
             )
             result.raise_for_status()
@@ -113,7 +113,7 @@ class HttpCompletionsPipeline(HttpMetaData, ModelPipelineCompletions[HttpConfigu
             }
         )
         try:
-            res = requests.get(url, verify=True)
+            res = requests.get(url, verify=True, timeout=1)
             res.raise_for_status()
         except Exception as e:
             logger.exception(str(e))
@@ -144,7 +144,7 @@ class HttpChatBotMetaData(HttpMetaData):
             r = requests.get(
                 self.config.inference_url + "/readiness",
                 headers=headers,
-                timeout=self.timeout(1),
+                timeout=1,
             )
             r.raise_for_status()
 
@@ -197,7 +197,7 @@ class HttpChatBotPipeline(HttpChatBotMetaData, ModelPipelineChatBot[HttpConfigur
             self.config.inference_url + "/v1/query",
             headers=self.headers,
             json=data,
-            timeout=self.timeout(1),
+            timeout=self.task_gen_timeout(1),
             verify=self.config.verify_ssl,
         )
 

--- a/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/langchain/pipelines.py
@@ -157,7 +157,7 @@ class LangchainMetaData(
         i = self.config.timeout
         self._timeout = int(i) if i is not None else None
 
-    def timeout(self, task_count=1):
+    def task_gen_timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None
 
 

--- a/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/llamacpp/pipelines.py
@@ -46,7 +46,7 @@ class LlamaCppMetaData(MetaData[LlamaCppConfiguration]):
         i = self.config.timeout
         self._timeout = int(i) if i is not None else None
 
-    def timeout(self, task_count=1):
+    def task_gen_timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None
 
 
@@ -110,7 +110,7 @@ class LlamaCppCompletionsPipeline(
                 self._prediction_url,
                 headers=self.headers,
                 json=llm_params,
-                timeout=self.timeout(task_count),
+                timeout=self.task_gen_timeout(task_count),
                 verify=self.config.verify_ssl,
             )
             result.raise_for_status()

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -207,7 +207,7 @@ class WCABaseMetaData(
         i = self.config.timeout
         self._timeout = int(i) if i is not None else None
 
-    def timeout(self, task_count=1):
+    def task_gen_timeout(self, task_count=1):
         return self._timeout * task_count if self._timeout else None
 
     @staticmethod
@@ -395,7 +395,7 @@ class WCABaseCompletionsPipeline(
                 prediction_url,
                 headers=headers,
                 json=data,
-                timeout=self.timeout(task_count),
+                timeout=self.task_gen_timeout(task_count),
                 verify=self.config.verify_ssl,
             )
 
@@ -469,7 +469,7 @@ class WCABaseContentMatchPipeline(
                     self._search_url,
                     headers=headers,
                     json=data,
-                    timeout=self.timeout(suggestion_count),
+                    timeout=self.task_gen_timeout(suggestion_count),
                     verify=self.config.verify_ssl,
                 )
 

--- a/ansible_ai_connect/ai/api/tests/test_api_timeout.py
+++ b/ansible_ai_connect/ai/api/tests/test_api_timeout.py
@@ -38,27 +38,27 @@ class TestApiTimeout(APIVersionTestCaseBase, WisdomServiceAPITestCaseBase):
 
     def test_timeout_settings_is_none(self):
         model_client = HttpMetaData(mock_pipeline_config("http", timeout=None))
-        self.assertIsNone(model_client.timeout(1))
+        self.assertIsNone(model_client.task_gen_timeout(1))
 
     def test_timeout_settings_is_not_none(self):
         model_client = HttpMetaData(mock_pipeline_config("http", timeout=123))
-        self.assertEqual(123, model_client.timeout(1))
+        self.assertEqual(123, model_client.task_gen_timeout(1))
 
     def test_timeout_settings_is_not_none_multi_task(self):
         model_client = HttpMetaData(mock_pipeline_config("http", timeout=123))
-        self.assertEqual(123 * 2, model_client.timeout(2))
+        self.assertEqual(123 * 2, model_client.task_gen_timeout(2))
 
     def test_timeout_settings_is_none_wca(self):
         model_client = WCASaaSCompletionsPipeline(mock_pipeline_config("wca", timeout=None))
-        self.assertIsNone(model_client.timeout(1))
+        self.assertIsNone(model_client.task_gen_timeout(1))
 
     def test_timeout_settings_is_not_none_wca(self):
         model_client = WCASaaSCompletionsPipeline(mock_pipeline_config("wca", timeout=123))
-        self.assertEqual(123, model_client.timeout(1))
+        self.assertEqual(123, model_client.task_gen_timeout(1))
 
     def test_timeout_settings_is_not_none_wca_multitask(self):
         model_client = WCASaaSCompletionsPipeline(mock_pipeline_config("wca", timeout=123))
-        self.assertEqual(123 * 2, model_client.timeout(2))
+        self.assertEqual(123 * 2, model_client.task_gen_timeout(2))
 
     @override_settings(ANSIBLE_AI_ENABLE_TECH_PREVIEW=True)
     @patch("requests.Session.post", side_effect=ReadTimeout())


### PR DESCRIPTION
Avoid using the `self.timeout()` method which can lead to a sisution
where we set `timeout=None`.

Also rename the `self.timeout()` method to `task_gen_timeout()` to
improve the readability.