### PR TITLE
To disable ssl verification for chatbot readiness for TLS communication updates

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -113,7 +113,7 @@ class HttpCompletionsPipeline(HttpMetaData, ModelPipelineCompletions[HttpConfigu
             }
         )
         try:
-            res = requests.get(url, verify=True, timeout=1)
+            res = requests.get(url, verify=self.config.verify_ssl, timeout=1)
             res.raise_for_status()
         except Exception as e:
             logger.exception(str(e))


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-39514>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
To disable ssl verification for chatbot readiness for TLS communication updates. Update required to fix: `AAP-39514`. And, this was needed even after adding openshift Service-Served Certificates, but (wisdom-service) doesn't have the OpenShift Service CA in its trusted certificate store to verify them.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Use ops PR: https://github.com/ansible/ansible-wisdom-ops/pull/1464
3. Update the argocd branch from ops PR
4. Test for chatbot and health functionality, both should work as expected.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Chatbot functionality and chatbot health readiness both should work as expected.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
