### PR TITLE
Remove display mode dropdown from chatbot header

### DIFF
--- a/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
+++ b/ansible_ai_connect_chatbot/src/AnsibleChatbot/AnsibleChatbot.tsx
@@ -5,7 +5,6 @@ import {
   Brand,
   DropdownList,
   DropdownItem,
-  DropdownGroup,
   ExpandableSection,
 } from "@patternfly/react-core";
 
@@ -20,12 +19,7 @@ import Message from "@patternfly/chatbot/dist/dynamic/Message";
 import ChatbotHeader, {
   ChatbotHeaderTitle,
   ChatbotHeaderActions,
-  ChatbotHeaderOptionsDropdown,
 } from "@patternfly/chatbot/dist/dynamic/ChatbotHeader";
-
-import ExpandIcon from "@patternfly/react-icons/dist/esm/icons/expand-icon";
-import OpenDrawerRightIcon from "@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon";
-import OutlinedWindowRestoreIcon from "@patternfly/react-icons/dist/esm/icons/outlined-window-restore-icon";
 
 import lightspeedLogo from "../assets/lightspeed.svg";
 import lightspeedLogoDark from "../assets/lightspeed_dark.svg";
@@ -155,7 +149,7 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
   }));
 
   const [chatbotVisible, setChatbotVisible] = useState<boolean>(true);
-  const [displayMode, setDisplayMode] = useState<ChatbotDisplayMode>(
+  const [displayMode] = useState<ChatbotDisplayMode>(
     ChatbotDisplayMode.fullscreen,
   );
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
@@ -189,13 +183,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
     value: string | number | undefined,
   ) => {
     setSelectedModel(value as string);
-  };
-
-  const onSelectDisplayMode = (
-    _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined,
-  ) => {
-    setDisplayMode(value as ChatbotDisplayMode);
   };
 
   const setCurrentConversation = (
@@ -317,40 +304,6 @@ export const AnsibleChatbot: React.FunctionComponent = () => {
                       </DropdownList>
                     </ChatbotHeaderSelectorDropdown>
                   )}
-                  <ChatbotHeaderOptionsDropdown onSelect={onSelectDisplayMode}>
-                    <DropdownGroup label="Display mode">
-                      <DropdownList>
-                        <DropdownItem
-                          value={ChatbotDisplayMode.default}
-                          key="switchDisplayOverlay"
-                          icon={<OutlinedWindowRestoreIcon aria-hidden />}
-                          isSelected={
-                            displayMode === ChatbotDisplayMode.default
-                          }
-                        >
-                          <span>Overlay</span>
-                        </DropdownItem>
-                        <DropdownItem
-                          value={ChatbotDisplayMode.docked}
-                          key="switchDisplayDock"
-                          icon={<OpenDrawerRightIcon aria-hidden />}
-                          isSelected={displayMode === ChatbotDisplayMode.docked}
-                        >
-                          <span>Dock to window</span>
-                        </DropdownItem>
-                        <DropdownItem
-                          value={ChatbotDisplayMode.fullscreen}
-                          key="switchDisplayFullscreen"
-                          icon={<ExpandIcon aria-hidden />}
-                          isSelected={
-                            displayMode === ChatbotDisplayMode.fullscreen
-                          }
-                        >
-                          <span>Fullscreen</span>
-                        </DropdownItem>
-                      </DropdownList>
-                    </DropdownGroup>
-                  </ChatbotHeaderOptionsDropdown>
                 </ChatbotHeaderActions>
               </ChatbotHeader>
               {alertMessage && (


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-53042
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: claude-code

## Description
Eliminated the display mode selection dropdown and related state management from the AnsibleChatbot component. This simplifies the UI by removing the option to switch between overlay, docked, and fullscreen modes.

## Testing
This is what the UI now looks like:

<img width="1720" height="905" alt="Screenshot 2025-09-08 at 2 20 00 PM" src="https://github.com/user-attachments/assets/39b89fe7-2196-445c-8289-3c088aa13b36" />

It didn't seem like there were any unit tests around this functionality originally so nothing is updated

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
