### PR TITLE
Fix polynomial-runtime ReDoS in Ollama answer parsers (SonarCloud S5852)

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/pipelines.py
@@ -131,14 +131,14 @@ def unwrap_role_answer(message: str, create_outline: bool) -> tuple[str, list[di
 def unwrap_message_with_yaml_answer(message: str) -> str:
     task: str = message_to_string(message)
 
-    m = re.search(r".*?```(yaml|yml|)\n+(.+)```", task, re.MULTILINE | re.DOTALL)
+    m = re.search(r"```(yaml|yml|)\n(.+?)```", task, re.MULTILINE | re.DOTALL)
     return m.group(2).strip() if m else ""
 
 
 def unwrap_playbook_answer(message: str) -> tuple[str, str]:
     task: str = message_to_string(message)
 
-    m = re.search(r".*?```(yaml|)\n+(.+)```(.*)", task, re.MULTILINE | re.DOTALL)
+    m = re.search(r"```(yaml|)\n(.+?)```(.*)", task, re.MULTILINE | re.DOTALL)
     if m:
         playbook = m.group(2).strip()
         outline = m.group(3).lstrip().strip()
@@ -150,7 +150,7 @@ def unwrap_playbook_answer(message: str) -> tuple[str, str]:
 def unwrap_task_answer(message: str) -> str:
     task: str = message_to_string(message)
 
-    m = re.search(r"```(yaml|)\n+(.+)```", task, re.MULTILINE | re.DOTALL)
+    m = re.search(r"```(yaml|)\n(.+?)```", task, re.MULTILINE | re.DOTALL)
     if m:
         task = m.group(2)
     return dedent(re.split(r"- name: .+\n", task)[-1]).rstrip()

--- a/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/ollama/tests/test_pipelines.py
@@ -226,6 +226,26 @@ aws_region: "us-west-2"
         )
 
 
+class TestUnwrapAnswerFirstBlock(TestCase):
+    """The fenced-block extractors use linear (non-backtracking) regexes to avoid the
+    polynomial-runtime ReDoS flagged by SonarCloud (python:S5852). A side effect of the
+    bounded, lazy capture is that they now correctly extract only the *first* fenced
+    block instead of greedily spanning from the first to the last fence."""
+
+    def test_message_yaml_extracts_only_first_block(self):
+        answer = "```yaml\nfirst```\nmiddle\n```yaml\nsecond```\n"
+        self.assertEqual(unwrap_message_with_yaml_answer(answer), "first")
+
+    def test_playbook_extracts_only_first_block(self):
+        answer = "```\nfirst```\nmiddle\n```\nsecond```\n"
+        playbook, _outline = unwrap_playbook_answer(answer)
+        self.assertEqual(playbook, "first")
+
+    def test_task_extracts_only_first_block(self):
+        answer = "```\n- name: a\n  debug: x```\nmiddle\n```\n- name: b\n  debug: y```\n"
+        self.assertEqual(unwrap_task_answer(answer), "debug: x")
+
+
 class TestOllamaCompletionsPipeline(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## What

Rewrites the three fenced-block extraction regexes in `ollama/pipelines.py` (`unwrap_message_with_yaml_answer`, `unwrap_playbook_answer`, `unwrap_task_answer`) from a backtracking-prone form to a linear one, resolving the three **`python:S5852`** Security Hotspots SonarCloud flagged in the new-code period:

> Make sure the regex used here, which is vulnerable to polynomial runtime due to backtracking, cannot lead to denial of service.

## Why

Each regex combined two overlapping unbounded quantifiers, the classic polynomial-backtracking shape:

- a leading `.*?` (redundant under `re.search`, which already scans) followed by a greedy `(.+)` — two unbounded `.`-matchers separated by a literal (` ``` `) that `.` can itself match;
- a `\n+` separator that overlaps the `(.+)` content match under `re.DOTALL` (`\n` is matched by both).

## The change

```diff
- re.search(r".*?```(yaml|yml|)\n+(.+)```", task, re.MULTILINE | re.DOTALL)
+ re.search(r"```(yaml|yml|)\n(.+?)```", task, re.MULTILINE | re.DOTALL)
```

(and the analogous two). Drop the redundant `.*?`, collapse `\n+` → `\n`, make the content capture lazy `(.+?)`.

## Behavior

For a **single** fenced block — the normal model output and every existing test — behavior is identical. As a side effect, the parsers now extract only the **first** fenced block instead of greedily spanning from the first fence to the *last* one (the old behavior merged multiple code blocks and their literal ` ``` ` markers into the returned YAML, which was never valid). New `TestUnwrapAnswerFirstBlock` cases lock this in.

## Testing

- Added `TestUnwrapAnswerFirstBlock` (3 cases) — fail on the old regexes, pass on the new ones.
- Existing `TestUnwrapTaskAnswer` / `TestUnwrapPlaybookAnswer` / `TestUnwrapRoleAnswer` / pipeline tests are unaffected (all single-block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)