### PR TITLE
pyproject: remove the version check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   'uwsgi-readiness-check~=0.2.0',
   'django-allow-cidr',
   'django-csp~=3.7',
-  'django-ansible-base[jwt-consumer,resource-registry]>=2025.8.18',
+  'django-ansible-base[jwt-consumer,resource-registry]',
 ]
 readme = "README.rst"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
This change removes the version check since it brings just extra work for us.
Downstream uses a different naming convention that is not compatible
with upstream:

```
ERROR: Could not find a version that satisfies the requirement django-ansible-base[jwt-consumer,resource-registry]>=2025.8.18 (from ansible-ai-connect) (from versions: 2.7.0)
```

See: https://github.com/ansible-automation-platform/ansible-lightspeed-container/pull/362