### PR TITLE
add condition to reflect gateway response as good when onprem

### DIFF
--- a/ansible_ai_connect/healthcheck/tests/test_healthcheck.py
+++ b/ansible_ai_connect/healthcheck/tests/test_healthcheck.py
@@ -186,6 +186,18 @@ class TestHealthCheck(BaseTestHealthCheck):
             data = json.loads(r.content)
             self.assert_common_data(data, "ok", settings.DEPLOYED_REGION)
 
+    @override_settings(DEPLOYMENT_MODE="onprem")
+    def test_liveness_probe_onprem(self):
+        with patch.object(
+            apps.get_app_config("ai"),
+            "get_model_pipeline",
+            Mock(return_value=DummyCompletionsPipeline(mock_pipeline_config("dummy"))),
+        ):
+            r = self.client.get(reverse("liveness_probe"), format="json")
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            data = json.loads(r.content)
+            self.assert_common_data(data, "good", settings.DEPLOYED_REGION)
+
     def test_health_check_all_healthy(self):
         cache.clear()
         with patch.object(

--- a/ansible_ai_connect/healthcheck/views.py
+++ b/ansible_ai_connect/healthcheck/views.py
@@ -162,7 +162,10 @@ class WisdomServiceLivenessProbeView(APIView):
     @method_decorator(never_cache)
     def get(self, request, *args, **kwargs):
         data = common_data()
-        data["status"] = "ok"
+        if settings.DEPLOYMENT_MODE == "onprem":
+            data["status"] = "good"
+        else:
+            data["status"] = "ok"
         data_json = json.dumps(data)
         return HttpResponse(data_json, content_type="application/json")
 


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-48579>
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: <name of code assistant if applicable>
Generated by: <name of code assistant if applicable>

## Description
Add condition to validate response as good or ok based on deployment mode

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. set the DEPLOYMENT_MODE as onprem 
3. get /api/v1/health and expect good
4. set the DEPLOYMENT_MODE as Saas
3. get /api/v1/health and expect ok

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
