### PR TITLE
Fix OpenAPI spec: optOut example type mismatch (string → boolean)

### DIFF
--- a/ansible_ai_connect/ai/api/openapi.py
+++ b/ansible_ai_connect/ai/api/openapi.py
@@ -24,3 +24,49 @@ def preprocessing_filter_spec(endpoints):
             continue
         filtered.append((path, path_regex, method, callback))
     return filtered
+
+
+def postprocessing_fix_additional_properties(result, generator, request, public):
+    """
+    Fix empty additionalProperties objects that cause ZAP parser failures.
+
+    drf-spectacular generates 'additionalProperties: {}' for DictField without
+    a child parameter. This empty object is ambiguous and causes some OpenAPI
+    parsers (including ZAP) to fail with NullPointerException.
+
+    This hook replaces 'additionalProperties: {}' with 'additionalProperties: true'
+    which correctly represents "allow any additional properties".
+    """
+
+    def fix_schema(schema):
+        """Recursively fix additionalProperties in schema objects."""
+        if not isinstance(schema, dict):
+            return schema
+
+        # Fix additionalProperties: {} → additionalProperties: true
+        if "additionalProperties" in schema:
+            if schema["additionalProperties"] == {}:
+                schema["additionalProperties"] = True
+
+        # Recursively process nested objects
+        for key, value in schema.items():
+            if isinstance(value, dict):
+                fix_schema(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        fix_schema(item)
+
+        return schema
+
+    # Fix in components/schemas
+    if "components" in result and "schemas" in result["components"]:
+        for schema_name, schema_def in result["components"]["schemas"].items():
+            fix_schema(schema_def)
+
+    # Fix in paths (inline schemas)
+    if "paths" in result:
+        for path_def in result["paths"].values():
+            fix_schema(path_def)
+
+    return result

--- a/ansible_ai_connect/ai/api/serializers.py
+++ b/ansible_ai_connect/ai/api/serializers.py
@@ -828,7 +828,7 @@ class WcaModelIdRequestSerializer(serializers.Serializer):
             summary="Request Telemetry settings",
             description="A valid request to set the Telemetry settings.",
             value={
-                "optOut": "true",
+                "optOut": True,
             },
             request_only=True,
             response_only=False,

--- a/ansible_ai_connect/ai/api/tests/test_openapi.py
+++ b/ansible_ai_connect/ai/api/tests/test_openapi.py
@@ -12,7 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from ansible_ai_connect.ai.api.openapi import preprocessing_filter_spec
+from ansible_ai_connect.ai.api.openapi import (
+    postprocessing_fix_additional_properties,
+    preprocessing_filter_spec,
+)
 from ansible_ai_connect.test_utils import WisdomTestCase
 
 
@@ -27,3 +30,156 @@ class TestOpenAPI(WisdomTestCase):
         filtered_endpoints = preprocessing_filter_spec(endpoints)
         self.assertEqual(len(filtered_endpoints), 1)
         self.assertEqual(filtered_endpoints[0][0], "/api/v1/me/")
+
+    def test_postprocessing_fix_empty_additional_properties(self):
+        """Test that empty additionalProperties {} is replaced with true."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "TestSchema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                        },
+                        "additionalProperties": {},  # Empty object - should be fixed
+                    }
+                }
+            }
+        }
+
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        self.assertEqual(
+            result["components"]["schemas"]["TestSchema"]["additionalProperties"],
+            True,
+        )
+
+    def test_postprocessing_preserves_valid_additional_properties(self):
+        """Test that valid additionalProperties values are preserved."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "SchemaWithTrue": {
+                        "type": "object",
+                        "additionalProperties": True,  # Already correct
+                    },
+                    "SchemaWithFalse": {
+                        "type": "object",
+                        "additionalProperties": False,  # Explicit false
+                    },
+                    "SchemaWithSchema": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},  # Schema definition
+                    },
+                }
+            }
+        }
+
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        # These should remain unchanged
+        self.assertEqual(
+            result["components"]["schemas"]["SchemaWithTrue"]["additionalProperties"],
+            True,
+        )
+        self.assertEqual(
+            result["components"]["schemas"]["SchemaWithFalse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            result["components"]["schemas"]["SchemaWithSchema"]["additionalProperties"],
+            {"type": "string"},
+        )
+
+    def test_postprocessing_fixes_nested_schemas(self):
+        """Test that nested schemas with empty additionalProperties are fixed."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ParentSchema": {
+                        "type": "object",
+                        "properties": {
+                            "child": {
+                                "type": "object",
+                                "additionalProperties": {},  # Nested empty object
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        self.assertEqual(
+            result["components"]["schemas"]["ParentSchema"]["properties"]["child"][
+                "additionalProperties"
+            ],
+            True,
+        )
+
+    def test_postprocessing_fixes_inline_path_schemas(self):
+        """Test that inline schemas in paths are fixed."""
+        spec = {
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "additionalProperties": {},
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        self.assertEqual(
+            result["paths"]["/test"]["get"]["responses"]["200"]["content"]["application/json"][
+                "schema"
+            ]["additionalProperties"],
+            True,
+        )
+
+    def test_postprocessing_handles_arrays_with_schemas(self):
+        """Test that schemas in arrays are processed."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "ArraySchema": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "object",
+                                "additionalProperties": {},  # In array
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        self.assertEqual(
+            result["components"]["schemas"]["ArraySchema"]["items"][0]["additionalProperties"],
+            True,
+        )
+
+    def test_postprocessing_handles_missing_components(self):
+        """Test that specs without components are handled gracefully."""
+        spec = {"paths": {}}
+
+        # Should not raise an error
+        result = postprocessing_fix_additional_properties(spec, None, None, None)
+
+        self.assertEqual(result, spec)

--- a/ansible_ai_connect/main/settings/development.py
+++ b/ansible_ai_connect/main/settings/development.py
@@ -50,6 +50,7 @@ if DEBUG:
         ],
         "POSTPROCESSING_HOOKS": [
             "ansible_base.api_documentation.postprocessing_hooks.add_x_ai_description",
+            "ansible_ai_connect.ai.api.openapi.postprocessing_fix_additional_properties",
         ],
         "APPEND_COMPONENTS": {
             "securitySchemes": {

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -676,7 +676,7 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
-                                    "additionalProperties": {}
+                                    "additionalProperties": true
                                 },
                                 "examples": {
                                     "ExampleOutput": {
@@ -1381,7 +1381,7 @@
                     },
                     "additionalContext": {
                         "type": "object",
-                        "additionalProperties": {},
+                        "additionalProperties": true,
                         "title": "Additional Context",
                         "description": "Additional context for completion API"
                     }
@@ -1801,7 +1801,7 @@
                     },
                     "additionalContext": {
                         "type": "object",
-                        "additionalProperties": {},
+                        "additionalProperties": true,
                         "title": "inline suggestions",
                         "description": "Parameter use for the inline suggestions."
                     },

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -845,7 +845,7 @@
                             "examples": {
                                 "ValidExample": {
                                     "value": {
-                                        "optOut": "true"
+                                        "optOut": true
                                     },
                                     "summary": "Request Telemetry settings",
                                     "description": "A valid request to set the Telemetry settings."

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -432,7 +432,7 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: {}
+                additionalProperties: true
               examples:
                 ExampleOutput:
                   value:
@@ -887,7 +887,7 @@ components:
           description: Ansible file type (playbook/tasks_in_role/tasks)
         additionalContext:
           type: object
-          additionalProperties: {}
+          additionalProperties: true
           title: Additional Context
           description: Additional context for completion API
     CompletionRequest:
@@ -1201,7 +1201,7 @@ components:
             of the Ansible Role.
         additionalContext:
           type: object
-          additionalProperties: {}
+          additionalProperties: true
           title: inline suggestions
           description: Parameter use for the inline suggestions.
         fileTypes:

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -537,7 +537,7 @@ paths:
             examples:
               ValidExample:
                 value:
-                  optOut: 'true'
+                  optOut: true
                 summary: Request Telemetry settings
                 description: A valid request to set the Telemetry settings.
           application/x-www-form-urlencoded:


### PR DESCRIPTION
## Summary
Fixes OpenAPI spec generation issues that cause ZAP parser to fail with `NullPointerException` errors during RapiDAST security scans.

## Problems Fixed

### 1. optOut Example Type Mismatch (Initial fix)
The `TelemetrySettingsRequestSerializer` defined `optOut` as a `BooleanField`, but the `OpenApiExample` used `"true"` (string) instead of `True` (boolean).

**Fix**: Changed `"optOut": "true"` → `"optOut": True` in `serializers.py:831`

### 2. Empty additionalProperties (Root cause)
drf-spectacular generates `additionalProperties: {}` (empty object) for `DictField` without a `child` parameter. This empty object is ambiguous in the OpenAPI spec and causes ZAP to fail with:

```
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "pk" is null
```

**Fix**: Added `postprocessing_fix_additional_properties` hook that recursively replaces `additionalProperties: {}` with `additionalProperties: true`.

## Changes

### Code
- `ansible_ai_connect/ai/api/serializers.py` - Fixed optOut example value
- `ansible_ai_connect/ai/api/openapi.py` - Added postprocessing hook
- `ansible_ai_connect/main/settings/development.py` - Registered postprocessing hook

### Generated Schema
- `tools/openapi-schema/ansible-ai-connect-service.yaml`
- `tools/openapi-schema/ansible-ai-connect-service.json`

Fixed 3 occurrences of `additionalProperties: {}`:
- Health check response (line 435)
- `CompletionRequest.additionalContext` (line 890)
- `GenerationRoleRequest.additionalContext` (line 1204)

## Testing

✅ **Validated with openapi-spec-validator**
✅ **Validated with custom type-checking script**
✅ **Tested with ZAP 2.17.0** - Successfully parses and imports 23 URLs (previously failed with NullPointerException)

### Before
```
Job openapi-import target: https://stage.ai.ansible.redhat.com/ error: 
Failed to parse OpenAPI definition.
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "pk" is null
Job openapi-import added 0 URLs
```

### After
```
✅ SUCCESS: ZAP parsed OpenAPI spec successfully!
Job openapi-import added 23 URLs
Automation plan succeeded!
```

## Related
- Fixes RapiDAST/ZAP scan failures in ansible-wisdom-testing repository
- Related to PR #2001 (OAuth2 flows fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes only affect OpenAPI schema generation and examples (plus dev-only `SPECTACULAR_SETTINGS`), with added unit coverage; no runtime API behavior is modified.
> 
> **Overview**
> Fixes OpenAPI spec generation issues that were breaking downstream parsers (e.g., ZAP) during security scanning.
> 
> Adds a drf-spectacular postprocessing hook (`postprocessing_fix_additional_properties`) to recursively replace ambiguous `additionalProperties: {}` with `additionalProperties: true`, registers it in development `SPECTACULAR_SETTINGS`, and adds targeted tests for nested/path/array cases.
> 
> Also corrects the `TelemetrySettingsRequestSerializer` OpenAPI example to use a boolean (`true`) instead of a string, and updates the checked-in generated OpenAPI JSON/YAML accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d8b7670424f60ec169667d14978892463f5184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->