### PR TITLE
Align GitHub workflows with aap-mcp-server security improvements

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -15,6 +15,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Only run for ansible organization
+    if: github.repository_owner == 'ansible'
+
+    permissions:
+      contents: read
+      pull-requests: read
+
     env:
       ANSIBLE_AI_DATABASE_HOST: localhost
       ANSIBLE_AI_DATABASE_NAME: wisdom
@@ -78,7 +85,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '21.x'
+        node-version: '22.x'
         cache: 'npm'
         cache-dependency-path: ./ansible_ai_connect_admin_portal/package-lock.json
 
@@ -96,7 +103,7 @@ jobs:
     - name: Use Node.js (chatbot)
       uses: actions/setup-node@v3
       with:
-        node-version: '21.x'
+        node-version: '22.x'
         cache: 'npm'
         cache-dependency-path: ./ansible_ai_connect_chatbot/package-lock.json
 

--- a/.github/workflows/sonar-pr.yaml
+++ b/.github/workflows/sonar-pr.yaml
@@ -21,13 +21,16 @@ on:
 
 jobs:
   sonar:
+    name: Upload to SonarCloud
+    runs-on: ubuntu-latest
+
+    # Only run for ansible organization
+    if: github.repository_owner == 'ansible' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+
     permissions:
       contents: read
       pull-requests: read
       actions: read
-    name: Upload to SonarCloud
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:


### PR DESCRIPTION
## Summary
- Add organization check to restrict workflows to ansible organization only
- Add explicit permissions blocks following CodeQL security best practices
- Update Node.js version from 21.x to 22.x for consistency with aap-mcp-server

## Changes
### `.github/workflows/code_coverage.yml`
- Added `if: github.repository_owner == 'ansible'` to prevent execution in forked/mirrored repos
- Added explicit permissions block (`contents: read`, `pull-requests: read`)
- Updated Node.js version to 22.x (admin portal and chatbot steps)

### `.github/workflows/sonar-pr.yaml`
- Added organization check to existing workflow condition
- Maintains existing permissions block

## Rationale
These changes align with security improvements implemented in [aap-mcp-server](https://github.com/ansible/aap-mcp-server):
- Commit [c28d7ef](https://github.com/ansible/aap-mcp-server/commit/c28d7eff45d3d3305247687e0f0c85ce9c430b29): Organization restriction
- Commit [3b7a691](https://github.com/ansible/aap-mcp-server/commit/3b7a69187da39358e031a5f38f9352cccfca0f65): Permissions and formatting

## Test Plan
- [x] Workflows should skip execution when run from forks/mirrors outside ansible org
- [x] Workflows should continue to function normally within ansible org
- [x] Node.js 22.x compatibility verified in aap-mcp-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)