### PR TITLE
Add automated OpenAPI spec sync to aap-openapi-specs on merge

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -128,11 +128,14 @@ jobs:
     ####################
     # OpenAPI file check
     ####################
-    - name: Ensure the OpenAPI file is up to date
+    - name: Start Django server for OpenAPI generation
       run: |
         make run-server &
         sleep 10
         make create-cachetable
+
+    - name: Ensure the OpenAPI file is up to date
+      run: |
         make update-openapi-schema
         git diff --exit-code -- tools/openapi-schema/ansible-ai-connect-service.yaml
         git diff --exit-code -- tools/openapi-schema/ansible-ai-connect-service.json
@@ -145,3 +148,206 @@ jobs:
 
         validate_url('http://localhost:8000/api/schema/', cls=OpenAPIV30SpecValidator)
         "
+
+    # Upload spec artifact only for branches that should sync to central repo
+    # To add a new stable branch: add it to the JSON array below AND to branch_mapping step in sync job
+    - name: Upload OpenAPI spec artifact (for sync)
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && contains(fromJSON('["main", "stable-2.6", "stable-2.7"]'), github.ref_name)
+      uses: actions/upload-artifact@v4
+      with:
+        name: openapi-schema
+        path: tools/openapi-schema/ansible-ai-connect-service.json
+        retention-days: 1
+
+  # Sync OpenAPI spec to aap-openapi-specs repository
+  # Only runs for: main, stable-2.6, stable-2.7
+  # To add a new stable branch: update the JSON array below AND the branch_mapping step
+  sync-to-central-repo:
+    name: Sync spec to central repo
+    needs: [build]
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && contains(fromJSON('["main", "stable-2.6", "stable-2.7"]'), github.ref_name)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Determine target branch in spec repo
+        id: branch_mapping
+        run: |
+          SOURCE_BRANCH="${{ github.ref_name }}"
+
+          # Map source branch to target branch in spec repo
+          case "$SOURCE_BRANCH" in
+            "main")
+              TARGET_BRANCH="devel"
+              ;;
+            "stable-2.6")
+              TARGET_BRANCH="stable-2.6"
+              ;;
+            "stable-2.7")
+              TARGET_BRANCH="stable-2.7"
+              ;;
+            *)
+              TARGET_BRANCH="devel"
+              ;;
+          esac
+
+          echo "source_branch=$SOURCE_BRANCH" >> $GITHUB_OUTPUT
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+          echo "📍 Source branch: $SOURCE_BRANCH → Target branch: $TARGET_BRANCH"
+
+      - name: Download spec artifact from component workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi-schema
+          path: ./component-spec
+
+      - name: Verify spec file exists
+        run: |
+          SPEC_FILE="./component-spec/ansible-ai-connect-service.json"
+          if [ ! -f "$SPEC_FILE" ]; then
+            echo "❌ Spec file not found at $SPEC_FILE"
+            echo "Contents of artifact:"
+            ls -la ./component-spec/
+            exit 1
+          fi
+          echo "✅ Found spec file at $SPEC_FILE"
+
+      - name: Checkout spec repo
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-automation-platform/aap-openapi-specs
+          ref: ${{ steps.branch_mapping.outputs.target_branch }}
+          path: spec-repo
+          token: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
+
+      - name: Check if branch exists in spec repo
+        id: check_branch
+        working-directory: spec-repo
+        run: |
+          BRANCH="${{ steps.branch_mapping.outputs.target_branch }}"
+
+          # Check if branch exists locally (already checked out)
+          if git rev-parse --verify HEAD >/dev/null 2>&1; then
+            echo "✅ Branch '$BRANCH' exists in spec repo"
+            echo "branch_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Branch '$BRANCH' does NOT exist in spec repo"
+            echo "branch_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fail if branch doesn't exist
+        if: steps.check_branch.outputs.branch_exists != 'true'
+        run: |
+          echo "##[error]❌ Branch '${{ steps.branch_mapping.outputs.target_branch }}' does not exist in the central spec repository."
+          echo "##[error]Expected branch: ${{ steps.branch_mapping.outputs.target_branch }}"
+          echo "##[error]This branch must be created in the spec repo before specs can be synced."
+          exit 1
+
+      - name: Compare specs
+        id: compare
+        run: |
+          COMPONENT_SPEC="./component-spec/ansible-ai-connect-service.json"
+          SPEC_REPO_FILE="spec-repo/lightspeed.json"
+
+          # Check if spec file exists in spec repo
+          if [ ! -f "$SPEC_REPO_FILE" ]; then
+            echo "Spec file doesn't exist in spec repo - will create new file"
+            echo "has_diff=true" >> $GITHUB_OUTPUT
+            echo "is_new_file=true" >> $GITHUB_OUTPUT
+          else
+            # Compare files
+            if diff -q "$COMPONENT_SPEC" "$SPEC_REPO_FILE" > /dev/null; then
+              echo "✅ No differences found - specs are identical"
+              echo "has_diff=false" >> $GITHUB_OUTPUT
+            else
+              echo "📝 Differences found - spec has changed"
+              echo "has_diff=true" >> $GITHUB_OUTPUT
+              echo "is_new_file=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Update spec file
+        if: steps.compare.outputs.has_diff == 'true'
+        run: |
+          cp "./component-spec/ansible-ai-connect-service.json" "spec-repo/lightspeed.json"
+          echo "✅ Updated spec-repo/lightspeed.json"
+
+      - name: Create PR in spec repo
+        if: steps.compare.outputs.has_diff == 'true'
+        working-directory: spec-repo
+        env:
+          GH_TOKEN: ${{ secrets.OPENAPI_SPEC_SYNC_TOKEN }}
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create branch for PR
+          SHORT_SHA="${{ github.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          BRANCH_NAME="update-lightspeed-${{ github.ref_name }}-${SHORT_SHA}"
+          git checkout -b "$BRANCH_NAME"
+
+          # Add and commit changes
+          git add "lightspeed.json"
+
+          if [ "${{ steps.compare.outputs.is_new_file }}" == "true" ]; then
+            COMMIT_MSG="Add Lightspeed OpenAPI spec for ${{ github.ref_name }}"
+          else
+            COMMIT_MSG="Update Lightspeed OpenAPI spec for ${{ github.ref_name }}"
+          fi
+
+          git commit -m "$COMMIT_MSG
+
+          Synced from ${{ github.repository }}@${{ github.sha }}
+          Source branch: ${{ github.ref_name }}
+
+          Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+          # Push branch
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          PR_TITLE="[${{ github.ref_name }}] Update Lightspeed spec from merged commit"
+
+          # Get commit message
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [ -z "$COMMIT_MSG" ]; then
+            COMMIT_MSG="Manual workflow trigger or commit message unavailable"
+          fi
+
+          PR_BODY="## Summary
+          Automated OpenAPI spec sync from component repository merge.
+
+          **Source:** [${{ github.repository }}@\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+          **Branch:** \`${{ github.ref_name }}\`
+          **Component:** \`lightspeed\`
+          **Spec File:** \`lightspeed.json\`
+
+          ## Changes
+          $(if [ "${{ steps.compare.outputs.is_new_file }}" == "true" ]; then echo "- 🆕 New spec file created"; else echo "- 📝 Spec file updated with latest changes"; fi)
+
+          ## Source Commit
+          \`\`\`
+          ${COMMIT_MSG}
+          \`\`\`
+
+          ---
+          🤖 This PR was automatically generated by the OpenAPI spec sync workflow."
+
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base "${{ steps.branch_mapping.outputs.target_branch }}" \
+            --head "$BRANCH_NAME"
+
+          echo "✅ Created PR in spec repo"
+
+      - name: Report results
+        if: always()
+        run: |
+          if [ "${{ steps.compare.outputs.has_diff }}" == "true" ]; then
+            echo "📝 Spec sync completed - PR created in spec repo"
+          else
+            echo "✅ Spec sync completed - no changes needed"
+          fi


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-60402
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: claude-code
Generated by: <name of code assistant if applicable>

## Description
This PR adds automated OpenAPI spec synchronization to the aap-openapi-specs central repository. When changes are merged to main, stable-2.6, or stable-2.7 branches, the workflow automatically generates the OpenAPI specification, uploads it as an artifact, and compares it against the current spec in the central repository. If drift is detected, it creates a pull request in aap-openapi-specs with the updated spec, targeting the appropriate branch (main → devel, stable-2.6 → stable-2.6, stable-2.7 → stable-2.7). This automation ensures that the central OpenAPI spec repository stays synchronized with the latest API changes from this service, eliminating the need for manual spec updates and reducing the risk of the specs falling out of sync. The workflow uses the OPENAPI_SPEC_SYNC_TOKEN secret to authenticate with the central repository and can also be triggered manually via workflow dispatch for testing purposes.

## Testing
This is actually quite difficult to test without fundamentally changing workflow itself since we only want this workflow to run when code is merged into a specific branch (main/stable-2.6/stable-2.7)


Here's an example of the workflow running successfully (with a hard coded change to the spec): https://github.com/ansible/ansible-ai-connect-service/actions/runs/21634216325 and here's the resulting PR: https://github.com/ansible-automation-platform/aap-openapi-specs/pull/41

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.6` - Backport to stable-2.6 branch

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
