### PR TITLE
Add IPv6 listen directive to nginx to fix 503s on IPv6/dualstack clusters

### DIFF
--- a/tools/configs/nginx-wisdom.conf
+++ b/tools/configs/nginx-wisdom.conf
@@ -9,6 +9,7 @@ upstream daphne {
 
 server {
     listen 8000 default_server;
+    listen [::]:8000 default_server;
     server_name _;
 
     location /static/ {


### PR DESCRIPTION


<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-71404
<!-- This PR does not need a corresponding Jira item. -->

Assisted-by: Claude (Anthropic)
  Generated by: N/A

  ## Description

  The `lightspeed-rhel9` container's nginx only binds IPv4 (`listen 8000 default_server`). On IPv6-only and dualstack clusters, traffic arrives on an IPv6 address and nginx refuses the connection, causing the gateway to return 503 for all lightspeed API endpoints.

  This adds `listen [::]:8000 default_server` so nginx accepts connections on both IPv4 and IPv6. IPv4 behavior is unchanged.

  Related operator-side IPv6 fix: ansible/ansible-ai-connect-operator#720

  ## Testing

  ### Steps to test
  1. Pull down the PR
  2. Build the container image: `podman build -t lightspeed-test -f wisdom-service.Containerfile .`
  3. Deploy to an IPv6 or dualstack cluster
  4. Verify lightspeed API endpoints return 200 (not 503) through the gateway

  ### Scenarios tested
  - Reproduced the 503 on the actual failing pipeline cluster (`aap-ipv6-dual-dev.ocp4.testing.ansible.com`) by creating a sandbox from the Jenkins pipeline configuration
  - Applied the fix via ConfigMap mount on the running deployment without rebuilding the image
  - Restarted the gateway to clear Envoy's cached unhealthy upstream state
  - Ran the full ATF lightspeed test suite (22 tests) against the cluster — all passed (previously all returned 503)
  - Verified on a local kind IPv6-only cluster that nginx accepts connections on both protocols after the fix
  - Confirmed IPv4 loopback (`127.0.0.1:8000`) continues to work alongside IPv6 (`[::1]:8000`)

  ## Type of Change
  - [x] Bug fix (non-breaking change fixing an issue)
  - [ ] New feature (non-breaking change adding functionality)
  - [ ] Breaking change (fix or feature causing existing functionality to break)
  - [ ] Security fix
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] CI/CD update

  ### Backport Justification

  All lightspeed tests on the IPv6 dualstack/singlestack CI pipelines have been failing for 13-15+ consecutive builds. The operator-side fix (ansible/ansible-ai-connect-operator#720) was already backported to 2.6 but only addressed the chatbot templates — the model service nginx was never fixed.

  ## Production deployment
  - [x] This code change is ready for production on its own
  - [ ] This code change requires the following considerations before going to production: