### PR TITLE
AAP-76479 AAP-76480: Bump vulnerable npm dependencies (CVE-2026-9277)

### DIFF
--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -31,7 +31,7 @@
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.0.0",
-        "axios": "^1.13.5",
+        "axios": "^1.16.1",
         "babel-jest": "^29.7.0",
         "babel-loader": "^8.2.3",
         "babel-preset-react-app": "^10.0.1",
@@ -74,7 +74,7 @@
         "tslib": "^2.6.2",
         "typescript": "^5.1.6",
         "webpack": "^5.64.4",
-        "webpack-dev-server": "^5.2.2",
+        "webpack-dev-server": "^5.2.4",
         "webpack-manifest-plugin": "^4.0.2",
         "webpack-mock-server": "^1.0.18",
         "workbox-webpack-plugin": "^6.4.1"
@@ -5592,9 +5592,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15711,9 +15711,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17014,9 +17014,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
@@ -18788,9 +18788,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -19556,9 +19556,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "axios": "^1.13.5",
+    "axios": "^1.16.1",
     "babel-jest": "^29.7.0",
     "babel-loader": "^8.2.3",
     "babel-preset-react-app": "^10.0.1",
@@ -74,7 +74,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.1.6",
     "webpack": "^5.64.4",
-    "webpack-dev-server": "^5.2.2",
+    "webpack-dev-server": "^5.2.4",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-mock-server": "^1.0.18",
     "workbox-webpack-plugin": "^6.4.1"
@@ -169,19 +169,13 @@
     ]
   },
   "overrides": {
-    "micromatch": "^4.0.8",
-    "uuid": ">=14.0.0",
-    "minimatch": "^3.1.4",
-    "bfj": "^9.1.2",
-    "flatted": "^3.4.2",
-    "serialize-javascript": "^7.0.5",
-    "http-proxy-agent": "^7.0.0",
-    "follow-redirects": ">=1.16.0",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "@svgr/webpack": {
       "@svgr/plugin-svgo": {
         "svgo": "3.3.3"
       }
     },
+    "bfj": "^9.1.2",
     "css-minimizer-webpack-plugin": {
       "cssnano": {
         "cssnano-preset-default": {
@@ -192,6 +186,15 @@
       }
     },
     "fast-uri": ">=3.1.1",
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
+    "flatted": "^3.4.2",
+    "follow-redirects": ">=1.16.0",
+    "http-proxy-agent": "^7.0.0",
+    "micromatch": "^4.0.8",
+    "minimatch": "^3.1.4",
+    "qs": "6.15.2",
+    "serialize-javascript": "^7.0.5",
+    "shell-quote": "1.8.4",
+    "uuid": ">=14.0.0",
+    "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump `shell-quote` to `1.8.4` for CVE-2026-9277
- also bump additional vulnerable npm deps in admin portal lock context to satisfy mandatory npm-audit CI gate (`axios`, `webpack-dev-server`) and override transitive vulnerable versions (`qs`, `ws`)
- patch `package-lock.json` surgically (no full lockfile regen)

## Security
- [x] Security fix
- CVE: CVE-2026-9277
- Jira: AAP-76479, AAP-76480

## Testing
- `npm audit --package-lock-only --json` now reports 0 vulnerabilities in `ansible_ai_connect_admin_portal`