### PR TITLE
AAP-54064 clear RBAC data in migration step

### DIFF
--- a/ansible_ai_connect/organizations/migrations/0005_migration_data_fix.py
+++ b/ansible_ai_connect/organizations/migrations/0005_migration_data_fix.py
@@ -1,0 +1,41 @@
+# Generated manually to create new Organization model and clear dab_rbac data
+
+from django.db import migrations
+
+
+def clear_dab_rbac_data(apps, schema_editor):
+    """Delete all entries from dab_rbac models"""
+    db_alias = schema_editor.connection.alias
+
+    # Get all dab_rbac models
+    from django.apps import apps as django_apps
+
+    dab_rbac_config = django_apps.get_app_config("dab_rbac")
+
+    # Delete all data from dab_rbac models in reverse dependency order
+    for model in reversed(dab_rbac_config.get_models()):
+        model.objects.using(db_alias).all().delete()
+
+
+def reverse_clear_dab_rbac_data(apps, schema_editor):
+    """Reverse operation - no-op since we can't restore deleted data"""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizations", "0004_organization_enable_anonymization"),
+        ("dab_rbac", "0004_remote_permissions_additions"),
+    ]
+
+    run_before = [
+        ("dab_rbac", "0005_remote_permissions_data"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            clear_dab_rbac_data,
+            reverse_clear_dab_rbac_data,
+        ),
+    ]

--- a/ansible_ai_connect/organizations/migrations/0005_migration_data_fix.py
+++ b/ansible_ai_connect/organizations/migrations/0005_migration_data_fix.py
@@ -1,6 +1,9 @@
 # Generated manually to create new Organization model and clear dab_rbac data
 
+import logging
 from django.db import migrations
+
+logger = logging.getLogger(__name__)
 
 
 def clear_dab_rbac_data(apps, schema_editor):
@@ -14,6 +17,13 @@ def clear_dab_rbac_data(apps, schema_editor):
 
     # Delete all data from dab_rbac models in reverse dependency order
     for model in reversed(dab_rbac_config.get_models()):
+        count = model.objects.using(db_alias).count()
+        if count > 0:
+            logger.warning(
+                "Migration 0005_migration_data_fix: Deleting %d entries from model %s",
+                count,
+                model.__name__
+            )
         model.objects.using(db_alias).all().delete()
 
 


### PR DESCRIPTION
This is split from https://github.com/ansible/ansible-ai-connect-service/pull/1770 to be the minimum changes to facilitate the fix.

Jira Issue: <https://issues.redhat.com/browse/AAP-54064>

Assisted-by: Claude (kind of, it wasn't that much help for this)

## Description
Without this, we can hit an upgrade error for the 2.5->2.6 line. This is because of the DAB 2.5 behavior of auto-registering the `Team` model. No models are intended to be registered, and you can see this in the setting in the `base.py` settings module. So there is no hazard in delete all rows in RBAC, as this does. RBAC is intended to be _enabled_ and also _unused_ and we will continue with that expectation.

## Testing
TBD - do upgrade testing

### Steps to test
Do full deployments in OCP, I don't have a local or minimal version of the fix. Although it would be possible.

### Scenarios tested
TBD

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

Needs testing in production.