### PR TITLE
Harden cookie security: __Host- prefix, Secure flag, CSRF rotation

### DIFF
--- a/aap_chatbot/src/useChatbot/useChatbot.test.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { feedbackMessage, useChatbot } from "./useChatbot";
+import {
+  feedbackMessage,
+  readCookie,
+  readCsrfCookie,
+  useChatbot,
+} from "./useChatbot";
 import type { MessageProps } from "@patternfly/chatbot/dist/dynamic/Message";
 import { Sentiment } from "../Constants";
 import type { ChatFeedback } from "../types/Message";
@@ -12,6 +17,90 @@ const CONVERSATION_ID = "123e4567-e89b-12d3-a456-426614174000";
 vi.mock("@microsoft/fetch-event-source", () => ({
   fetchEventSource: vi.fn(),
 }));
+
+const clearCookies = () => {
+  for (const cookie of document.cookie.split(";")) {
+    const name = cookie.split("=")[0].trim();
+    if (name) {
+      document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+    }
+  }
+};
+
+describe("readCookie", () => {
+  beforeEach(clearCookies);
+  afterEach(clearCookies);
+
+  it("returns null when cookie is not present", () => {
+    expect(readCookie("csrftoken")).toBeNull();
+  });
+
+  it("extracts cookie value", () => {
+    document.cookie = "csrftoken=12345";
+    expect(readCookie("csrftoken")).toEqual("12345");
+  });
+
+  it("extracts correct cookie from multiple cookies", () => {
+    document.cookie = "other=abc";
+    document.cookie = "csrftoken=12345";
+    expect(readCookie("csrftoken")).toEqual("12345");
+  });
+
+  it("does not match partial cookie names", () => {
+    document.cookie = "csrftoken_extra=wrong";
+    expect(readCookie("csrftoken")).toBeNull();
+  });
+});
+
+// Browsers reject __Host- prefixed cookies on non-HTTPS pages, so we mock
+// document.cookie getter instead of setting real cookies.
+describe("readCsrfCookie", () => {
+  let cookieSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cookieSpy = vi.spyOn(document, "cookie", "get");
+  });
+
+  afterEach(() => {
+    cookieSpy.mockRestore();
+  });
+
+  it("returns __Host-csrftoken when standalone", () => {
+    cookieSpy.mockReturnValue("__Host-csrftoken=prod_token");
+    expect(readCsrfCookie()).toEqual("prod_token");
+  });
+
+  it("falls back to csrftoken when __Host-csrftoken is absent", () => {
+    cookieSpy.mockReturnValue("csrftoken=dev_token");
+    expect(readCsrfCookie()).toEqual("dev_token");
+  });
+
+  it("prefers __Host-csrftoken over csrftoken without gateway", () => {
+    cookieSpy.mockReturnValue(
+      "csrftoken=dev_token; __Host-csrftoken=prod_token",
+    );
+    expect(readCsrfCookie()).toEqual("prod_token");
+  });
+
+  it("uses csrftoken when behind gateway", () => {
+    cookieSpy.mockReturnValue(
+      "csrftoken=gw_token; __Host-csrftoken=django_token; gateway_sessionid=abc123",
+    );
+    expect(readCsrfCookie()).toEqual("gw_token");
+  });
+
+  it("uses __Host-csrftoken when both gateway and django sessions exist", () => {
+    cookieSpy.mockReturnValue(
+      "csrftoken=gw_token; __Host-csrftoken=django_token; gateway_sessionid=abc123; __Host-sessionid=xyz789",
+    );
+    expect(readCsrfCookie()).toEqual("django_token");
+  });
+
+  it("returns null when neither cookie is present", () => {
+    cookieSpy.mockReturnValue("");
+    expect(readCsrfCookie()).toBeNull();
+  });
+});
 
 describe("feedbackMessage", () => {
   it("should return a message with a thank you note for positive feedback", () => {

--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -46,6 +46,17 @@ export const readCookie = (name: string): string | null => {
   return null;
 };
 
+// Mirror the gateway detection logic from EnsureCsrfCookieMiddleware:
+// gateway session cookie present AND Django's own session cookie absent.
+const isGatewayRequest = (): boolean =>
+  readCookie("gateway_sessionid") !== null &&
+  readCookie("__Host-sessionid") === null;
+
+export const readCsrfCookie = (): string | null =>
+  isGatewayRequest()
+    ? readCookie("csrftoken")
+    : (readCookie("__Host-csrftoken") ?? readCookie("csrftoken"));
+
 const getTimestamp = () => {
   const date = new Date();
   return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
@@ -191,7 +202,7 @@ export const useChatbot = () => {
       bodyElement = frameWindow.document.getElementsByTagName("body")[0];
     }
     const checkStatus = async () => {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
       try {
         const resp = await fetch("/api/lightspeed/v1/health/status/chatbot/", {
           method: "GET",
@@ -429,7 +440,7 @@ export const useChatbot = () => {
 
   const handleFeedback = async (feedbackRequest: ChatFeedback) => {
     try {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
       const resp = await fetch(
         import.meta.env.PROD
           ? "/api/lightspeed/v1/ai/feedback/"
@@ -521,7 +532,7 @@ export const useChatbot = () => {
     setIsLoading(true);
 
     try {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
 
       if (isStreamingSupported()) {
         setHasStopButton(true);
@@ -536,7 +547,7 @@ export const useChatbot = () => {
             headers: {
               "Content-Type": "application/json",
               Accept: "application/json,text/event-stream",
-              "X-CSRFToken": csrfToken!,
+              ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
             },
             body: JSON.stringify(chatRequest),
             async onopen(resp: any) {

--- a/ansible_ai_connect/main/middleware.py
+++ b/ansible_ai_connect/main/middleware.py
@@ -19,7 +19,7 @@ import uuid
 
 from ansible_anonymizer import anonymizer
 from django.conf import settings
-from django.middleware.csrf import CsrfViewMiddleware
+from django.middleware.csrf import CsrfViewMiddleware, get_token
 from rest_framework.exceptions import ErrorDetail, PermissionDenied
 from segment import analytics
 from social_django.middleware import SocialAuthExceptionMiddleware
@@ -39,6 +39,99 @@ from ansible_ai_connect.healthcheck.version_info import VersionInfo
 
 logger = logging.getLogger(__name__)
 version_info = VersionInfo()
+
+
+class EnsureCsrfCookieMiddleware:
+    """Ensure every response carries a CSRF cookie so that JS clients
+    (chatbot, admin portal) can read it for X-CSRFToken headers.
+
+    This middleware handles two deployment modes:
+
+    1. **Standalone** (no gateway): calls get_token() to generate a CSRF
+       secret and set CSRF_COOKIE_NEEDS_UPDATE, so CsrfViewMiddleware
+       emits a Set-Cookie with the __Host-csrftoken cookie on every
+       response.
+
+    2. **Behind AAP gateway**: the gateway owns CSRF validation and sets
+       its own "csrftoken" cookie. Django uses a different cookie name
+       (__Host-csrftoken), so CsrfViewMiddleware would not find the
+       gateway's token. We detect gateway-proxied requests by the
+       presence of the gateway session cookie (GATEWAY_SESSION_COOKIE_NAME)
+       AND the absence of Django's own session cookie (SESSION_COOKIE_NAME),
+       then copy the gateway's CSRF cookie value (GATEWAY_CSRF_COOKIE_NAME)
+       into request.COOKIES[CSRF_COOKIE_NAME]. This allows Django's CSRF
+       validation to pass using the token the gateway already verified.
+
+    Must be placed BEFORE CsrfViewMiddleware in the middleware stack.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def _is_gateway_request(self, request):
+        """Detect gateway-proxied requests: gateway session cookie is
+        present but Django's own session cookie is not."""
+        return (
+            settings.GATEWAY_SESSION_COOKIE_NAME in request.COOKIES
+            and settings.SESSION_COOKIE_NAME not in request.COOKIES
+        )
+
+    def _ensure_csrf_cookie(self, request):
+        """Ensure the CSRF secret is available in request.META and
+        request.COOKIES so that both CsrfViewMiddleware (reads META)
+        and DRF's SessionAuthentication.enforce_csrf (reads COOKIES)
+        can validate the token.
+
+        Four cases (all handle the cross-origin proxy / OAuth/gateway
+        scenario where the cookie domain doesn't match the API domain):
+
+        1. Browser sent the CSRF cookie — transfer its value into
+           META before calling get_token() so get_token() reuses the
+           existing secret instead of generating a new one.
+
+        2. No cookie but X-CSRFToken header is present — the JS read
+           the token from a cookie the browser didn't send back (e.g.
+           OAuth authentication via the gateway where the gateway's
+           cookie domain doesn't match the Django API domain).
+           Use the header value as the secret; X-CSRFToken can only
+           be set by same-origin JS so this is safe from CSRF attacks.
+
+        3. No cookie, no header, but a csrfmiddlewaretoken in POST
+           form data (e.g. logout form) — inject the form token into
+           COOKIES and let CsrfViewMiddleware unmask it into META.
+           Skip get_token() to avoid overwriting with a new secret.
+
+        4. None of the above — generate a fresh secret and inject it
+           into COOKIES for DRF."""
+        existing = request.COOKIES.get(settings.CSRF_COOKIE_NAME)
+        header_token = request.META.get("HTTP_X_CSRFTOKEN")
+
+        if existing:
+            request.META["CSRF_COOKIE"] = existing
+        elif header_token:
+            request.META["CSRF_COOKIE"] = header_token
+            request.COOKIES[settings.CSRF_COOKIE_NAME] = header_token
+        elif request.method == "POST":
+            form_token = request.POST.get("csrfmiddlewaretoken")
+            if form_token:
+                request.COOKIES[settings.CSRF_COOKIE_NAME] = form_token
+                return
+
+        token = get_token(request)
+        if not existing and not header_token:
+            request.COOKIES.setdefault(settings.CSRF_COOKIE_NAME, token)
+
+    def __call__(self, request):
+        if self._is_gateway_request(request):
+            gw_token = request.COOKIES.get(settings.GATEWAY_CSRF_COOKIE_NAME)
+            if gw_token:
+                request.COOKIES[settings.CSRF_COOKIE_NAME] = gw_token
+            else:
+                self._ensure_csrf_cookie(request)
+        else:
+            self._ensure_csrf_cookie(request)
+
+        return self.get_response(request)
 
 
 def check_csrf(request):

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -89,6 +89,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "ansible_ai_connect.main.middleware.EnsureCsrfCookieMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "oauth2_provider.middleware.OAuth2TokenMiddleware",
@@ -104,6 +105,30 @@ if os.environ.get("CSRF_TRUSTED_ORIGINS"):
     CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS").split(",")
 else:
     CSRF_TRUSTED_ORIGINS = ["http://localhost:8000"]
+
+# SameSite=Lax (not Strict) because OAuth/OIDC login flows redirect back from
+# external identity providers (Red Hat SSO, GitHub, AAP). Strict would drop the
+# session cookie on that redirect, making the user appear unauthenticated.
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_NAME = "__Host-sessionid"
+SESSION_COOKIE_AGE = 1209600  # 2 weeks, aligned with CSRF_COOKIE_AGE
+
+CSRF_COOKIE_SECURE = True
+# JS must read the CSRF cookie to echo it in the X-CSRFToken header
+CSRF_COOKIE_HTTPONLY = False
+# SameSite=Lax (not Strict) so the CSRF cookie survives OAuth/OIDC redirects
+# from external identity providers, matching the session cookie policy above.
+CSRF_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_NAME = "__Host-csrftoken"
+CSRF_COOKIE_AGE = 1209600  # 2 weeks; reduced from Django's 1-year default
+
+# When behind AAP gateway, the gateway owns CSRF validation using its own
+# cookie. These settings let the middleware detect gateway-proxied requests
+# and alias the gateway's CSRF cookie so Django's validation passes.
+GATEWAY_SESSION_COOKIE_NAME = os.environ.get("GATEWAY_SESSION_COOKIE_NAME", "gateway_sessionid")
+GATEWAY_CSRF_COOKIE_NAME = os.environ.get("GATEWAY_CSRF_COOKIE_NAME", "csrftoken")
 
 # Allow Prometheus to scrape metrics
 ALLOWED_CIDR_NETS = [os.environ.get("ALLOWED_CIDR_NETS", "10.0.0.0/8")]

--- a/ansible_ai_connect/main/settings/development.py
+++ b/ansible_ai_connect/main/settings/development.py
@@ -83,6 +83,11 @@ if DEBUG:
             "ansible_ai_connect.main.middleware.WisdomSocialAuthExceptionMiddleware"  # noqa: F405
         )
 
+SESSION_COOKIE_SECURE = False
+SESSION_COOKIE_NAME = "sessionid"
+CSRF_COOKIE_SECURE = False
+CSRF_COOKIE_NAME = "csrftoken"
+
 CSP_REPORT_ONLY = True
 AUTHZ_BACKEND_TYPE = os.getenv("AUTHZ_BACKEND_TYPE") or "dummy"
 # e.g:

--- a/ansible_ai_connect/main/settings/tests/test_cookie_security.py
+++ b/ansible_ai_connect/main/settings/tests/test_cookie_security.py
@@ -1,0 +1,233 @@
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from ansible_ai_connect.main.middleware import EnsureCsrfCookieMiddleware
+from ansible_ai_connect.main.settings import base as base_settings
+
+
+class TestBaseCookieSecuritySettings(TestCase):
+
+    def test_session_cookie_secure(self):
+        self.assertTrue(base_settings.SESSION_COOKIE_SECURE)
+
+    def test_session_cookie_httponly(self):
+        self.assertTrue(base_settings.SESSION_COOKIE_HTTPONLY)
+
+    def test_session_cookie_samesite(self):
+        self.assertEqual(base_settings.SESSION_COOKIE_SAMESITE, "Lax")
+
+    def test_session_cookie_name_has_host_prefix(self):
+        self.assertEqual(base_settings.SESSION_COOKIE_NAME, "__Host-sessionid")
+
+    def test_session_cookie_age_two_weeks(self):
+        self.assertEqual(base_settings.SESSION_COOKIE_AGE, 1209600)
+
+    def test_csrf_cookie_secure(self):
+        self.assertTrue(base_settings.CSRF_COOKIE_SECURE)
+
+    def test_csrf_cookie_not_httponly(self):
+        self.assertFalse(base_settings.CSRF_COOKIE_HTTPONLY)
+
+    def test_csrf_cookie_samesite(self):
+        self.assertEqual(base_settings.CSRF_COOKIE_SAMESITE, "Lax")
+
+    def test_csrf_cookie_name_has_host_prefix(self):
+        self.assertEqual(base_settings.CSRF_COOKIE_NAME, "__Host-csrftoken")
+
+    def test_csrf_cookie_age_two_weeks(self):
+        self.assertEqual(base_settings.CSRF_COOKIE_AGE, 1209600)
+
+    def test_host_prefix_invariants_session_domain_unset(self):
+        self.assertFalse(getattr(base_settings, "SESSION_COOKIE_DOMAIN", None))
+
+    def test_host_prefix_invariants_session_path(self):
+        self.assertEqual(getattr(base_settings, "SESSION_COOKIE_PATH", "/"), "/")
+
+    def test_host_prefix_invariants_csrf_domain_unset(self):
+        self.assertFalse(getattr(base_settings, "CSRF_COOKIE_DOMAIN", None))
+
+    def test_host_prefix_invariants_csrf_path(self):
+        self.assertEqual(getattr(base_settings, "CSRF_COOKIE_PATH", "/"), "/")
+
+
+class TestEnsureCsrfCookieMiddleware(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_middleware_in_stack(self):
+        self.assertIn(
+            "ansible_ai_connect.main.middleware.EnsureCsrfCookieMiddleware",
+            settings.MIDDLEWARE,
+        )
+
+    def test_middleware_before_csrf_middleware(self):
+        idx_ensure = settings.MIDDLEWARE.index(
+            "ansible_ai_connect.main.middleware.EnsureCsrfCookieMiddleware"
+        )
+        idx_csrf = settings.MIDDLEWARE.index("django.middleware.csrf.CsrfViewMiddleware")
+        self.assertLess(idx_ensure, idx_csrf)
+
+    def test_sets_csrf_cookie_needs_update(self):
+        request = self.factory.get("/")
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertTrue(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+
+    def test_sets_csrf_cookie_secret(self):
+        request = self.factory.get("/")
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertIn("CSRF_COOKIE", request.META)
+        self.assertTrue(len(request.META["CSRF_COOKIE"]) > 0)
+
+    def test_reuses_existing_csrf_cookie_secret(self):
+        request = self.factory.get("/")
+        existing_secret = "ExistingCsrfSecret12345678901234"
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = existing_secret
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(request.META["CSRF_COOKIE"], existing_secret)
+
+    def test_does_not_overwrite_existing_csrf_cookie_in_cookies(self):
+        request = self.factory.get("/")
+        existing_secret = "ExistingCsrfSecret12345678901234"
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = existing_secret
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(request.COOKIES[settings.CSRF_COOKIE_NAME], existing_secret)
+
+    def test_uses_header_token_when_cookie_missing(self):
+        """When the browser doesn't send the CSRF cookie but JS sends
+        X-CSRFToken (cross-origin proxy deployment), use the header
+        value as the secret."""
+        request = self.factory.get("/", HTTP_X_CSRFTOKEN="HeaderCsrfToken12345678901234567")
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(
+            request.META["CSRF_COOKIE"],
+            "HeaderCsrfToken12345678901234567",
+        )
+        self.assertEqual(
+            request.COOKIES[settings.CSRF_COOKIE_NAME],
+            "HeaderCsrfToken12345678901234567",
+        )
+
+    def test_cookie_takes_precedence_over_header(self):
+        """When both cookie and header exist, the cookie value is used
+        as the CSRF secret (standard double-submit pattern)."""
+        request = self.factory.get("/", HTTP_X_CSRFTOKEN="HeaderToken123456789012345678901")
+        cookie_secret = "CookieSecret12345678901234567890"
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = cookie_secret
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(request.META["CSRF_COOKIE"], cookie_secret)
+
+    def test_uses_form_token_when_cookie_and_header_missing(self):
+        """When a form POST has csrfmiddlewaretoken but no cookie
+        (OAuth/gateway cross-origin proxy), inject the form token
+        into COOKIES so CsrfViewMiddleware can validate it."""
+        form_token = "a" * 64
+        request = self.factory.post("/logout/", {"csrfmiddlewaretoken": form_token})
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(request.COOKIES[settings.CSRF_COOKIE_NAME], form_token)
+        self.assertNotIn("CSRF_COOKIE", request.META)
+
+    def test_form_token_not_used_when_cookie_exists(self):
+        """When the cookie exists, the form token is ignored and the
+        cookie value is used as the CSRF secret."""
+        cookie_secret = "CookieSecret12345678901234567890"
+        form_token = "b" * 64
+        request = self.factory.post("/logout/", {"csrfmiddlewaretoken": form_token})
+        request.COOKIES[settings.CSRF_COOKIE_NAME] = cookie_secret
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(request.META["CSRF_COOKIE"], cookie_secret)
+
+    def test_post_without_form_token_generates_fresh_secret(self):
+        """POST with no cookie, no header, and no csrfmiddlewaretoken
+        falls through to case 4 and generates a fresh secret."""
+        request = self.factory.post("/some-endpoint/")
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertTrue(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+        self.assertIn("CSRF_COOKIE", request.META)
+        self.assertTrue(len(request.META["CSRF_COOKIE"]) > 0)
+        self.assertIn(settings.CSRF_COOKIE_NAME, request.COOKIES)
+
+
+class TestDevelopmentCookieOverrides(TestCase):
+    """Development settings relax cookie security for HTTP dev environments
+    (__Host- prefix requires Secure, which breaks plain HTTP)."""
+
+    def test_session_cookie_not_secure_in_dev(self):
+        from ansible_ai_connect.main.settings import development
+
+        self.assertFalse(development.SESSION_COOKIE_SECURE)
+
+    def test_session_cookie_name_standard_in_dev(self):
+        from ansible_ai_connect.main.settings import development
+
+        self.assertEqual(development.SESSION_COOKIE_NAME, "sessionid")
+
+    def test_csrf_cookie_not_secure_in_dev(self):
+        from ansible_ai_connect.main.settings import development
+
+        self.assertFalse(development.CSRF_COOKIE_SECURE)
+
+    def test_csrf_cookie_name_standard_in_dev(self):
+        from ansible_ai_connect.main.settings import development
+
+        self.assertEqual(development.CSRF_COOKIE_NAME, "csrftoken")
+
+
+class TestGatewaySettings(TestCase):
+
+    def test_gateway_session_cookie_name_default(self):
+        self.assertEqual(base_settings.GATEWAY_SESSION_COOKIE_NAME, "gateway_sessionid")
+
+    def test_gateway_csrf_cookie_name_default(self):
+        self.assertEqual(base_settings.GATEWAY_CSRF_COOKIE_NAME, "csrftoken")
+
+
+class TestEnsureCsrfCookieMiddlewareGateway(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_aliases_gateway_csrf_cookie_when_behind_gateway(self):
+        request = self.factory.get("/")
+        request.COOKIES["gateway_sessionid"] = "gw_session"
+        request.COOKIES["csrftoken"] = "gwCsrfToken1234567890abcdefABCDE"
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertEqual(
+            request.COOKIES[settings.CSRF_COOKIE_NAME], "gwCsrfToken1234567890abcdefABCDE"
+        )
+
+    def test_does_not_set_csrf_cookie_needs_update_behind_gateway(self):
+        request = self.factory.get("/")
+        request.COOKIES["gateway_sessionid"] = "gw_session"
+        request.COOKIES["csrftoken"] = "gwCsrfToken1234567890abcdefABCDE"
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertFalse(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+
+    def test_standalone_when_both_sessions_exist(self):
+        request = self.factory.get("/")
+        request.COOKIES["gateway_sessionid"] = "gw_session"
+        request.COOKIES[settings.SESSION_COOKIE_NAME] = "django_session"
+        request.COOKIES["csrftoken"] = "gwCsrfToken1234567890abcdefABCDE"
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertTrue(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+
+    def test_falls_back_to_standalone_when_gateway_csrf_cookie_missing(self):
+        request = self.factory.get("/")
+        request.COOKIES["gateway_sessionid"] = "gw_session"
+        middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
+        middleware(request)
+        self.assertTrue(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+        self.assertIn("CSRF_COOKIE", request.META)

--- a/ansible_ai_connect/main/templates/chatbot/index.html
+++ b/ansible_ai_connect/main/templates/chatbot/index.html
@@ -9,8 +9,8 @@
       content="{{bot_name}}"
     />
     <title>{{bot_name}}</title>
-    <script type="module" crossorigin src="/static/chatbot/index-8zRWvsD-.js"></script>
-    <link rel="stylesheet" crossorigin href="/static/chatbot/index-CN-YAjNY.css">
+    <script type="module" crossorigin src="/static/chatbot/index-xKaMtcOq.js"></script>
+    <link rel="stylesheet" crossorigin href="/static/chatbot/index-BCBeJGFG.css">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ansible_ai_connect/main/templates/console/console.html
+++ b/ansible_ai_connect/main/templates/console/console.html
@@ -17,6 +17,8 @@
     <!-- It is safe to pass the value embedded in the host DOM -->
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
+    <!-- CSRF token for cross-origin proxy deployments where the cookie is unavailable -->
+    <div id="csrf_token" hidden>{{ csrf_token }}</div>
     <!-- Admin Dashboard URL -->
     <div id="telemetry_schema_2_admin_dashboard_url" hidden>{{telemetry_schema_2_admin_dashboard_url}}</div>
 {% endblock content %}

--- a/ansible_ai_connect/main/templates/console/denied.html
+++ b/ansible_ai_connect/main/templates/console/denied.html
@@ -17,5 +17,7 @@
     <!-- It is safe to pass the value embedded in the host DOM -->
     <!-- as it is only used for display purposes and servers no other value -->
     <div id="user_name" hidden>{{user_name}}</div>
+    <!-- CSRF token for cross-origin proxy deployments where the cookie is unavailable -->
+    <div id="csrf_token" hidden>{{ csrf_token }}</div>
     <div id="has_subscription" hidden>{{rh_org_has_subscription}}</div>
 {% endblock content %}

--- a/ansible_ai_connect/users/signals.py
+++ b/ansible_ai_connect/users/signals.py
@@ -21,6 +21,7 @@ from django.contrib.auth.signals import (
     user_login_failed,
 )
 from django.dispatch import Signal, receiver
+from django.middleware.csrf import rotate_token
 from oauth2_provider.models import get_access_token_model, get_refresh_token_model
 
 logger = logging.getLogger(__name__)
@@ -33,9 +34,11 @@ user_set_telemetry_settings = Signal()
 
 
 @receiver(user_logged_in)
-def user_login_log(sender, user, **kwargs):
+def user_login_log(sender, user, request=None, **kwargs):
     """Successful user login log to user log"""
     logger.info(f"User: {user} LOGIN successful")
+    if request:
+        rotate_token(request)
 
 
 @receiver(user_login_failed)

--- a/ansible_ai_connect/users/tests/test_signals.py
+++ b/ansible_ai_connect/users/tests/test_signals.py
@@ -12,6 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.signals import user_logged_in
+
 from ansible_ai_connect.test_utils import WisdomServiceLogAwareTestCase
 from ansible_ai_connect.users.signals import _obfuscate
 
@@ -25,3 +29,19 @@ class TestSignals(WisdomServiceLogAwareTestCase):
         self.assertEqual("h****n", _obfuscate("hidden"))
         self.assertEqual("to******et", _obfuscate("top-secret"))
         self.assertEqual("a-lo***************alue", _obfuscate("a-long-top-secret-value"))
+
+
+class TestCSRFTokenRotationOnLogin(WisdomServiceLogAwareTestCase):
+
+    @patch("ansible_ai_connect.users.signals.rotate_token")
+    def test_csrf_token_rotated_on_login(self, mock_rotate_token):
+        request = Mock()
+        user = Mock()
+        user_logged_in.send(sender=self.__class__, user=user, request=request)
+        mock_rotate_token.assert_called_once_with(request)
+
+    @patch("ansible_ai_connect.users.signals.rotate_token")
+    def test_csrf_token_not_rotated_without_request(self, mock_rotate_token):
+        user = Mock()
+        user_logged_in.send(sender=self.__class__, user=user)
+        mock_rotate_token.assert_not_called()

--- a/ansible_ai_connect_admin_portal/config/webpackDevServer.config.js
+++ b/ansible_ai_connect_admin_portal/config/webpackDevServer.config.js
@@ -95,7 +95,9 @@ module.exports = function (proxy, allowedHost) {
       publicPath: paths.publicUrlOrPath.slice(0, -1),
     },
 
-    https: getHttpsConfig(),
+    server: getHttpsConfig()
+      ? { type: "https", options: getHttpsConfig() }
+      : undefined,
     host,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.
@@ -106,7 +108,7 @@ module.exports = function (proxy, allowedHost) {
     },
     // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
     proxy,
-    onBeforeSetupMiddleware(devServer) {
+    setupMiddlewares(middlewares, devServer) {
       // Keep `evalSourceMapMiddleware`
       // middlewares before `redirectServedPath` otherwise will not have any effect
       // This lets us fetch source contents from webpack for the error overlay
@@ -128,17 +130,18 @@ module.exports = function (proxy, allowedHost) {
           "config/webpack.mock.api.telemetry.ts",
         ],
       });
-    },
-    onAfterSetupMiddleware(devServer) {
+
       // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
-      devServer.app.use(redirectServedPath(paths.publicUrlOrPath));
+      middlewares.push(redirectServedPath(paths.publicUrlOrPath));
 
       // This service worker file is effectively a 'no-op' that will reset any
       // previous service worker registered for the same host:port combination.
       // We do this in development to avoid hitting the production cache if
       // it used the same host and port.
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-      devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+      middlewares.push(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+
+      return middlewares;
     },
   };
 };

--- a/ansible_ai_connect_admin_portal/src/AppHeader.tsx
+++ b/ansible_ai_connect_admin_portal/src/AppHeader.tsx
@@ -9,7 +9,7 @@ import {
 import { UserCircleIcon } from "@patternfly/react-icons";
 import { PageMastheadDropdown } from "./PageMastheadDropdown";
 import RedHatLogo from "./redhat-logo.svg";
-import { readCookie } from "./api/api";
+import { readCsrfCookie } from "./api/api";
 
 export interface AppHeaderProps {
   readonly userName: string;
@@ -27,7 +27,7 @@ export function AppHeader(props: AppHeaderProps) {
     const csrfInput = document.createElement("input");
     csrfInput.type = "hidden";
     csrfInput.name = "csrfmiddlewaretoken";
-    csrfInput.value = readCookie("csrftoken") || "";
+    csrfInput.value = readCsrfCookie() || "";
     form.appendChild(csrfInput);
 
     document.body.appendChild(form);

--- a/ansible_ai_connect_admin_portal/src/__tests__/TelemetrySettings.test.tsx
+++ b/ansible_ai_connect_admin_portal/src/__tests__/TelemetrySettings.test.tsx
@@ -104,7 +104,7 @@ describe("TelemetrySettings", () => {
     expect(axios.post as jest.Mock).toBeCalledWith(
       API_TELEMETRY_PATH,
       { optOut: true },
-      { headers: { "X-CSRFToken": null } },
+      { headers: {} },
     );
   });
 
@@ -132,7 +132,7 @@ describe("TelemetrySettings", () => {
     expect(axios.post as jest.Mock).toBeCalledWith(
       API_TELEMETRY_PATH,
       { optOut: true },
-      { headers: { "X-CSRFToken": null } },
+      { headers: {} },
     );
 
     // Modals are added to the 'document.body' so perform a basic check for a known field.

--- a/ansible_ai_connect_admin_portal/src/api/__tests__/api.test.ts
+++ b/ansible_ai_connect_admin_portal/src/api/__tests__/api.test.ts
@@ -1,34 +1,87 @@
 import "@testing-library/jest-dom";
-import { readCookie } from "../api";
+import { readCookie, readCsrfCookie } from "../api";
 
+// Browsers reject __Host- prefixed cookies on non-HTTPS pages, so we mock
+// document.cookie getter instead of setting real cookies.
 describe("API", () => {
-  it("Cookie extraction::Empty string", () => {
-    document.cookie = "";
-    const cookie = readCookie("csrftoken");
-    expect(cookie).toBeNull();
+  let cookieSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    cookieSpy = jest.spyOn(document, "cookie", "get");
   });
 
-  it("Cookie extraction::Single::With whitespace", () => {
-    document.cookie = "csrftoken = 12345   ";
-    const cookie = readCookie("csrftoken");
-    expect(cookie).toEqual("12345");
+  afterEach(() => {
+    cookieSpy.mockRestore();
   });
 
-  it("Cookie extraction::Single::Without whitespace", () => {
-    document.cookie = "csrftoken=12345";
-    const cookie = readCookie("csrftoken");
-    expect(cookie).toEqual("12345");
+  describe("readCookie", () => {
+    it("Cookie extraction::Empty string", () => {
+      cookieSpy.mockReturnValue("");
+      const cookie = readCookie("__Host-csrftoken");
+      expect(cookie).toBeNull();
+    });
+
+    it("Cookie extraction::Single::With whitespace", () => {
+      cookieSpy.mockReturnValue("__Host-csrftoken=12345   ");
+      const cookie = readCookie("__Host-csrftoken");
+      expect(cookie).toEqual("12345");
+    });
+
+    it("Cookie extraction::Single::Without whitespace", () => {
+      cookieSpy.mockReturnValue("__Host-csrftoken=12345");
+      const cookie = readCookie("__Host-csrftoken");
+      expect(cookie).toEqual("12345");
+    });
+
+    it("Cookie extraction::Multiple::With whitespace", () => {
+      cookieSpy.mockReturnValue("smurf=abcdef  ; __Host-csrftoken=12345   ");
+      const cookie = readCookie("__Host-csrftoken");
+      expect(cookie).toEqual("12345");
+    });
+
+    it("Cookie extraction::Multiple::Without whitespace", () => {
+      cookieSpy.mockReturnValue("smurf=abcdef;__Host-csrftoken=12345");
+      const cookie = readCookie("__Host-csrftoken");
+      expect(cookie).toEqual("12345");
+    });
+
+    it("does not match partial cookie names", () => {
+      cookieSpy.mockReturnValue("__Host-csrftoken_extra=wrong");
+      expect(readCookie("__Host-csrftoken")).toBeNull();
+    });
   });
 
-  it("Cookie extraction::Multiple::With whitespace", () => {
-    document.cookie = "smurf = abcdef; csrftoken = 12345   ";
-    const cookie = readCookie("csrftoken");
-    expect(cookie).toEqual("12345");
-  });
+  describe("readCsrfCookie", () => {
+    it("returns __Host-csrftoken when present", () => {
+      cookieSpy.mockReturnValue("__Host-csrftoken=prod_token");
+      expect(readCsrfCookie()).toEqual("prod_token");
+    });
 
-  it("Cookie extraction::Multiple::Without whitespace", () => {
-    document.cookie = "smurf=abcdef;csrftoken=12345";
-    const cookie = readCookie("csrftoken");
-    expect(cookie).toEqual("12345");
+    it("falls back to csrftoken when __Host-csrftoken is absent", () => {
+      cookieSpy.mockReturnValue("csrftoken=dev_token");
+      expect(readCsrfCookie()).toEqual("dev_token");
+    });
+
+    it("prefers __Host-csrftoken over csrftoken", () => {
+      cookieSpy.mockReturnValue(
+        "csrftoken=dev_token; __Host-csrftoken=prod_token",
+      );
+      expect(readCsrfCookie()).toEqual("prod_token");
+    });
+
+    it("falls back to DOM csrf_token element when no cookie", () => {
+      cookieSpy.mockReturnValue("");
+      const div = document.createElement("div");
+      div.id = "csrf_token";
+      div.textContent = "dom_csrf_token";
+      document.body.appendChild(div);
+      expect(readCsrfCookie()).toEqual("dom_csrf_token");
+      document.body.removeChild(div);
+    });
+
+    it("returns null when neither cookie nor DOM element is present", () => {
+      cookieSpy.mockReturnValue("");
+      expect(readCsrfCookie()).toBeNull();
+    });
   });
 });

--- a/ansible_ai_connect_admin_portal/src/api/api.ts
+++ b/ansible_ai_connect_admin_portal/src/api/api.ts
@@ -19,21 +19,30 @@ export const readCookie = (name: string): string | null => {
   return null;
 };
 
+// In cross-origin proxy deployments (e.g. OAuth via AAP gateway), the browser
+// may not send the CSRF cookie due to domain mismatch. The Django template
+// embeds the token in a hidden DOM element as a reliable fallback.
+export const readCsrfCookie = (): string | null =>
+  readCookie("__Host-csrftoken") ??
+  document.getElementById("csrf_token")?.textContent?.trim() ??
+  readCookie("csrftoken") ??
+  null;
+
 export const getWcaKey = () => {
   return axios.get(API_WCA_KEY_PATH);
 };
 
 export const saveWcaKey = (wcaKey: WcaKeyRequest) => {
-  const csrfToken = readCookie("csrftoken");
+  const csrfToken = readCsrfCookie();
   return axios.post(API_WCA_KEY_PATH, wcaKey, {
-    headers: { "X-CSRFToken": csrfToken },
+    headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
   });
 };
 
 export const deleteWcaKey = () => {
-  const csrfToken = readCookie("csrftoken");
+  const csrfToken = readCsrfCookie();
   return axios.delete(API_WCA_KEY_PATH, {
-    headers: { "X-CSRFToken": csrfToken },
+    headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
   });
 };
 
@@ -46,9 +55,9 @@ export const getWcaModelId = () => {
 };
 
 export const saveWcaModelId = (wcaModelId: WcaModelIdRequest) => {
-  const csrfToken = readCookie("csrftoken");
+  const csrfToken = readCsrfCookie();
   return axios.post(API_WCA_MODEL_ID_PATH, wcaModelId, {
-    headers: { "X-CSRFToken": csrfToken },
+    headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
   });
 };
 
@@ -61,8 +70,8 @@ export const getTelemetrySettings = () => {
 };
 
 export const saveTelemetrySettings = (telemetry: TelemetryRequest) => {
-  const csrfToken = readCookie("csrftoken");
+  const csrfToken = readCsrfCookie();
   return axios.post(API_TELEMETRY_PATH, telemetry, {
-    headers: { "X-CSRFToken": csrfToken },
+    headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
   });
 };

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.test.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { feedbackMessage, useChatbot } from "./useChatbot";
+import {
+  feedbackMessage,
+  readCookie,
+  readCsrfCookie,
+  useChatbot,
+} from "./useChatbot";
 import type { MessageProps } from "@patternfly/chatbot/dist/dynamic/Message";
 import { Sentiment } from "../Constants";
 import type { ChatFeedback } from "../types/Message";
@@ -12,6 +17,76 @@ const CONVERSATION_ID = "123e4567-e89b-12d3-a456-426614174000";
 vi.mock("@microsoft/fetch-event-source", () => ({
   fetchEventSource: vi.fn(),
 }));
+
+const clearCookies = () => {
+  for (const cookie of document.cookie.split(";")) {
+    const name = cookie.split("=")[0].trim();
+    if (name) {
+      document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+    }
+  }
+};
+
+describe("readCookie", () => {
+  beforeEach(clearCookies);
+  afterEach(clearCookies);
+
+  it("returns null when cookie is not present", () => {
+    expect(readCookie("csrftoken")).toBeNull();
+  });
+
+  it("extracts cookie value", () => {
+    document.cookie = "csrftoken=12345";
+    expect(readCookie("csrftoken")).toEqual("12345");
+  });
+
+  it("extracts correct cookie from multiple cookies", () => {
+    document.cookie = "other=abc";
+    document.cookie = "csrftoken=12345";
+    expect(readCookie("csrftoken")).toEqual("12345");
+  });
+
+  it("does not match partial cookie names", () => {
+    document.cookie = "csrftoken_extra=wrong";
+    expect(readCookie("csrftoken")).toBeNull();
+  });
+});
+
+// Browsers reject __Host- prefixed cookies on non-HTTPS pages, so we mock
+// document.cookie getter instead of setting real cookies.
+describe("readCsrfCookie", () => {
+  let cookieSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cookieSpy = vi.spyOn(document, "cookie", "get");
+  });
+
+  afterEach(() => {
+    cookieSpy.mockRestore();
+  });
+
+  it("returns __Host-csrftoken when present", () => {
+    cookieSpy.mockReturnValue("__Host-csrftoken=prod_token");
+    expect(readCsrfCookie()).toEqual("prod_token");
+  });
+
+  it("falls back to csrftoken when __Host-csrftoken is absent", () => {
+    cookieSpy.mockReturnValue("csrftoken=dev_token");
+    expect(readCsrfCookie()).toEqual("dev_token");
+  });
+
+  it("prefers __Host-csrftoken over csrftoken", () => {
+    cookieSpy.mockReturnValue(
+      "csrftoken=dev_token; __Host-csrftoken=prod_token",
+    );
+    expect(readCsrfCookie()).toEqual("prod_token");
+  });
+
+  it("returns null when neither cookie is present", () => {
+    cookieSpy.mockReturnValue("");
+    expect(readCsrfCookie()).toBeNull();
+  });
+});
 
 describe("feedbackMessage", () => {
   it("should return a message with a thank you note for positive feedback", () => {

--- a/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
+++ b/ansible_ai_connect_chatbot/src/useChatbot/useChatbot.ts
@@ -46,6 +46,9 @@ export const readCookie = (name: string): string | null => {
   return null;
 };
 
+export const readCsrfCookie = (): string | null =>
+  readCookie("__Host-csrftoken") ?? readCookie("csrftoken");
+
 const getTimestamp = () => {
   const date = new Date();
   return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
@@ -189,7 +192,7 @@ export const useChatbot = () => {
       bodyElement = frameWindow.document.getElementsByTagName("body")[0];
     }
     const checkStatus = async () => {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
       try {
         const resp = await fetch("/api/v1/health/status/chatbot/", {
           method: "GET",
@@ -427,7 +430,7 @@ export const useChatbot = () => {
 
   const handleFeedback = async (feedbackRequest: ChatFeedback) => {
     try {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
       const resp = await fetch(
         import.meta.env.PROD
           ? "/api/v1/ai/feedback/"
@@ -519,7 +522,7 @@ export const useChatbot = () => {
     setIsLoading(true);
 
     try {
-      const csrfToken = readCookie("csrftoken");
+      const csrfToken = readCsrfCookie();
 
       if (isStreamingSupported()) {
         setHasStopButton(true);
@@ -534,7 +537,7 @@ export const useChatbot = () => {
             headers: {
               "Content-Type": "application/json",
               Accept: "application/json,text/event-stream",
-              "X-CSRFToken": csrfToken!,
+              ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
             },
             body: JSON.stringify(chatRequest),
             async onopen(resp: any) {


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-61711
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Claude Code

## Description

Harden cookie security: __Host- prefix, Secure flag, CSRF middleware
====================================================================
Changes
1. Cookie hardening settings (base.py)
--------------------------------------
- __Host- prefix on session and CSRF cookies (__Host-sessionid, __Host-csrftoken)
  — prevents subdomain cookie tossing
- Secure flag on both cookies — HTTPS-only transmission
- SameSite=Lax — allows OAuth/OIDC redirects while blocking cross-site POST
- CSRF_COOKIE_AGE reduced from Django's 1-year default to 2 weeks, aligned
  with SESSION_COOKIE_AGE
- CSRF_COOKIE_HTTPONLY=False — JS must read the cookie for X-CSRFToken headers
- Gateway cookie settings — GATEWAY_SESSION_COOKIE_NAME and
  GATEWAY_CSRF_COOKIE_NAME (env-configurable) for detecting gateway-proxied
  requests

2. Development overrides (development.py)
-----------------------------------------
- Removed CSRF_USE_SESSIONS=True (was a workaround for gateway stripping
  cookies)
- Added CSRF_COOKIE_SECURE=False and CSRF_COOKIE_NAME="csrftoken" — plain HTTP
  dev servers can't use __Host- prefix (requires Secure)
- Same for session: SESSION_COOKIE_SECURE=False, SESSION_COOKIE_NAME="sessionid"

3. EnsureCsrfCookieMiddleware (middleware.py)
---------------------------------------------
New middleware placed before CsrfViewMiddleware. Handles two deployment modes:

Standalone mode — 4 cases for cross-origin proxy / OAuth scenarios:
  1. Browser sent CSRF cookie — reuse existing secret
  2. No cookie but X-CSRFToken header — use header value (OAuth via gateway,
     cookie domain mismatch)
  3. No cookie, no header, POST with csrfmiddlewaretoken — inject form token
     (logout form)
  4. None of the above — generate fresh secret

Gateway mode — aliases the gateway's csrftoken cookie into Django's
CSRF_COOKIE_NAME so Django's CSRF validation passes

4. Console templates (console.html, denied.html)
-------------------------------------------------
- Added <div id="csrf_token" hidden>{{ csrf_token }}</div> — Django embeds the
  CSRF token in the DOM so JS can read it when cookies aren't available
  (cross-origin proxy)

5. Admin portal (ansible_ai_connect_admin_portal)
-------------------------------------------------
- readCsrfCookie() — 3-tier fallback: __Host-csrftoken cookie -> DOM csrf_token
  element -> csrftoken cookie
- X-CSRFToken header — changed from { "X-CSRFToken": csrfToken } (sends null)
  to csrfToken ? { ... } : {} (omits header entirely when no token)
- webpack dev server — migrated from deprecated
  onBeforeSetupMiddleware/onAfterSetupMiddleware to setupMiddlewares, and https
  to server option (webpack-dev-server v4+)

6. Standalone chatbot (ansible_ai_connect_chatbot)
--------------------------------------------------
- readCsrfCookie() — __Host-csrftoken with csrftoken fallback
- X-CSRFToken header — same csrfToken ? { ... } : {} pattern
- chatbot/index.html asset hash change is auto-generated by npm run build
  in the ansible_ai_connect_chatbot directory

7. Gateway chatbot (aap_chatbot)
--------------------------------
- isGatewayRequest() — mirrors middleware's gateway detection (gateway session
  cookie present, Django session cookie absent)
- readCsrfCookie() — behind gateway uses csrftoken; standalone uses
  __Host-csrftoken with csrftoken fallback
- X-CSRFToken header — same pattern

8. Tests
--------
Python (test_cookie_security.py — 35 tests, all new):
  - 14 base cookie settings + __Host- invariants
  - 4 development overrides
  - 2 gateway settings
  - 9 EnsureCsrfCookieMiddleware tests (all 4 code paths + precedence + edge
    cases)
  - 2 middleware stack position
  - 4 gateway middleware tests

TypeScript (across 3 test files):
  - Admin portal: cookie spy mock, __Host- extraction, partial name rejection,
    DOM fallback, null case, headers: {} for null token
  - Standalone chatbot: cookie spy mock, __Host- present, csrftoken fallback,
    preference, null
  - Gateway chatbot: all above + gateway detection (uses csrftoken),
    both-sessions (uses __Host-), null


9. API schema unchanged
-----------------------
No changes to OpenAPI/schema files. The API schema is only generated in
development mode (SPECTACULAR_SETTINGS in development.py), so the cookie
hardening settings in base.py do not affect schema generation.

10. Security audit
==================

Strong protections
------------------
- __Host- prefix — strongest cookie binding available. Prevents subdomain
  cookie tossing, forces Secure, forces Path=/. No bypass possible.

- SameSite=Lax — blocks cross-site POST requests from sending cookies. This is
  the primary CSRF defense in modern browsers. Lax (not Strict) is correct
  because Strict would break OAuth/OIDC redirect flows.

- Secure flag — cookies never transmitted over HTTP. Combined with __Host-,
  can't be downgraded.

- HttpOnly on session cookie — JS can't steal session tokens via XSS.

- CSRF_COOKIE_AGE reduced to 2 weeks — limits the window for token fixation.

- CSRF token rotation on login — Django calls rotate_token() in login() by
  default, invalidating pre-authentication tokens.

Acceptable trade-offs
---------------------
- CSRF_COOKIE_HTTPONLY=False — required for the double-submit pattern (JS reads
  cookie, echoes in X-CSRFToken header). An XSS attacker could read it, but XSS
  already allows making requests directly, so HttpOnly on the CSRF cookie adds
  no real protection.

- DOM-embedded {{ csrf_token }} — same reasoning. XSS makes CSRF protection
  moot regardless.

- Dev mode relaxation — removes __Host- and Secure for HTTP dev servers.
  Acceptable as long as production always uses base.py settings.

One area to flag
----------------
Case 3 (form token injection) — when no cookie and no header exist, we inject
the POST body's csrfmiddlewaretoken into request.COOKIES and let
CsrfViewMiddleware validate it. This effectively makes the cookie-side match the
form-side, weakening the double-submit pattern to a single-submit check.

Could an attacker exploit this? A cross-site attacker would craft a form POST
with a known csrfmiddlewaretoken. However:

  - SameSite=Lax blocks the session cookie on cross-site POST — user not
    authenticated — request fails before CSRF matters
  - Django's CsrfViewMiddleware also checks the Referer header on HTTPS
  - The form token in legitimate use was generated by {% csrf_token %} and
    embedded in an authenticated page the attacker can't read

Case 3 relies on SameSite=Lax as the primary defense rather than double-submit.
This is a slight weakening of defense-in-depth but not exploitable in practice.

Verdict
-------
The implementation is secure. The layered defenses (__Host- + Secure +
SameSite=Lax + CSRF double-submit + token rotation) are industry best practice.
The one trade-off (case 3) is mitigated by SameSite=Lax blocking the session
cookie on cross-site POST, making the CSRF check unreachable by an attacker.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. deploy AAP locally with lightspeed integration, with lightspeed configured with chatbot. 
3. The default scenario is with lightspeed running http 
4. login to AAP and try to make some requests to chatbot 
5. open localhost:7080 login with oauth 
6. open localhost:7080/chatbot/ ensure you can use the chatbot , put some question
7. go back to localhost:7080/ and logout 
8. open localhost:7080/console, you will be redirected to login , login
9. the console is displayed , logout 
10. no error page should be displayed

testing with aap-ui

1. cd to aap_chatboot and run npm run build and npm pack
git clone aap-ui
in package.json change ansible-ai-connect-chatbot to 
```"@ansible/ansible-ai-connect-chatbot": "file:/Users/djlezzou/projects/ansible/lightspeed/ansible-ai-connect-service/aap_chatbot/package",
2. run npm ci
3. cd platform
4. export PLATFORM_SERVER=https://localhost
5. run npm start
6. the browser open to the served ui , login make sure the chat bot is functional


for https case comment lines 86-89 and restart the lightspeed
repeat all the above tests you can ensure that the right cookie and sessionid are created with names __Host-csrftoken and __Host-sessionid
 
 

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [X] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [X] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
