### PR TITLE
/login: ensure next is always set

### DIFF
--- a/ansible_ai_connect/main/views.py
+++ b/ansible_ai_connect/main/views.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 class LoginView(auth_views.LoginView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["next"] = self.request.GET.get("next")
+        context["next"] = self.request.GET.get("next") or "/"
         context["deployment_mode"] = settings.DEPLOYMENT_MODE
         context["project_name"] = settings.ANSIBLE_AI_PROJECT_NAME
         context["aap_api_provider_name"] = settings.AAP_API_PROVIDER_NAME


### PR DESCRIPTION
This to avoid the following exception when we use a Django user:

```
Using the URLconf defined in ansible_ai_connect.main.urls, Django tried these URL patterns, in this order:

[name='home']
login/<str:backend>/ [name='begin']
The current path, login/None/, matched the last one.
```
