### PR TITLE
Increase chatbot readiness health check timeout from 1s to 5s

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -154,7 +154,7 @@ class HttpChatBotMetaData(HttpMetaData):
             r = self.session.get(
                 self.config.inference_url + "/readiness",
                 headers=headers,
-                timeout=1,
+                timeout=5,
             )
             r.raise_for_status()
 


### PR DESCRIPTION
## Summary
- Increases the `/readiness` call timeout in `HttpChatBotMetaData.self_test()` from 1 second to 5 seconds
- The 1s timeout caused intermittent false-negative health check failures when external LLM providers (Azure OpenAI, RHOAI) were slow to respond to health probes
- Normal-case checks complete in ~0.2s, so 5s provides comfortable margin without slowing down the happy path

Closes: [AAP-77500](https://issues.redhat.com/browse/AAP-77500)

## Test plan
- [ ] Verify health check passes consistently with Azure OpenAI provider
- [ ] Verify health check passes consistently with RHOAI provider
- [ ] Confirm no regression in normal-case health check response time

🤖 Generated with [Claude Code](https://claude.com/claude-code)