### PR TITLE
Fix OpenAPI spec: add OAuth2 authorizationCode flow configuration

### DIFF
--- a/ansible_ai_connect/main/settings/development.py
+++ b/ansible_ai_connect/main/settings/development.py
@@ -51,6 +51,24 @@ if DEBUG:
         "POSTPROCESSING_HOOKS": [
             "ansible_base.api_documentation.postprocessing_hooks.add_x_ai_description",
         ],
+        "APPEND_COMPONENTS": {
+            "securitySchemes": {
+                "oauth2": {
+                    "type": "oauth2",
+                    "flows": {
+                        "authorizationCode": {
+                            "authorizationUrl": "/o/authorize/",
+                            "tokenUrl": "/o/token/",
+                            "scopes": {
+                                "read": "Read basic user information",
+                                "write": "Request Ansible content suggestions",
+                                "delete": "Delete resources",
+                            },
+                        }
+                    },
+                }
+            }
+        },
     }
 
     # social_django does not process auth exceptions when DEBUG=True by default.

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -2376,7 +2376,17 @@
             },
             "oauth2": {
                 "type": "oauth2",
-                "flows": {}
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "/o/authorize/",
+                        "tokenUrl": "/o/token/",
+                        "scopes": {
+                            "read": "Read basic user information",
+                            "write": "Request Ansible content suggestions",
+                            "delete": "Delete resources"
+                        }
+                    }
+                }
             }
         }
     },

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -1651,7 +1651,14 @@ components:
       name: sessionid
     oauth2:
       type: oauth2
-      flows: {}
+      flows:
+        authorizationCode:
+          authorizationUrl: /o/authorize/
+          tokenUrl: /o/token/
+          scopes:
+            read: Read basic user information
+            write: Request Ansible content suggestions
+            delete: Delete resources
 servers:
 - url: https://lightspeed-instance/api/v1
   description: Direct access to a Lightspeed instance


### PR DESCRIPTION
## Summary

Fixes the OpenAPI schema generation to include proper OAuth2 authorizationCode flow configuration instead of invalid empty flows `{}`.

## Problem

The generated OpenAPI schema had an invalid oauth2 security scheme with empty flows:
```yaml
oauth2:
  type: oauth2
  flows: {}
```

This violates OpenAPI 3.0 specification and causes:
- ❌ ZAP (OWASP ZAP Proxy) OpenAPI parser to fail with `NullPointerException`
- ❌ Security scanning (rapidast DAST) failures since April 16, 2026
- ❌ Invalid API documentation

## Root Cause

- `drf-spectacular` auto-generates the oauth2 security scheme from `django-oauth-toolkit` authentication classes
- Without explicit configuration, it generates with empty `flows: {}`
- ZAP's OpenAPI add-on v54 (released April 14, 2026) added stricter validation

## Solution

Add `APPEND_COMPONENTS` to `SPECTACULAR_SETTINGS` in `development.py`:

```python
"APPEND_COMPONENTS": {
    "securitySchemes": {
        "oauth2": {
            "type": "oauth2",
            "flows": {
                "authorizationCode": {
                    "authorizationUrl": "/o/authorize/",
                    "tokenUrl": "/o/token/",
                    "scopes": {
                        "read": "Read basic user information",
                        "write": "Request Ansible content suggestions",
                        "delete": "Delete resources",
                    },
                }
            },
        }
    }
}
```

## Testing

After merging, regenerate the OpenAPI schema:
```bash
make update-openapi-schema
```

Then update the spec file in `ansible-wisdom-testing` repo:
```bash
cp tools/openapi-schema/ansible-ai-connect-service.yaml \
   ../ansible-wisdom-testing/spec-file/ansible_lightspeed_service.yaml
```

## Verification

✅ OpenAPI 3.0 validation passes
✅ ZAP can parse the schema without errors
✅ OAuth2 flow properly documents the existing authentication endpoints

## Related

- UUID field defaults were already fixed in commit 1a425b33
- Related to ansible-wisdom-testing rapidast scan failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/schema-only change that doesn’t alter runtime auth behavior; main risk is consumers relying on the previously invalid/empty OAuth2 flow definition.
> 
> **Overview**
> Fixes OpenAPI schema generation to emit a valid OAuth2 security scheme by **appending an `authorizationCode` flow** (authorize/token URLs plus `read`/`write`/`delete` scopes) via `SPECTACULAR_SETTINGS` in `development.py`.
> 
> Regenerates the checked-in OpenAPI artifacts (`ansible-ai-connect-service.json`/`.yaml`) so `components.securitySchemes.oauth2.flows` is no longer `{}` and can be consumed by stricter OpenAPI parsers/scanners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243be886caa30d22e47204d2ff53e38d7bd339f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->