### PR TITLE
Release AAP Chatbot UI package 0.1.13

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-ai-connect-chatbot",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-ai-connect-chatbot",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "@patternfly/chatbot": "^6.5.0",

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/ansible-ai-connect-chatbot",
   "type": "module",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "./dist/ansible-chatbot.umd.cjs",
   "module": "./dist/ansible-chatbot.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps `@ansible/ansible-ai-connect-chatbot` from 0.1.12 to 0.1.13
- Needed to publish the package with the `getProductName()` export (replaces `ANSIBLE_LIGHTSPEED_PRODUCT_NAME`)

## Test plan
- [ ] Merge this PR
- [ ] Run the "AAP Chatbot - Publish" workflow to publish 0.1.13 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)