### PR TITLE
Fix ValueError: Chunk too big

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -349,7 +349,14 @@ class HttpStreamingChatBotPipeline(
         # Create connector with proper SSL handling
         connector = self._get_aiohttp_connector(verify_ssl=self.config.verify_ssl)
 
-        async with aiohttp.ClientSession(raise_for_status=True, connector=connector) as session:
+        # aiohttp defaults to read_bufsize=64KB, which caps a single SSE line
+        # at 128KB (2x buffer). Large tool_call/tool_result payloads from the
+        # chatbot backend can exceed that, raising "ValueError: Chunk too big".
+        # 1MB buffer allows single SSE lines up to 2MB.
+        sse_read_bufsize = 1024 * 1024  # 1 MB
+        async with aiohttp.ClientSession(
+            raise_for_status=True, connector=connector, read_bufsize=sse_read_bufsize
+        ) as session:
             headers = {
                 "Content-Type": "application/json",
                 "Accept": "application/json,text/event-stream",
@@ -404,79 +411,99 @@ class HttpStreamingChatBotPipeline(
                     ev.modelName = params.model_id
                     ev.no_tools = params.no_tools
 
-                    async for chunk in response.content:
-                        try:
-                            if chunk:
-                                chunk_string = chunk.decode("utf-8").strip()
-                                if chunk_string and chunk_string.startswith("data: "):
-                                    o = json.loads(chunk_string[len("data: ") :])
-                                    event = o.get("event")
-                                    if event == "error":
-                                        default_data = {
-                                            "response": "(not provided)",
-                                            "cause": "(not provided)",
-                                        }
-                                        data = o.get("data", default_data)
-                                        logger.error(
-                                            "An error received in chat streaming content:"
-                                            + " response="
-                                            + str(data.get("response"))
-                                            + ", cause="
-                                            + str(data.get("cause"))
-                                        )
-                                    elif event == "start":
-                                        ev.phase = event
-                                        default_data = {
-                                            "conversation_id": conversation_id,
-                                        }
-                                        data = o.get("data", default_data)
-                                        conversation_id = data.get("conversation_id")
-                                        ev.conversation_id = conversation_id
-                                        self.send_schema1_event(ev)
-                                    elif event in ("tool_call", "tool_result"):
-                                        if not settings.CHATBOT_RETURN_TOOL_CALL:
-                                            # do not return tool_call event to final user response
-                                            # and send an empty token data instead
-                                            # include also the original tool_call/tool_response
-                                            data = o.get("data", {"id": 0})
-                                            chunk_id = data.get("id")
-                                            logger.debug(
-                                                "hide tool_call/tool_result from final result, "
-                                                "original chunk: %s",
-                                                chunk_string,
-                                            )
-                                            new_chunk_data = {
-                                                "event": "token",
-                                                "data": {"id": chunk_id, "token": ""},
-                                                "original": o,
+                    try:
+                        async for chunk in response.content:
+                            try:
+                                if chunk:
+                                    chunk_string = chunk.decode("utf-8").strip()
+                                    if chunk_string and chunk_string.startswith("data: "):
+                                        o = json.loads(chunk_string[len("data: ") :])
+                                        event = o.get("event")
+                                        if event == "error":
+                                            default_data = {
+                                                "response": "(not provided)",
+                                                "cause": "(not provided)",
                                             }
-                                            new_chunk_data_json = json.dumps(new_chunk_data)
-                                            chunk = (
-                                                b"data: "
-                                                + new_chunk_data_json.encode("utf-8")
-                                                + b"\n"
+                                            data = o.get("data", default_data)
+                                            logger.error(
+                                                "An error received in chat streaming content:"
+                                                + " response="
+                                                + str(data.get("response"))
+                                                + ", cause="
+                                                + str(data.get("cause"))
                                             )
-                                    elif event == "end":
-                                        ev.phase = event
-                                        default_data = {
-                                            "referenced_documents": [],
-                                            "truncated": False,
-                                        }
-                                        data = o.get("data", default_data)
-                                        referenced_documents = self._normalize_referenced_documents(
-                                            data.get("referenced_documents", [])
-                                        )
-                                        truncated = data.get("truncated", False)
-                                        ev.conversation_id = conversation_id
-                                        ev.chat_referenced_documents = (
-                                            referenced_documents
-                                        )  # type: ignore[assignment]
-                                        ev.chat_truncated = truncated
-                                        self.send_schema1_event(ev)
-                        except JSONDecodeError:
-                            pass
-                        logger.debug(chunk)
-                        yield chunk
+                                        elif event == "start":
+                                            ev.phase = event
+                                            default_data = {
+                                                "conversation_id": conversation_id,
+                                            }
+                                            data = o.get("data", default_data)
+                                            conversation_id = data.get("conversation_id")
+                                            ev.conversation_id = conversation_id
+                                            self.send_schema1_event(ev)
+                                        elif event in ("tool_call", "tool_result"):
+                                            if not settings.CHATBOT_RETURN_TOOL_CALL:
+                                                # do not return tool_call event to final user response
+                                                # and send an empty token data instead
+                                                # include also the original tool_call/tool_response
+                                                data = o.get("data", {"id": 0})
+                                                chunk_id = data.get("id")
+                                                logger.debug(
+                                                    "hide tool_call/tool_result from final result, "
+                                                    "original chunk: %s",
+                                                    chunk_string,
+                                                )
+                                                new_chunk_data = {
+                                                    "event": "token",
+                                                    "data": {"id": chunk_id, "token": ""},
+                                                    "original": o,
+                                                }
+                                                new_chunk_data_json = json.dumps(new_chunk_data)
+                                                chunk = (
+                                                    b"data: "
+                                                    + new_chunk_data_json.encode("utf-8")
+                                                    + b"\n"
+                                                )
+                                        elif event == "end":
+                                            ev.phase = event
+                                            default_data = {
+                                                "referenced_documents": [],
+                                                "truncated": False,
+                                            }
+                                            data = o.get("data", default_data)
+                                            referenced_documents = self._normalize_referenced_documents(
+                                                data.get("referenced_documents", [])
+                                            )
+                                            truncated = data.get("truncated", False)
+                                            ev.conversation_id = conversation_id
+                                            ev.chat_referenced_documents = (
+                                                referenced_documents
+                                            )  # type: ignore[assignment]
+                                            ev.chat_truncated = truncated
+                                            self.send_schema1_event(ev)
+                            except JSONDecodeError:
+                                pass
+                            logger.debug(chunk)
+                            yield chunk
+                    except ValueError as e:
+                        if "Chunk too big" in str(e):
+                            logger.error(
+                                "Chatbot response too large to process: %s", str(e)
+                            )
+                            error = {
+                                "event": "error",
+                                "data": {
+                                    "response": "The response was too large to process.",
+                                    "cause": "A chatbot response event exceeded"
+                                    " the maximum supported size.",
+                                },
+                            }
+                            yield (
+                                b"data: " + json.dumps(error).encode("utf-8") + b"\n"
+                            )
+                            return
+                        else:
+                            raise
                 else:
                     logging.error(
                         "Streaming query API returned status code="

--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -471,8 +471,10 @@ class HttpStreamingChatBotPipeline(
                                                 "truncated": False,
                                             }
                                             data = o.get("data", default_data)
-                                            referenced_documents = self._normalize_referenced_documents(
-                                                data.get("referenced_documents", [])
+                                            referenced_documents = (
+                                                self._normalize_referenced_documents(
+                                                    data.get("referenced_documents", [])
+                                                )
                                             )
                                             truncated = data.get("truncated", False)
                                             ev.conversation_id = conversation_id
@@ -486,10 +488,12 @@ class HttpStreamingChatBotPipeline(
                             logger.debug(chunk)
                             yield chunk
                     except ValueError as e:
+                        # aiohttp raises ValueError with this message when a
+                        # single line exceeds _high_water. There is no specific
+                        # exception type, so we match by message. If aiohttp
+                        # changes the wording, this will re-raise instead.
                         if "Chunk too big" in str(e):
-                            logger.error(
-                                "Chatbot response too large to process: %s", str(e)
-                            )
+                            logger.error("Chatbot response too large to process: %s", e)
                             error = {
                                 "event": "error",
                                 "data": {
@@ -498,9 +502,7 @@ class HttpStreamingChatBotPipeline(
                                     " the maximum supported size.",
                                 },
                             }
-                            yield (
-                                b"data: " + json.dumps(error).encode("utf-8") + b"\n"
-                            )
+                            yield (b"data: " + json.dumps(error).encode("utf-8") + b"\n")
                             return
                         else:
                             raise

--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -443,9 +443,9 @@ class HttpStreamingChatBotPipeline(
                                             self.send_schema1_event(ev)
                                         elif event in ("tool_call", "tool_result"):
                                             if not settings.CHATBOT_RETURN_TOOL_CALL:
-                                                # do not return tool_call event to final user response
-                                                # and send an empty token data instead
-                                                # include also the original tool_call/tool_response
+                                                # Hide tool_call/tool_result from
+                                                # final response; send empty token
+                                                # with original data attached.
                                                 data = o.get("data", {"id": 0})
                                                 chunk_id = data.get("id")
                                                 logger.debug(
@@ -497,12 +497,12 @@ class HttpStreamingChatBotPipeline(
                             error = {
                                 "event": "error",
                                 "data": {
-                                    "response": "The response was too large to process.",
-                                    "cause": "A chatbot response event exceeded"
-                                    " the maximum supported size.",
+                                    "response": "Unable to process chatbot response",
+                                    "cause": "The response exceeded the maximum"
+                                    " supported size. Please try again.",
                                 },
                             }
-                            yield (b"data: " + json.dumps(error).encode("utf-8") + b"\n")
+                            yield (b"data: " + json.dumps(error).encode("utf-8") + b"\n\n")
                             return
                         else:
                             raise

--- a/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_pipelines.py
@@ -547,11 +547,11 @@ class TestHttpStreamingChatBotPipeline(IsolatedAsyncioTestCase, WisdomLogAwareMi
         self.assertEqual(error_data["event"], "error")
         self.assertEqual(
             error_data["data"]["response"],
-            "The response was too large to process.",
+            "Unable to process chatbot response",
         )
         self.assertEqual(
             error_data["data"]["cause"],
-            "A chatbot response event exceeded the maximum supported size.",
+            "The response exceeded the maximum supported size. Please try again.",
         )
 
     @patch("aiohttp.ClientSession.post")

--- a/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_pipelines.py
@@ -157,6 +157,31 @@ class TestHttpStreamingChatBotPipeline(IsolatedAsyncioTestCase, WisdomLogAwareMi
             event=event,
         )
 
+    def get_return_value_with_error(self, stream_data_before_error, error):
+        """Return a mock whose async generator raises an exception mid-stream."""
+
+        class MyAsyncContextManager:
+            def __init__(self, stream_data, error, status=200):
+                self.stream_data = stream_data
+                self.error = error
+                self.status = status
+                self.reason = ""
+
+            async def my_async_generator(self):
+                for data in self.stream_data:
+                    s = json.dumps(data)
+                    yield (f"data: {s}\n\n".encode())
+                raise self.error
+
+            async def __aenter__(self):
+                self.content = self.my_async_generator()
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        return MyAsyncContextManager(stream_data_before_error, error)
+
     def send_event(self, ev):
         self.call_counter += 1
         self.assertEqual(ev.conversation_id, "92766ddd-dfc8-4830-b269-7a4b3dbc7c3f")
@@ -498,6 +523,51 @@ class TestHttpStreamingChatBotPipeline(IsolatedAsyncioTestCase, WisdomLogAwareMi
                 # Reset mocks for next iteration
                 mock_tcp_connector.reset_mock()
                 mock_post.reset_mock()
+
+    @patch("aiohttp.ClientSession.post")
+    async def test_async_invoke_chunk_too_big_yields_error_event(self, mock_post):
+        """Test that ValueError 'Chunk too big' yields an SSE error event."""
+        stream_data_before_error = [
+            {"event": "start", "data": {"conversation_id": "92766ddd-dfc8-4830-b269-7a4b3dbc7c3f"}},
+            {"event": "token", "data": {"id": 0, "token": "Hello"}},
+        ]
+        mock_post.return_value = self.get_return_value_with_error(
+            stream_data_before_error, ValueError("Chunk too big")
+        )
+
+        chunks = []
+        async for chunk in self.pipeline.async_invoke(self.get_params()):
+            chunks.append(chunk.decode("utf-8"))
+
+        # Should have: start, token, and the error event
+        self.assertEqual(len(chunks), 3)
+        error_chunk = chunks[-1]
+        self.assertTrue(error_chunk.startswith("data: "))
+        error_data = json.loads(error_chunk[len("data: ") :])
+        self.assertEqual(error_data["event"], "error")
+        self.assertEqual(
+            error_data["data"]["response"],
+            "The response was too large to process.",
+        )
+        self.assertEqual(
+            error_data["data"]["cause"],
+            "A chatbot response event exceeded the maximum supported size.",
+        )
+
+    @patch("aiohttp.ClientSession.post")
+    async def test_async_invoke_other_value_error_is_reraised(self, mock_post):
+        """Test that a ValueError other than 'Chunk too big' is re-raised."""
+        stream_data_before_error = [
+            {"event": "start", "data": {"conversation_id": "92766ddd-dfc8-4830-b269-7a4b3dbc7c3f"}},
+        ]
+        mock_post.return_value = self.get_return_value_with_error(
+            stream_data_before_error, ValueError("something else")
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            async for _ in self.pipeline.async_invoke(self.get_params()):
+                pass
+        self.assertIn("something else", str(ctx.exception))
 
 
 class TestHttpStreamingChatBotPipelineNormalizeReferencedDocuments(

--- a/ansible_ai_connect/main/templates/chatbot/index.html
+++ b/ansible_ai_connect/main/templates/chatbot/index.html
@@ -9,7 +9,7 @@
       content="{{bot_name}}"
     />
     <title>{{bot_name}}</title>
-    <script type="module" crossorigin src="/static/chatbot/index-XIUBsxbo.js"></script>
+    <script type="module" crossorigin src="/static/chatbot/index-BNfZq7Pw.js"></script>
     <link rel="stylesheet" crossorigin href="/static/chatbot/index-BKe7a7oO.css">
   </head>
   <body>

--- a/ansible_ai_connect_chatbot/package-lock.json
+++ b/ansible_ai_connect_chatbot/package-lock.json
@@ -18,7 +18,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "vite": "6.4.2",
+        "vite": "^6.4.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -1971,6 +1971,14 @@
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3371,11 +3379,14 @@
       "dev": true
     },
     "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dset": {
       "version": "3.1.4",

--- a/ansible_ai_connect_chatbot/package.json
+++ b/ansible_ai_connect_chatbot/package.json
@@ -37,6 +37,9 @@
       "last 1 safari version"
     ]
   },
+  "overrides": {
+    "dompurify": ">=3.4.0"
+  },
   "devDependencies": {
     "@eslint/compat": "^1.2.1",
     "@eslint/js": "^9.13.0",

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -910,9 +910,7 @@ test("Chat streaming error in streaming data", async () => {
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
   expect(textContent).toEqual(
-    "Bot returned an error: " +
-      'response="Oops, something went wrong during LLM invocation", ' +
-      "cause=\"Error code: 404 - {'detail': 'Not Found'}\"",
+    "Error code: 404 - {'detail': 'Not Found'}",
   );
 });
 

--- a/ansible_ai_connect_chatbot/src/App.test.tsx
+++ b/ansible_ai_connect_chatbot/src/App.test.tsx
@@ -909,9 +909,7 @@ test("Chat streaming error in streaming data", async () => {
   await sendMessage("error in stream");
   const alert = view.container.querySelector(".pf-v6-c-alert__description");
   const textContent = alert?.textContent;
-  expect(textContent).toEqual(
-    "Error code: 404 - {'detail': 'Not Found'}",
-  );
+  expect(textContent).toEqual("Error code: 404 - {'detail': 'Not Found'}");
 });
 
 test("Chat streaming error in status check", async () => {

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -573,10 +573,8 @@ export const useChatbot = () => {
               } else if (message.event === "error") {
                 const data = message.data;
                 setAlertMessage({
-                  title: "Error",
-                  message:
-                    `Bot returned an error: response="${data.response}", ` +
-                    `cause="${data.cause}"`,
+                  title: data.response,
+                  message: data.cause,
                   variant: "danger",
                 });
               } else if (


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-72084

  Assisted-by: Claude Code (Claude Opus 4.6)

  Description

  Fix `ValueError: Chunk too big` when the chatbot backend returns large SSE events (>128KB), such as tool_call/tool_result payloads containing full playbook content or job output from MCP tools.

  `aiohttp.ClientSession` defaults to `read_bufsize=65536` (64KB), which sets an internal _high_water of 128KB. When iterating async for chunk in response.content:, aiohttp uses readline() under the hood — if any single SSE data: line exceeds 128KB, it raises `ValueError: Chunk too big`. This was unhandled, so the stream died silently with no feedback to the user.

  Changes:
  - Increase aiohttp's read_bufsize from the default 64KB to 1MB, allowing single SSE lines up to 2MB
  - Add graceful error handling: if a response still exceeds the limit, the user receives a clear SSE error event instead of a silent stream failure, and the upstream connection is closed to stop wasting LLM resources
  - Add tests for both the error recovery path and the re-raise path for unrelated ValueErrors

  Closes https://github.com/ansible/ansible-ai-connect-service/issues/2000

 npm audit fix (dompurify):
  - dompurify<=3.3.3 has 7 moderate-severity XSS advisories
  - Transitive dependency via @patternfly/chatbot -> monaco-editor -> dompurify@3.1.7
  - npm's suggested fix requires downgrading @patternfly/chatbot to 6.4.1 (breaking change)
  - Instead, added "overrides": { "dompurify": ">=3.4.0" } in package.json to force the patched version without breaking the chatbot dependency



  Testing

  Steps to test

  1. Pull down the PR
  2. Start the service via podman compose -f tools/docker-compose/compose.yaml --env-file ./.env up
  3. Start a mock SSE server on port 8321 that returns a >128KB single data: line (to verify the buffer increase works) and a >2MB line (to verify the error handling works)
  4. Create a test token: `podman exec docker-compose-django-1 wisdom-manage createtoken --create-user --token-name mytest --username testuser --organization-id 11009103 --groups test`
  5. Send a streaming chat request: `curl -X POST 'http://127.0.0.1:8000/api/v1/ai/streaming_chat/' -H 'Authorization: Bearer mytest' -H 'Content-Type: application/json' -d '{"query": "troubleshoot this playbook"}'`
  6. Verify 200KB payloads stream successfully (previously crashed)
  7. Verify >2MB payloads return a clear SSE error event: {"event": "error", "data": {"response": "The response was too large to process.", ...}}
  8. Run unit tests: `podman exec docker-compose-django-1 bash -c "MOCK_WCA_SECRETS_MANAGER=False wisdom-manage test ansible_ai_connect.ai.api.model_pipelines.http.tests.test_pipelines"` — all 20 tests pass

  Scenarios tested

  - 200KB SSE event (previously crashed with ValueError) — now streams successfully
  - ~2MB SSE event (at the new limit boundary) — streams successfully
  - 3MB SSE event (exceeds new limit) — user receives a clear SSE error event, upstream connection closed
  - All 18 existing unit tests continue to pass
  - 2 new unit tests verify error handling and re-raise behavior

  Type of Change

  - Bug fix (non-breaking change fixing an issue)

  Backport Justification

  - Production bug affecting AAP 2.6 users streaming chat responses with large playbooks (~587+ lines)
  - The stream fails silently with no user feedback, and the LLM continues generating on the backend wasting resources

  Production deployment

  - This code change is ready for production on its own
