### PR TITLE
AAP-74336 AAP-74335: Pin fast-uri to >=3.1.1 and @babel/plugin-transform-modules-systemjs to >=7.29.4 (CVE-2026-6321, GHSA-fv7c-fp4j-7gwp)

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -6367,9 +6367,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -80,6 +80,7 @@
     "minimatch": "^3.1.3",
     "marked": ">=18.0.2",
     "dompurify": ">=3.4.0",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "fast-uri": ">=3.1.1"
   }
 }

--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -1456,9 +1456,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
@@ -8989,9 +8989,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -190,6 +190,8 @@
           }
         }
       }
-    }
+    },
+    "fast-uri": ">=3.1.1",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
   }
 }


### PR DESCRIPTION
## Summary

Pins two vulnerable transitive dependencies in `ansible_ai_connect_admin_portal` and `aap_chatbot` via `overrides`:

- **fast-uri** `>=3.1.1` (CVE-2026-6321): path traversal via percent-encoded separators in `normalize()`/`equal()`; both sub-packages affected
- **@babel/plugin-transform-modules-systemjs** `>=7.29.4` (GHSA-fv7c-fp4j-7gwp): arbitrary code generation from malicious input; `ansible_ai_connect_admin_portal` only

## Jira
- AAP-74336
- AAP-74335

## Context

Both packages are transitive build-time-only dependencies. They are not included in the production browser bundle and their vulnerable code paths are not reachable at runtime.

| Package | Sub-package | Old | New |
|---|---|---|---|
| fast-uri | ansible_ai_connect_admin_portal | 3.0.3 | 3.1.2 |
| fast-uri | aap_chatbot | 3.1.0 | 3.1.2 |
| @babel/plugin-transform-modules-systemjs | ansible_ai_connect_admin_portal | 7.25.9 | 7.29.4 |

## Test plan
- [ ] CI passes (npm audit clean)

## Security fix
- [x] This is a security fix

Made with [Cursor](https://cursor.com)