### PR TITLE
Add explicit x-ai-description for Chat endpoint (AAP-82242)

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -1151,6 +1151,11 @@ class Chat(AACSAPIView):
             503: OpenApiResponse(description="Service unavailable"),
         },
         summary="Chat request",
+        extensions={
+            "x-ai-description": "Query the Ansible Automation Platform knowledge base."
+            " Use this to answer questions about AAP concepts, features,"
+            " configuration, best practices, and troubleshooting.",
+        },
     )
     def post(self, request) -> Response:
         headers = {"Content-Type": "application/json"}

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -75,7 +75,7 @@
                         "description": "Service unavailable"
                     }
                 },
-                "x-ai-description": "Create new ai chat"
+                "x-ai-description": "Query the Ansible Automation Platform knowledge base. Use this to answer questions about AAP concepts, features, configuration, best practices, and troubleshooting."
             }
         },
         "/ai/completions/": {

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -47,7 +47,9 @@ paths:
           description: Internal server error
         '503':
           description: Service unavailable
-      x-ai-description: Create new ai chat
+      x-ai-description: Query the Ansible Automation Platform knowledge base. Use
+        this to answer questions about AAP concepts, features, configuration, best
+        practices, and troubleshooting.
   /ai/completions/:
     post:
       operationId: ai_completions_create


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-82242

Assisted-by: Claude Code

## Description
Add explicit `x-ai-description` to the Chat endpoint's `@extend_schema` decorator and regenerate the OpenAPI spec files. The auto-generated description `"Create new ai chat"` is too generic for LLMs to understand this endpoint is for querying the AAP knowledge base. This pairs with [aap-mcp-server#171](https://github.com/ansible/aap-mcp-server/pull/171) which moves the tool into the `content_discovery` toolset.

Once merged, the `sync-openapi-spec.yml` workflow will create a PR in `aap-openapi-specs` with the updated `lightspeed.json`.

## Testing
### Steps to test
1. Pull down the PR
2. `make start-db`
3. `make run-server`
4. `make create-cachetable`
5. `make update-openapi-schema`
6. Verify the `x-ai-description` for `POST /ai/chat/` in `tools/openapi-schema/ansible-ai-connect-service.json` matches the new description

### Scenarios tested
- Spun up Django dev server locally, ran `make update-openapi-schema`, verified the generated spec contains the new `x-ai-description`
- Verified the `@extend_schema` extensions pattern matches existing endpoints (explanations, generations, health, users views)

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)


### Backport Justification
LLM-facing metadata needs to be consistent across all supported releases so the MCP server content_discovery toolset works correctly regardless of which AAP version is deployed.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: