### PR TITLE
Release aap-chatbot 0.1.15

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-ai-connect-chatbot",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-ai-connect-chatbot",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "@patternfly/chatbot": "^6.5.0",

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/ansible-ai-connect-chatbot",
   "type": "module",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "./dist/ansible-chatbot.umd.cjs",
   "module": "./dist/ansible-chatbot.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@ansible/ansible-ai-connect-chatbot` version from `0.1.14` to `0.1.15` in `aap_chatbot/package.json`
- Regenerate `aap_chatbot/package-lock.json` after install so lockfile version metadata matches the package version bump

## Test plan
- [x] Run `npm install` in `aap_chatbot`
- [x] Verify diff contains only `aap_chatbot/package.json` and `aap_chatbot/package-lock.json`