### PR TITLE
AAP-70265: CSP config to fix issues found by DAST

### DIFF
--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -513,10 +513,11 @@ _OAUTH_SCHEMES = (
 
 # For loopback addresses (RFC 8252 - OAuth 2.0 for Native Apps)
 # These support dynamic ports as required by the spec
+# Port wildcard (:*) is required because OAuth clients bind to random available ports
 _LOOPBACK_PATTERNS = (
-    "http://127.0.0.1",
-    "http://[::1]",
-    "http://localhost",
+    "http://127.0.0.1:*",
+    "http://[::1]:*",
+    "http://localhost:*",
 )
 
 # OAuth provider origins from existing configuration

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import sys
+from urllib.parse import urlparse
 from importlib.resources import files
 from pathlib import Path
 from typing import cast
@@ -500,16 +501,39 @@ CSP_SELF = "'self'"
 CSP_DEFAULT_SRC = (CSP_SELF, "data:")
 CSP_CONNECT_SRC = CSP_SELF
 CSP_BASE_URI = (CSP_SELF,)
-CSP_FORM_ACTION = (
-    CSP_SELF,
-    "http:",
-    "https:",
+
+# OAuth2 redirect URI schemes and loopback support
+_OAUTH_SCHEMES = (
     "vscode:",
     "vscodium:",
     "vscode-insiders:",
     "code-oss:",
     "checode:",
 )
+
+# For loopback addresses (RFC 8252 - OAuth 2.0 for Native Apps)
+# These support dynamic ports as required by the spec
+_LOOPBACK_PATTERNS = (
+    "http://127.0.0.1",
+    "http://[::1]",
+    "http://localhost",
+)
+
+# OAuth provider origins from existing configuration
+# Extract origins from AAP_API_URL and SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
+_oauth_origins = []
+if AAP_API_URL:
+    parsed = urlparse(AAP_API_URL)
+    if parsed.scheme and parsed.netloc:
+        _oauth_origins.append(f"{parsed.scheme}://{parsed.netloc}")
+if SOCIAL_AUTH_OIDC_OIDC_ENDPOINT:
+    parsed = urlparse(SOCIAL_AUTH_OIDC_OIDC_ENDPOINT)
+    if parsed.scheme and parsed.netloc:
+        _oauth_origins.append(f"{parsed.scheme}://{parsed.netloc}")
+_OAUTH_ORIGINS = tuple(_oauth_origins)
+
+CSP_FORM_ACTION = (CSP_SELF,) + _OAUTH_SCHEMES + _LOOPBACK_PATTERNS + _OAUTH_ORIGINS
+
 CSP_FRAME_ANCESTORS = ("'none'",)
 CSP_INCLUDE_NONCE_IN = ["script-src-elem"]
 

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -28,10 +28,10 @@ import json
 import logging
 import os
 import sys
-from urllib.parse import urlparse
 from importlib.resources import files
 from pathlib import Path
 from typing import cast
+from urllib.parse import urlparse
 
 from ansible_ai_connect.main.settings.legacy import load_from_env_vars
 from ansible_ai_connect.main.settings.types import (

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -520,6 +520,7 @@ _LOOPBACK_PATTERNS = (
     "http://localhost:*",
 )
 
+
 # OAuth provider origins from existing configuration
 # Extract origins from AAP_API_URL and SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
 def _extract_oauth_origins(*urls):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -522,16 +522,18 @@ _LOOPBACK_PATTERNS = (
 
 # OAuth provider origins from existing configuration
 # Extract origins from AAP_API_URL and SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
-_oauth_origins = []
-if AAP_API_URL:
-    parsed = urlparse(AAP_API_URL)
-    if parsed.scheme and parsed.netloc:
-        _oauth_origins.append(f"{parsed.scheme}://{parsed.netloc}")
-if SOCIAL_AUTH_OIDC_OIDC_ENDPOINT:
-    parsed = urlparse(SOCIAL_AUTH_OIDC_OIDC_ENDPOINT)
-    if parsed.scheme and parsed.netloc:
-        _oauth_origins.append(f"{parsed.scheme}://{parsed.netloc}")
-_OAUTH_ORIGINS = tuple(_oauth_origins)
+def _extract_oauth_origins(*urls):
+    """Extract origins (scheme://netloc) from OAuth provider URLs."""
+    origins = []
+    for url in urls:
+        if url:
+            parsed = urlparse(url)
+            if parsed.scheme and parsed.netloc:
+                origins.append(f"{parsed.scheme}://{parsed.netloc}")
+    return tuple(origins)
+
+
+_OAUTH_ORIGINS = _extract_oauth_origins(AAP_API_URL, SOCIAL_AUTH_OIDC_OIDC_ENDPOINT)
 
 CSP_FORM_ACTION = (CSP_SELF,) + _OAUTH_SCHEMES + _LOOPBACK_PATTERNS + _OAUTH_ORIGINS
 

--- a/ansible_ai_connect/main/tests/test_urls.py
+++ b/ansible_ai_connect/main/tests/test_urls.py
@@ -65,35 +65,53 @@ class TestUrls(TestCase):
 
     def test_csp_oauth_origin_parsing(self):
         """Test URL parsing logic for OAuth origins in CSP configuration"""
-        from urllib.parse import urlparse
+        from ansible_ai_connect.main.settings.base import _extract_oauth_origins
 
-        # Test cases for AAP_API_URL and OIDC endpoint parsing
-        test_cases = [
-            ("https://aap.example.com:8443", "https://aap.example.com:8443"),
-            ("https://aap.example.com:8443/api/v2", "https://aap.example.com:8443"),
-            ("http://localhost:8080/api", "http://localhost:8080"),
-            ("https://sso.redhat.com/auth/realms/test", "https://sso.redhat.com"),
-            ("https://sso.redhat.com", "https://sso.redhat.com"),
-        ]
+        # Test single URL
+        result = _extract_oauth_origins("https://aap.example.com:8443/api/v2")
+        self.assertEqual(result, ("https://aap.example.com:8443",))
 
-        for url, expected_origin in test_cases:
-            with self.subTest(url=url):
-                parsed = urlparse(url)
-                if parsed.scheme and parsed.netloc:
-                    result = f"{parsed.scheme}://{parsed.netloc}"
-                    self.assertEqual(
-                        result,
-                        expected_origin,
-                        f"URL {url} should parse to origin {expected_origin}",
-                    )
+        # Test multiple URLs
+        result = _extract_oauth_origins(
+            "https://aap.example.com:8443",
+            "https://sso.redhat.com/auth/realms/test",
+        )
+        self.assertEqual(
+            result,
+            ("https://aap.example.com:8443", "https://sso.redhat.com"),
+        )
 
-        # Test that netloc preserves ports (not hostname)
-        parsed = urlparse("https://aap.example.com:9080")
-        self.assertEqual(parsed.netloc, "aap.example.com:9080")
-        self.assertEqual(parsed.hostname, "aap.example.com")
-        # We should use netloc to preserve the port
-        origin_with_netloc = f"{parsed.scheme}://{parsed.netloc}"
-        self.assertEqual(origin_with_netloc, "https://aap.example.com:9080")
+        # Test with None values (should be skipped)
+        result = _extract_oauth_origins(None, "https://sso.redhat.com")
+        self.assertEqual(result, ("https://sso.redhat.com",))
+
+        # Test with all None values
+        result = _extract_oauth_origins(None, None)
+        self.assertEqual(result, ())
+
+        # Test with empty string (should be skipped)
+        result = _extract_oauth_origins("", "https://sso.redhat.com")
+        self.assertEqual(result, ("https://sso.redhat.com",))
+
+        # Test with localhost and port
+        result = _extract_oauth_origins("http://localhost:8080/api")
+        self.assertEqual(result, ("http://localhost:8080",))
+
+        # Test that ports are preserved (netloc, not hostname)
+        result = _extract_oauth_origins("https://aap.example.com:9080")
+        self.assertEqual(result, ("https://aap.example.com:9080",))
+
+        # Test standard ports (no explicit port in URL)
+        result = _extract_oauth_origins("https://sso.redhat.com/path")
+        self.assertEqual(result, ("https://sso.redhat.com",))
+
+        # Test invalid URL (no scheme)
+        result = _extract_oauth_origins("example.com")
+        self.assertEqual(result, ())
+
+        # Test URL with only scheme (no netloc)
+        result = _extract_oauth_origins("http://")
+        self.assertEqual(result, ())
 
     def test_telemetry_patterns(self):
         api_versions = settings.REST_FRAMEWORK["ALLOWED_VERSIONS"]

--- a/ansible_ai_connect/main/tests/test_urls.py
+++ b/ansible_ai_connect/main/tests/test_urls.py
@@ -51,7 +51,10 @@ class TestUrls(TestCase):
         self.assertIn("base-uri 'self'", csp_headers)
         self.assertIn("form-action 'self'", csp_headers)
         self.assertIn("vscode:", csp_headers)
-        self.assertIn("http://127.0.0.1", csp_headers)
+        # Check loopback patterns with port wildcards for dynamic OAuth ports
+        self.assertIn("http://127.0.0.1:*", csp_headers)
+        self.assertIn("http://[::1]:*", csp_headers)
+        self.assertIn("http://localhost:*", csp_headers)
         # Ensure no wildcard schemes that would allow any http/https URL
         # Check for both space and semicolon separators
         self.assertNotIn("http: ", csp_headers)
@@ -59,6 +62,38 @@ class TestUrls(TestCase):
         self.assertNotIn("https: ", csp_headers)
         self.assertNotIn("https:;", csp_headers)
         self.assertIn("frame-ancestors 'none'", csp_headers)
+
+    def test_csp_oauth_origin_parsing(self):
+        """Test URL parsing logic for OAuth origins in CSP configuration"""
+        from urllib.parse import urlparse
+
+        # Test cases for AAP_API_URL and OIDC endpoint parsing
+        test_cases = [
+            ("https://aap.example.com:8443", "https://aap.example.com:8443"),
+            ("https://aap.example.com:8443/api/v2", "https://aap.example.com:8443"),
+            ("http://localhost:8080/api", "http://localhost:8080"),
+            ("https://sso.redhat.com/auth/realms/test", "https://sso.redhat.com"),
+            ("https://sso.redhat.com", "https://sso.redhat.com"),
+        ]
+
+        for url, expected_origin in test_cases:
+            with self.subTest(url=url):
+                parsed = urlparse(url)
+                if parsed.scheme and parsed.netloc:
+                    result = f"{parsed.scheme}://{parsed.netloc}"
+                    self.assertEqual(
+                        result,
+                        expected_origin,
+                        f"URL {url} should parse to origin {expected_origin}",
+                    )
+
+        # Test that netloc preserves ports (not hostname)
+        parsed = urlparse("https://aap.example.com:9080")
+        self.assertEqual(parsed.netloc, "aap.example.com:9080")
+        self.assertEqual(parsed.hostname, "aap.example.com")
+        # We should use netloc to preserve the port
+        origin_with_netloc = f"{parsed.scheme}://{parsed.netloc}"
+        self.assertEqual(origin_with_netloc, "https://aap.example.com:9080")
 
     def test_telemetry_patterns(self):
         api_versions = settings.REST_FRAMEWORK["ALLOWED_VERSIONS"]

--- a/ansible_ai_connect/main/tests/test_urls.py
+++ b/ansible_ai_connect/main/tests/test_urls.py
@@ -50,6 +50,14 @@ class TestUrls(TestCase):
         self.assertIn("connect-src 'self'", csp_headers)
         self.assertIn("base-uri 'self'", csp_headers)
         self.assertIn("form-action 'self'", csp_headers)
+        self.assertIn("vscode:", csp_headers)
+        self.assertIn("http://127.0.0.1", csp_headers)
+        # Ensure no wildcard schemes that would allow any http/https URL
+        # Check for both space and semicolon separators
+        self.assertNotIn("http: ", csp_headers)
+        self.assertNotIn("http:;", csp_headers)
+        self.assertNotIn("https: ", csp_headers)
+        self.assertNotIn("https:;", csp_headers)
         self.assertIn("frame-ancestors 'none'", csp_headers)
 
     def test_telemetry_patterns(self):


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-70265>

## Description
Improve the CSP handling, replacing too relaxed rules by more strict rules.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Run locally
3. Login into VS Code with localhost installation (Using Safari or Chrome, not Firefox)
4. Do simple task completion

## Type of Change
- [x] Security fix

### Scenarios tested
Installed locally and authorized in VS Code with localhost installations, did basic task request.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:
      * Check the login with Safari/Chrome with VS Code on Stage before promotion. Check the Rapidast report findings should not find issue mentioned in the Jira ticket anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CSP `form-action` from broad `http:`/`https:` allowances to a curated allowlist (editor schemes, loopback with wildcard ports, and parsed OAuth provider origins), which could break login/redirect flows if an environment uses an unexpected IdP/AAP URL format.
> 
> **Overview**
> Tightens the Content Security Policy `form-action` directive by removing blanket `http:`/`https:` scheme allowances and replacing them with an explicit allowlist for native-app OAuth flows: VS Code–style redirect schemes, loopback URLs with dynamic ports, and **only** the origins parsed from configured OAuth provider URLs (`AAP_API_URL`, `SOCIAL_AUTH_OIDC_OIDC_ENDPOINT`).
> 
> Adds tests to assert the new CSP header contents (including loopback wildcards) and to validate the URL-origin extraction helper used to build the allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b592b28f12ffa3e6d1cf59d6191a6a491620baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->