### PR TITLE
simplify the pr_deployment flow

### DIFF
--- a/.github/workflows/pr_deployment_test.yml
+++ b/.github/workflows/pr_deployment_test.yml
@@ -8,28 +8,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  pr_testing:
-    if: ${{ github.event.label.name == 'pr-deployment' }}
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    needs: deployment_ready
-    steps:
-    - uses: actions/checkout@v4
-    - name: Trigger tests on PR deployment
-      id: test_pr
-      run: |
-        TEST_RESULTS=$(bash ./.github/workflows/scripts/pr_deployment_test.sh invoke_pr_test 81148901 ${{ secrets.TESTING_TRIGGER_PAT }} ${{ github.event.number }})
-        echo "TEST_RESULTS=${TEST_RESULTS}" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: report test results
-      uses: mshick/add-pr-comment@v2
-      with:
-        message: |
-          ${{ steps.test_pr.outputs.TEST_RESULTS }}
-
-
-  deployment_ready:
+  pr_deplolyment_test:
     if: ${{ github.event.label.name == 'pr-deployment' }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -38,3 +17,16 @@ jobs:
       - name: Wait for PR deployment completion
         run: bash ./.github/workflows/scripts/pr_deployment_test.sh wait_for_pr_deployment ${{ github.event.number }} ${{ secrets.PR_DEPLOY_CLUSTER_HOSTNAME }}
         shell: bash
+  pr_testing:
+    if: ${{ github.event.label.name == 'pr-deployment' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    needs: pr_deplolyment_test
+    steps:
+    - uses: actions/checkout@v4
+    - name: Trigger tests on PR deployment
+      id: test_pr
+      run: |
+        bash ./.github/workflows/scripts/pr_deployment_test.sh invoke_pr_test 81148901 ${{ secrets.TESTING_TRIGGER_PAT }} ${{ github.event.number }}
+      shell: bash

--- a/.github/workflows/scripts/pr_deployment_test.sh
+++ b/.github/workflows/scripts/pr_deployment_test.sh
@@ -34,7 +34,7 @@ invoke_pr_test() {
     run_status=$(echo "$run_info" | jq -r '.status')
     if [[ $run_status == "completed" ]]; then
       conclusion=$(echo "$run_info" | jq -r '.conclusion')
-      echo "Tests execution https://api.github.com/repos/ansible/ansible-wisdom-testing/actions/runs/$RUN_ID completed with conclusion: $conclusion"
+      echo "Tests execution https://github.com/ansible/ansible-wisdom-testing/actions/runs/$RUN_ID completed with conclusion: $conclusion"
       if [[ $conclusion == "success" ]]; then
         exit 0
       else
@@ -74,4 +74,4 @@ wait_for_pr_deployment() {
   echo "Deployment probably is broken. Please check"
 }
 
-$1 $2 $3 $4 $5 $6 $7
+$*


### PR DESCRIPTION
- not output in the PR
- no more `TEST_RESULTS` variable
- use `$*` to pass the parameters to the functions
- only run a subset of the `sanity` test-suite, See:
  - https://github.com/ansible/ansible-wisdom-testing/pull/964
  - https://issues.redhat.com/browse/AAP-51574
- print the direct URL of the test run