### PR TITLE
Update x-ai-description for Chat endpoint to reference RAG database (AAP-82242)

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -1152,9 +1152,9 @@ class Chat(AACSAPIView):
         },
         summary="Chat request",
         extensions={
-            "x-ai-description": "Query the Ansible Automation Platform knowledge base."
-            " Use this to answer questions about AAP concepts, features,"
-            " configuration, best practices, and troubleshooting.",
+            "x-ai-description": "Query the Ansible Automation Platform RAG database"
+            " for documentation and product guidance on installing, configuring,"
+            " and using AAP.",
         },
     )
     def post(self, request) -> Response:

--- a/tools/openapi-schema/ansible-ai-connect-service.json
+++ b/tools/openapi-schema/ansible-ai-connect-service.json
@@ -75,7 +75,7 @@
                         "description": "Service unavailable"
                     }
                 },
-                "x-ai-description": "Query the Ansible Automation Platform knowledge base. Use this to answer questions about AAP concepts, features, configuration, best practices, and troubleshooting."
+                "x-ai-description": "Query the Ansible Automation Platform RAG database for documentation and product guidance on installing, configuring, and using AAP."
             }
         },
         "/ai/completions/": {

--- a/tools/openapi-schema/ansible-ai-connect-service.yaml
+++ b/tools/openapi-schema/ansible-ai-connect-service.yaml
@@ -47,9 +47,8 @@ paths:
           description: Internal server error
         '503':
           description: Service unavailable
-      x-ai-description: Query the Ansible Automation Platform knowledge base. Use
-        this to answer questions about AAP concepts, features, configuration, best
-        practices, and troubleshooting.
+      x-ai-description: Query the Ansible Automation Platform RAG database for documentation
+        and product guidance on installing, configuring, and using AAP.
   /ai/completions/:
     post:
       operationId: ai_completions_create


### PR DESCRIPTION
## Summary
- Updates `x-ai-description` on the Chat endpoint to use "RAG database" instead of "knowledge base"
- Avoids confusion with the Red Hat Portal knowledge base (which is not included in the RAG)
- Regenerated OpenAPI spec files from running service

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)