### PR TITLE
update update-browserslist-db@latest

### DIFF
--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -50,7 +50,7 @@
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
-        "happy-dom": "^15.11.0",
+        "happy-dom": "^20.0.10",
         "html-webpack-plugin": "^5.5.0",
         "i18next-browser-languagedetector": "^7.1.0",
         "identity-obj-proxy": "^3.0.0",
@@ -4452,6 +4452,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
@@ -6031,9 +6038,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001683",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
-      "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9251,6 +9258,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9601,19 +9609,36 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "15.11.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.6.tgz",
-      "integrity": "sha512-elX7iUTu+5+3b2+NGQc0L3eWyq9jKhuJJ4GpOMxxT/c2pg9O3L5H3ty2VECX0XXZgRmmRqXyOK8brA2hDI6LsQ==",
+      "version": "20.0.10",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.10.tgz",
+      "integrity": "sha512-6umCCHcjQrhP5oXhrHQQvLB0bwb1UzHAHdsXy+FjtKoYjUhmNZsQL8NivwM1vDvNEChJabVrUYxUnp/ZdYmy2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
         "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
+      "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -50,9 +50,10 @@
     "eslint-webpack-plugin": "^3.1.1",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.1.1",
-    "happy-dom": "^15.11.0",
+    "happy-dom": "^20.0.10",
     "html-webpack-plugin": "^5.5.0",
     "i18next-browser-languagedetector": "^7.1.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-resolve": "^29.7.0",
@@ -67,6 +68,7 @@
     "prettier": "^3.0.2",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",
+    "react-router-dom": "^6.28.0",
     "react-test-renderer": "^18.2.0",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^5.0.0",
@@ -81,9 +83,7 @@
     "webpack-dev-server": "^5.2.2",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-mock-server": "^1.0.18",
-    "workbox-webpack-plugin": "^6.4.1",
-    "react-router-dom": "^6.28.0",
-    "identity-obj-proxy": "^3.0.0"
+    "workbox-webpack-plugin": "^6.4.1"
   },
   "scripts": {
     "start": "node scripts/start.js",


### PR DESCRIPTION
With:
- `npx update-browserslist-db@latest`
- `npm audit fix --force`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades happy-dom to v20 and updates lockfile, including newer caniuse-lite data and related type dependencies.
> 
> - **Dependencies**:
>   - Upgrade `happy-dom` to `^20.0.10` (requires Node `>=20`), adding transitive deps `@types/whatwg-mimetype` and `undici-types`.
>   - Update `caniuse-lite` dataset to latest.
>   - Lockfile refresh with associated entries (e.g., mark `fsevents` as dev, update nested `@types/node`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcf89f4dd5979d84cdda47cff9cf8bcda9ebb769. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->