### PR TITLE
AAP-71802: Bump serialize-javascript to ^7.0.5 (CVE-2026-34043)

### DIFF
--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -174,7 +174,7 @@
     "minimatch": "^3.1.4",
     "bfj": "^9.1.2",
     "flatted": "^3.4.2",
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.0.5",
     "http-proxy-agent": "^7.0.0",
     "@svgr/webpack": {
       "@svgr/plugin-svgo": {


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-71802>, <https://issues.redhat.com/browse/AAP-71804>
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Claude (Cursor)
Generated by: Claude (Cursor)

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Tightens the `serialize-javascript` override in `ansible_ai_connect_admin_portal/package.json` from `^7.0.3` to `^7.0.5` to explicitly exclude versions vulnerable to CVE-2026-34043.

CVE-2026-34043 is a DoS vulnerability where serializing a specially crafted array-like object (one inheriting from `Array.prototype` with a very large `length` property) causes 100% CPU consumption. Fixed in `serialize-javascript` 7.0.5.

Note: `serialize-javascript` is a build-time only dependency used by webpack tools (`css-minimizer-webpack-plugin`, `rollup-plugin-terser`). It is not included in the built output and the deployed service is not directly exposed to this vulnerability. The lockfile was already resolving to 7.0.5; this change closes the gap in the declared minimum.

Closes AAP-71802, AAP-71804.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. `cd ansible_ai_connect_admin_portal && npm install`
3. Run `npm audit` and verify `serialize-javascript` does not appear in the output
4. Run `make admin-portal-test` and verify tests pass

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [x] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->
Security vulnerability fix (CVE-2026-34043). Should be applied to all active stable branches.

**Special backport considerations:**
One-line version bump, applies cleanly to all branches. No dependencies on other commits.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
- Verified `npm audit` returns no `serialize-javascript` findings after the change
- Confirmed `package-lock.json` was already resolving to 7.0.5 prior to this change

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: