### PR TITLE
AAP-65247 - fix: add allow_null=True to organization field in UserResponseSerializer

### DIFF
--- a/ansible_ai_connect/users/serializers.py
+++ b/ansible_ai_connect/users/serializers.py
@@ -43,7 +43,7 @@ class UserResponseSerializer(serializers.Serializer):
     family_name = serializers.CharField(required=False)
     given_name = serializers.CharField(required=False)
     org_telemetry_opt_out = serializers.BooleanField(required=False)
-    organization = OrganizationSerializer(required=False)
+    organization = OrganizationSerializer(required=False, allow_null=True)
     rh_org_has_subscription = serializers.BooleanField(read_only=True)
     rh_user_has_seat = serializers.BooleanField(read_only=True)
     rh_user_is_org_admin = serializers.BooleanField(required=False)

--- a/ansible_ai_connect/users/tests/test_serializers.py
+++ b/ansible_ai_connect/users/tests/test_serializers.py
@@ -1,0 +1,66 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for UserResponseSerializer, verifying nullable organization handling.
+"""
+
+from unittest.mock import Mock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from ansible_ai_connect.users.serializers import UserResponseSerializer
+
+
+class UserResponseSerializerTest(TestCase):
+    def _make_user(self, organization=None):
+        """Create a mock user with the fields required by UserResponseSerializer."""
+        user = Mock()
+        user.email = "test@example.com"
+        user.external_username = "testuser"
+        user.family_name = "Doe"
+        user.given_name = "John"
+        user.organization = organization
+        user.rh_org_has_subscription = False
+        user.rh_user_has_seat = False
+        user.rh_user_is_org_admin = False
+        user.username = "testuser"
+        user.userplan_set = []
+        user.uuid = uuid4()
+        return user
+
+    def test_serializer_with_null_organization(self):
+        """Verify that a user with organization=None serializes correctly."""
+        user = self._make_user(organization=None)
+        serializer = UserResponseSerializer(user)
+        data = serializer.data
+
+        self.assertIn("organization", data)
+        self.assertIsNone(data["organization"])
+        self.assertEqual(data["username"], "testuser")
+
+    def test_serializer_with_valid_organization(self):
+        """Verify that a user with a valid organization serializes correctly."""
+        org = Mock()
+        org.id = 12345
+        org.telemetry_opt_out = False
+
+        user = self._make_user(organization=org)
+        serializer = UserResponseSerializer(user)
+        data = serializer.data
+
+        self.assertIn("organization", data)
+        self.assertIsNotNone(data["organization"])
+        self.assertEqual(data["organization"]["id"], 12345)

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -2310,7 +2310,12 @@
                         "type": "boolean"
                     },
                     "organization": {
-                        "$ref": "#/components/schemas/Organization"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Organization"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "rh_org_has_subscription": {
                         "type": "boolean",

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1606,7 +1606,9 @@ components:
         org_telemetry_opt_out:
           type: boolean
         organization:
-          $ref: '#/components/schemas/Organization'
+          allOf:
+          - $ref: '#/components/schemas/Organization'
+          nullable: true
         rh_org_has_subscription:
           type: boolean
           readOnly: true


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-65247
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Claude-4.6-opus
Generated by: <name of code assistant if applicable>

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
The UserResponseSerializer in ansible_ai_connect/users/serializers.py defines the organization field as OrganizationSerializer(required=False) but does not include allow_null=True. The /api/v1/me/ endpoint can return "organization": null for users without an associated Red Hat organization (e.g., gateway admin users), but the generated OpenAPI spec does not mark the field as nullable. This causes downstream generated API clients (such as the ATF Lightspeed client) to crash when parsing the response.


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2.  Run wisdom-manage spectacular --file /tmp/test-schema.yaml
3. Verify the generated spec includes nullable: true for the organization field under UserResponse:

```
organization:
allOf:
- $ref: '#/components/schemas/Organization'
nullable: true

```
4. Previously (without allow_null=True), the field was generated as a non-nullable $ref which caused clients to crash on null responses.
5. Run tests available in `test_serializers.py`

Output:
```

System check identified no issues (0 silenced).
test_serializer_with_null_organization (ansible_ai_connect.users.tests.test_serializers.UserResponseSerializerTest.test_serializer_with_null_organization)
Verify that a user with organization=None serializes correctly. ... ok
test_serializer_with_valid_organization (ansible_ai_connect.users.tests.test_serializers.UserResponseSerializerTest.test_serializer_with_valid_organization)
Verify that a user with a valid organization serializes correctly. ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.007s
```


## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [ ] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:


Depends-On: https://github.com/ansible/ansible-ai-connect-service/pull/1869
