### PR TITLE
Fix pyright errors and bump deps for pip-audit CVEs

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -16,7 +16,7 @@ import json
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Mapping, Optional, TypeVar, cast
 
 import backoff
 import requests
@@ -403,7 +403,7 @@ class WCABaseCompletionsPipeline(
         def post_request():
             return self.session.post(
                 prediction_url,
-                headers=headers,
+                headers=cast(Mapping[str, str], headers),
                 json=data,
                 timeout=self.task_gen_timeout(task_count),
             )
@@ -555,7 +555,7 @@ class WCABasePlaybookGenerationPipeline(
         def post_request():
             return self.session.post(
                 f"{self.config.inference_url}/v1/wca/codegen/ansible/playbook",
-                headers=headers,
+                headers=cast(Mapping[str, str], headers),
                 json=data,
             )
 
@@ -642,7 +642,7 @@ class WCABaseRoleGenerationPipeline(
         def post_request():
             return self.session.post(
                 f"{self.config.inference_url}/v1/wca/codegen/ansible/roles",
-                headers=headers,
+                headers=cast(Mapping[str, str], headers),
                 json=data,
             )
 
@@ -729,8 +729,8 @@ class WCABasePlaybookExplanationPipeline(
         def post_request():
             return self.session.post(
                 f"{self.config.inference_url}/v1/wca/explain/ansible/playbook",
-                headers=headers,
-                json=data,
+                headers=cast(Mapping[str, str], headers),
+                json=cast(Any, data),
             )
 
         result = post_request()
@@ -794,7 +794,7 @@ class WCABaseRoleExplanationPipeline(
         def post_request():
             return self.session.post(
                 f"{self.config.inference_url}/v1/wca/codegen/ansible/roles/explain",
-                headers=headers,
+                headers=cast(Mapping[str, str], headers),
                 json=data,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   'cbor2~=5.9.0',
   'cython',
   'daphne~=4.2.1',
-  'Django~=5.2.13',
+  'Django~=5.2.14',
   'django-deprecate-fields~=0.1.1',
   'django-extensions~=3.2.1',
   'django-health-check~=3.17.0',
@@ -42,7 +42,7 @@ dependencies = [
   'slack-sdk~=3.31.0',
   'social-auth-app-django~=5.6.0',
   'social-auth-core~=4.7.0',
-  'urllib3~=2.6.3',
+  'urllib3~=2.7.0',
   'uwsgi~=2.0.28',
   'uwsgi-readiness-check~=0.2.0',
   'django-allow-cidr',
@@ -93,6 +93,8 @@ constraint-dependencies = [
   'dynaconf>=3.2.13',
   'pyjwt>=2.12.0',
   'ujson>=5.12.0',
+  'twisted>=26.4.0',
+  'pygments>=2.20.0',
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ diff-match-patch==20241021
     # via django-import-export
 distro==1.9.0
     # via llama-stack-client
-django==5.2.13
+django==5.2.14
     # via
     #   ansible-ai-connect
     #   django-allow-cidr
@@ -350,7 +350,7 @@ pydantic-core==2.41.5
     # via pydantic
 pydrive2==1.20.0
     # via ansible-ai-connect
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   ipython
     #   rich
@@ -469,7 +469,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-twisted==25.5.0
+twisted==26.4.0
     # via daphne
 txaio==25.12.1
     # via autobahn
@@ -502,7 +502,7 @@ uritemplate==4.2.0
     # via
     #   drf-spectacular
     #   google-api-python-client
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   ansible-ai-connect
     #   botocore

--- a/uv.lock
+++ b/uv.lock
@@ -11,8 +11,10 @@ constraints = [
     { name = "certifi", git = "https://github.com/ansible/system-certifi?rev=5aa52ab91f9d579bfe52b5acf30ca799f1a563d9" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "dynaconf", specifier = ">=3.2.13" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "twisted", specifier = ">=26.4.0" },
     { name = "ujson", specifier = ">=5.12.0" },
 ]
 
@@ -208,7 +210,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = "~=7.2.1" },
     { name = "cython" },
     { name = "daphne", specifier = "~=4.2.1" },
-    { name = "django", specifier = "~=5.2.13" },
+    { name = "django", specifier = "~=5.2.14" },
     { name = "django-allow-cidr" },
     { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "resource-registry"], specifier = ">=2026.1.26" },
     { name = "django-csp", specifier = "~=3.7" },
@@ -247,7 +249,7 @@ requires-dist = [
     { name = "social-auth-app-django", specifier = "~=5.6.0" },
     { name = "social-auth-core", specifier = "~=4.7.0" },
     { name = "torch-model-archiver", marker = "extra == 'dev'" },
-    { name = "urllib3", specifier = "~=2.6.3" },
+    { name = "urllib3", specifier = "~=2.7.0" },
     { name = "uwsgi", specifier = "~=2.0.28" },
     { name = "uwsgi-readiness-check", specifier = "~=0.2.0" },
     { name = "virtualenv", marker = "extra == 'dev'", specifier = ">=20.28.0" },
@@ -859,16 +861,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.13"
+version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
 ]
 
 [[package]]
@@ -2547,11 +2549,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -3152,7 +3154,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "25.5.0"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3163,9 +3165,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/0f/82716ed849bf7ea4984c21385597c949944f0f9b428b5710f79d0afc084d/twisted-25.5.0.tar.gz", hash = "sha256:1deb272358cb6be1e3e8fc6f9c8b36f78eb0fa7c2233d2dbe11ec6fee04ea316", size = 3545725, upload-time = "2025-06-07T09:52:24.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/66/ab7efd8941f0bc7b2bd555b0f0471bff77df4c88e0cc31120c82737fec77/twisted-25.5.0-py3-none-any.whl", hash = "sha256:8559f654d01a54a8c3efe66d533d43f383531ebf8d81d9f9ab4769d91ca15df7", size = 3204767, upload-time = "2025-06-07T09:52:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
 ]
 
 [package.optional-dependencies]
@@ -3291,11 +3293,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `cast(Mapping[str, str], headers)` at `requests.post()` call sites to fix 5 pyright `reportArgumentType` errors triggered by `requests 2.34.0` stricter type stubs (no behavior change)
- Bump django 5.2.13 -> 5.2.14, urllib3 2.6.3 -> 2.7.0 (direct deps in pyproject.toml)
- Add twisted >= 26.4.0, pygments >= 2.20.0 as constraint-dependencies (transitive deps)
- Regenerated uv.lock and requirements.txt via `uv lock` + `uv export`

## Test plan
- [ ] CI pyright check passes
- [ ] CI pip-audit check passes
- [ ] Existing unit tests pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)