### PR TITLE
POC: Lightweight token exchange for MCP server authentication

### DIFF
--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -305,12 +305,12 @@ class AACSAPIView(APIView):
                 provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
             )
         except UserSocialAuth.DoesNotExist:
-            logger.debug("No AAP social auth record for user %s", user.id)
+            logger.info("No AAP social auth record for user %s", user.id)
             return None
 
         refresh_token = social.extra_data.get("refresh_token")
         if not refresh_token:
-            logger.debug("No refresh token stored for user %s", user.id)
+            logger.info("No refresh token stored for user %s", user.id)
             return None
 
         import requests as http_requests

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -346,6 +346,10 @@ class AACSAPIView(APIView):
         jwt_header_name = "X-DAB-JW-TOKEN"
         token = request.headers.get(jwt_header_name, None)
         user = request.user
+        logger.info(
+            f"get_mcp_headers: token:{token} is_authenticated:{user.is_authenticated} "
+            f"aap_user:{user.aap_user} mcp_servers:{config.mcp_servers}"
+        )
         if token and user.is_authenticated and user.aap_user and config.mcp_servers:
             gateway_token = AACSAPIView._get_gateway_access_token(user)
             for mcp_server in config.mcp_servers:

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -357,18 +357,18 @@ class AACSAPIView(APIView):
             logger.info(f"gateway_token:{gateway_token}")
             for mcp_server in config.mcp_servers:
                 logger.info(f"mcp_server:{mcp_server}")
-                if mcp_server["type"] == "mcp-server" and gateway_token:
-                    logger.info(
-                        f"Setting MCP header - server_type: {mcp_server['type']}, "
-                        f"server_name: {mcp_server['name']}, header_name: Authorization"
-                    )
-                    mcp_headers[mcp_server["name"]] = {"X-Authorization": f"Bearer {gateway_token}"}
-                elif mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
-                    logger.info(
-                        f"Setting MCP header - server_type: {mcp_server['type']}, "
-                        f"server_name: {mcp_server['name']}, header_name: {jwt_header_name}"
-                    )
-                    mcp_headers[mcp_server["name"]] = {jwt_header_name: token}
+                # if mcp_server["type"] == "mcp-server" and gateway_token:
+                logger.info(
+                    f"Setting MCP header - server_type: {mcp_server['type']}, "
+                    f"server_name: {mcp_server['name']}, header_name: X-Authorization"
+                )
+                mcp_headers[mcp_server["name"]] = {"X-Authorization": f"Bearer {gateway_token}"}
+                # elif mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
+                #     logger.info(
+                #         f"Setting MCP header - server_type: {mcp_server['type']}, "
+                #         f"server_name: {mcp_server['name']}, header_name: {jwt_header_name}"
+                #     )
+                #     mcp_headers[mcp_server["name"]] = {jwt_header_name: token}
                 # This functionality seems experimental for gateway and does not allow the user to
                 # access wide range of api endpoints, we need to find a solution for gateway,
                 # but for the moment comment this code.

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -347,12 +347,16 @@ class AACSAPIView(APIView):
         token = request.headers.get(jwt_header_name, None)
         user = request.user
         logger.info(
-            f"get_mcp_headers: token:{token} is_authenticated:{user.is_authenticated} "
-            f"aap_user:{user.aap_user} mcp_servers:{config.mcp_servers}"
+            f"get_mcp_headers: token:{token}\n"
+            f"is_authenticated:{user.is_authenticated}\n"
+            f"aap_user:{user.aap_user}\n"
+            f"mcp_servers:{config.mcp_servers}"
         )
         if token and user.is_authenticated and user.aap_user and config.mcp_servers:
             gateway_token = AACSAPIView._get_gateway_access_token(user)
+            logger.info(f"gateway_token:{gateway_token}")
             for mcp_server in config.mcp_servers:
+                logger.info(f"mcp_server:{mcp_server}")
                 if mcp_server["type"] == "mcp-server" and gateway_token:
                     logger.info(
                         f"Setting MCP header - server_type: {mcp_server['type']}, "

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -350,13 +350,13 @@ class AACSAPIView(APIView):
             gateway_token = AACSAPIView._get_gateway_access_token(user)
             for mcp_server in config.mcp_servers:
                 if mcp_server["type"] == "mcp-server" and gateway_token:
-                    logger.debug(
+                    logger.info(
                         f"Setting MCP header - server_type: {mcp_server['type']}, "
                         f"server_name: {mcp_server['name']}, header_name: Authorization"
                     )
-                    mcp_headers[mcp_server["name"]] = {"Authorization": f"Bearer {gateway_token}"}
+                    mcp_headers[mcp_server["name"]] = {"X-Authorization": f"Bearer {gateway_token}"}
                 elif mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
-                    logger.debug(
+                    logger.info(
                         f"Setting MCP header - server_type: {mcp_server['type']}, "
                         f"server_name: {mcp_server['name']}, header_name: {jwt_header_name}"
                     )

--- a/ansible_ai_connect/ai/api/views.py
+++ b/ansible_ai_connect/ai/api/views.py
@@ -102,6 +102,7 @@ from ansible_ai_connect.ai.api.utils.segment import send_schema1_event
 from ansible_ai_connect.ai.api.utils.segment_analytics_telemetry import (
     send_segment_analytics_event,
 )
+from ansible_ai_connect.users.constants import USER_SOCIAL_AUTH_PROVIDER_AAP
 from ansible_ai_connect.users.models import User
 
 from ...main.permissions import IsAAPUser, IsRHInternalUser, IsTestUser
@@ -289,14 +290,72 @@ class AACSAPIView(APIView):
         return None
 
     @staticmethod
+    def _get_gateway_access_token(user) -> str | None:
+        """Exchange a user's stored AAP refresh token for a Gateway OAuth2 access token."""
+        cache_key = f"mcp_gateway_token_{user.id}"
+        cached = cache.get(cache_key)
+        if cached:
+            return cached
+
+        from social_django.models import UserSocialAuth
+
+        try:
+            social = UserSocialAuth.objects.get(
+                user=user,
+                provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
+            )
+        except UserSocialAuth.DoesNotExist:
+            logger.debug("No AAP social auth record for user %s", user.id)
+            return None
+
+        refresh_token = social.extra_data.get("refresh_token")
+        if not refresh_token:
+            logger.debug("No refresh token stored for user %s", user.id)
+            return None
+
+        import requests as http_requests
+
+        resp = http_requests.post(
+            f"{settings.AAP_API_URL}/o/token/",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": settings.SOCIAL_AUTH_AAP_KEY,
+                "client_secret": settings.SOCIAL_AUTH_AAP_SECRET,
+            },
+        )
+        if resp.status_code != 200:
+            logger.warning("Gateway token exchange failed: %s", resp.status_code)
+            return None
+
+        token_data = resp.json()
+        access_token = token_data["access_token"]
+        expires_in = max(token_data.get("expires_in", 3600) - 600, 60)
+        cache.set(cache_key, access_token, timeout=expires_in)
+
+        new_refresh = token_data.get("refresh_token")
+        if new_refresh and new_refresh != refresh_token:
+            social.extra_data["refresh_token"] = new_refresh
+            social.save(update_fields=["extra_data"])
+
+        return access_token
+
+    @staticmethod
     def get_mcp_headers(request: Request, config: HttpConfiguration) -> dict:
         mcp_headers = {}
         jwt_header_name = "X-DAB-JW-TOKEN"
         token = request.headers.get(jwt_header_name, None)
         user = request.user
-        if token and user.is_authenticated and user.aap_user:
+        if token and user.is_authenticated and user.aap_user and config.mcp_servers:
+            gateway_token = AACSAPIView._get_gateway_access_token(user)
             for mcp_server in config.mcp_servers:
-                if mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
+                if mcp_server["type"] == "mcp-server" and gateway_token:
+                    logger.debug(
+                        f"Setting MCP header - server_type: {mcp_server['type']}, "
+                        f"server_name: {mcp_server['name']}, header_name: Authorization"
+                    )
+                    mcp_headers[mcp_server["name"]] = {"Authorization": f"Bearer {gateway_token}"}
+                elif mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
                     logger.debug(
                         f"Setting MCP header - server_type: {mcp_server['type']}, "
                         f"server_name: {mcp_server['name']}, header_name: {jwt_header_name}"

--- a/docs/MCP-Authentication.md
+++ b/docs/MCP-Authentication.md
@@ -1,0 +1,239 @@
+# MCP Server Authentication Design Options
+
+## Background
+
+The Ansible Lightspeed chatbot integrates with MCP (Model Context Protocol)
+servers that need to call AAP Gateway APIs on behalf of the authenticated user.
+User-scoped RBAC must be preserved: when an MCP server calls a Gateway API, the
+call must execute with the permissions of the user who initiated the chat.
+
+### Current state
+
+The Lightspeed backend receives a DAB JWT (`X-DAB-JW-TOKEN`) from the
+authenticated user. This JWT cannot be used by MCP servers to call Gateway
+APIs directly because **Gateway's API accepts OAuth2 access tokens, not DAB
+JWTs**. These are different token types serving different purposes:
+
+| Token type | Header | Purpose |
+|---|---|---|
+| DAB JWT | `X-DAB-JW-TOKEN` | Internal DAB service-to-service communication (WebSocket auth, claims loading) |
+| OAuth2 access token | `Authorization: Bearer <token>` | Gateway public API access (programmatic) |
+| Session cookie | `awx_sessionid` | Gateway browser UI access |
+
+Gateway does not publish a JWKS endpoint, so external services cannot
+validate Gateway-issued tokens via standard OIDC discovery. Lightspeed Core
+Stack's `jwk-token` authentication module cannot be used here because there
+is no JWKS endpoint to point it at, and Gateway would not accept the
+validated token on its API regardless.
+
+The `ansible_base.jwt_consumer` module in DAB validates incoming JWTs and
+extracts user claims, but this is the inbound direction (tokens coming into
+Lightspeed), not the outbound direction (tokens going to Gateway).
+
+### Constraints
+
+- **User RBAC required** -- client credentials (service-level tokens) are
+  insufficient because the chatbot is user-facing and users expect their
+  permissions to apply to API calls made by MCP servers.
+- **AAP Gateway uses Django OAuth Toolkit (DOT)** -- DOT does not support
+  RFC 8693 (OAuth 2.0 Token Exchange). There is no open issue or PR for it
+  upstream.
+- **Security sensitivity** -- any solution that forwards raw user credentials
+  (cookies, session tokens) between services will face scrutiny in security
+  reviews.
+
+## Options
+
+### Option 1: Lightweight custom token exchange endpoint
+
+Build a small endpoint (in Gateway or Lightspeed) that accepts the user's
+existing JWT and issues a scoped OAuth2 access token.
+
+#### Flow
+
+```
+Lightspeed backend                    Token Exchange Endpoint
+     |                                         |
+     |-- POST /api/v1/token-exchange           |
+     |   Authorization: Bearer <DAB JWT>       |
+     |   Body: { scope: "mcp", audience: ... } |
+     |                                         |
+     |   1. Validate the JWT                   |
+     |   2. Look up the user                   |
+     |   3. Create an OAuth2 AccessToken       |
+     |      scoped to the user with RBAC       |
+     |   4. Return { access_token, expires_in }|
+     |                                         |
+     |<-- 200 { access_token: "...",           |
+     |         expires_in: 3600 }              |
+```
+
+#### Implementation
+
+A Django view that:
+
+1. Authenticates the request using the existing DAB JWT
+2. Calls Django OAuth Toolkit's
+   `AccessToken.objects.create(user=request.user, scope=..., expires=...)` to
+   issue a real OAuth2 token
+3. Returns the token to the Lightspeed backend
+4. The Lightspeed backend passes the token to MCP servers via
+   `X-Authorization: Bearer {access_token}`
+
+#### Pros
+
+- Clean separation -- MCP servers call Gateway directly with a standard
+  OAuth2 token
+- RBAC preserved -- the token is tied to the real user
+- Standard mechanism -- OAuth2 bearer tokens are well-understood
+- MCP servers are autonomous -- no dependency on Lightspeed for Gateway calls
+
+#### Cons
+
+- Requires code changes in Gateway (or Lightspeed, if Gateway can accept
+  tokens issued by Lightspeed)
+- Gateway team involvement likely required
+- New token type to manage (expiry, revocation, caching)
+
+### Option 2: Proxy pattern
+
+Route all MCP-to-Gateway API calls through the Lightspeed backend, which
+already has the user's authenticated session. No new tokens are issued.
+
+#### Flow
+
+```
+User (browser)       Lightspeed Backend       MCP Server       Gateway
+     |                      |                     |                |
+     |-- Chat message ----->|                     |                |
+     |                      |-- MCP tool call --->|                |
+     |                      |                     |                |
+     |                      |<-- proxy request ---|                |
+     |                      |   { method, path,   |                |
+     |                      |     params }         |                |
+     |                      |                     |                |
+     |                      |-- Gateway API call -|--------------->|
+     |                      |   (with user's      |                |
+     |                      |    session or JWT)   |                |
+     |                      |                     |                |
+     |                      |<--------------------|--- response ---|
+     |                      |-- proxy response -->|                |
+```
+
+#### Implementation
+
+1. MCP servers call back to the Lightspeed backend when they need Gateway
+   data, instead of calling Gateway directly
+2. The Lightspeed backend forwards the request to Gateway using the
+   credentials it already holds for the user
+3. An allowlist restricts which Gateway API endpoints can be proxied
+
+#### Pros
+
+- No new auth infrastructure -- uses existing credentials
+- No Gateway team dependency
+- Smaller security surface -- no tokens shared with MCP servers
+- Fastest to ship
+
+#### Cons
+
+- Added latency (extra network hop through Lightspeed)
+- Tighter coupling between Lightspeed and MCP servers
+- Lightspeed must maintain an allowlist of Gateway endpoints
+- MCP servers lose autonomy -- they depend on the proxy for Gateway access
+
+### Option 3: RFC 8693 token exchange (long-term)
+
+Request the Gateway team to implement RFC 8693 (OAuth 2.0 Token Exchange)
+as a custom grant type in Django OAuth Toolkit.
+
+This is the standard mechanism for the "service needs a token on behalf of
+a user" problem. The backend presents the user's existing token to the
+token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`
+and receives a new token scoped for downstream services.
+
+#### Pros
+
+- Standards-compliant
+- Cleanest long-term architecture
+- Reusable by other AAP services with the same need
+
+#### Cons
+
+- Django OAuth Toolkit does not support it natively
+- Requires upstream contribution or Gateway-specific extension
+- Cross-team effort with the Gateway team
+- Longer timeline
+
+## Comparison
+
+| Consideration              | Option 1 (Token Exchange) | Option 2 (Proxy) | Option 3 (RFC 8693) |
+|----------------------------|---------------------------|-------------------|---------------------|
+| RBAC preserved             | Yes                       | Yes               | Yes                 |
+| New auth code needed       | Yes                       | No                | Yes (in Gateway)    |
+| Gateway team involvement   | Likely                    | Minimal           | Required            |
+| MCP server autonomy        | High                      | Low               | High                |
+| Security surface           | Moderate                  | Smallest          | Moderate            |
+| Latency                    | Low                       | Higher            | Low                 |
+| Time to ship               | Medium                    | Fastest           | Longest             |
+
+## Recommendation
+
+The DAB JWT and Gateway OAuth2 access tokens are fundamentally different
+token types. The JWT cannot be "fixed" to work with Gateway's API — a
+different authentication mechanism is needed.
+
+1. **To ship quickly**, Option 2 (proxy) avoids cross-team dependencies and
+   new auth infrastructure. Lightspeed already has the user's authenticated
+   session and can proxy Gateway calls on behalf of MCP servers.
+2. **For cleaner long-term architecture**, Option 1 (lightweight token
+   exchange) gives MCP servers autonomy. This requires Gateway team
+   involvement to either build the exchange endpoint or accept tokens
+   issued by Lightspeed.
+
+## Approaches to avoid
+
+The POC in [PR #2049](https://github.com/ansible/ansible-ai-connect-service/pull/2049)
+automates the OAuth2 authorization code flow server-side by forwarding the
+user's cookies and CSRF token to the authorization endpoint and parsing the
+302 redirect. This approach has several security concerns:
+
+- **Cookie/credential forwarding** -- replaying user session cookies
+  server-side is a credential forwarding anti-pattern
+- **No redirect validation** -- the Location header is trusted without
+  verifying the target URL matches the expected redirect URI
+- **No `state` parameter** -- missing CSRF protection on the OAuth flow
+- **TLS verification disabled** -- `verify=False` on all requests
+- **Fragile coupling** -- depends on the authorization server's form
+  field names and redirect behavior
+
+This pattern should not move to production regardless of hardening applied.
+
+## Open questions
+
+- [x] ~~What specific error does Gateway return when MCP servers present the
+      DAB JWT?~~ — Gateway's API does not accept DAB JWTs. It requires
+      OAuth2 access tokens (`Authorization: Bearer`) or session cookies.
+- [x] ~~Can the DAB JWT be configured to include Gateway as a valid
+      audience?~~ — No. The tokens are different types; this is not an
+      audience configuration issue.
+- [x] ~~Does Gateway publish a JWKS endpoint?~~ — No. Gateway does not
+      expose `.well-known/jwks.json` or OIDC discovery endpoints for
+      external token validation.
+- [ ] Does the Gateway team have plans for any token delegation mechanism?
+- [ ] What Gateway API endpoints do MCP servers actually need to call?
+      (Determines scope of the proxy allowlist for Option 2)
+- [ ] For Option 1, would the Gateway team accept an endpoint that exchanges
+      a DAB JWT for a scoped OAuth2 access token?
+
+## References
+
+- [RFC 8693 - OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
+- [Django OAuth Toolkit Documentation](https://django-oauth-toolkit.readthedocs.io/)
+- [PR #2049 - POC mcp server integration oauth2 tokens](https://github.com/ansible/ansible-ai-connect-service/pull/2049)
+- [AAP-75808](https://redhat.atlassian.net/browse/AAP-75808)
+- [AAP Gateway](https://github.com/ansible-automation-platform/aap-gateway)
+- [Django Ansible Base (DAB)](https://github.com/ansible-automation-platform/django-ansible-base)
+- [DAB Channels Authentication](https://github.com/ansible/django-ansible-base/blob/devel/docs/lib/channels_authentication.md)
+- [LCS JWK Token Authentication](https://github.com/lightspeed-core/lightspeed-stack/blob/main/docs/auth/jwk-token.md)
+- [AAP 2.7 OIDC for HashiCorp Vault](https://developers.redhat.com/articles/2026/06/10/whats-new-red-hat-ansible-automation-platform-2-7)

--- a/docs/plans/mcp-token-exchange-poc.md
+++ b/docs/plans/mcp-token-exchange-poc.md
@@ -1,0 +1,138 @@
+# POC: Lightweight Token Exchange for MCP Server Authentication
+
+## Context
+
+MCP servers need Gateway OAuth2 access tokens to call Gateway APIs with user
+RBAC. The current DAB JWT (`X-DAB-JW-TOKEN`) is not accepted by Gateway's
+API. PR #2049's approach (automating the 302 redirect flow) has security
+concerns. See `docs/MCP-Authentication.md` for full background.
+
+**Key insight:** Users who log in via AAP OAuth2 (on-prem) already have a
+**refresh token from Gateway** stored in `UserSocialAuth.extra_data`. We can
+exchange that for a fresh Gateway access token via a standard
+`grant_type=refresh_token` call — no browser flow, no cookie forwarding.
+
+## Approach
+
+Create a token exchange utility function and integrate it into `get_mcp_headers`.
+The function:
+1. Looks up the user's `UserSocialAuth` record for the AAP provider
+2. Uses the stored `refresh_token` to call Gateway's `/o/token/`
+3. Caches the resulting access token (keyed by user ID, with TTL)
+4. Returns the access token for MCP servers
+
+## Files to modify
+
+### 1. `ansible_ai_connect/ai/api/views.py`
+
+- Add `_get_gateway_access_token(user)` function near `get_mcp_headers`
+- Replace the `_AUTH_ACCESS` plain dict with Django's cache framework
+- Update `get_mcp_headers` to call the new function for `"mcp-server"` type servers
+
+The function (~40 lines):
+
+```python
+from django.core.cache import cache
+from social_django.models import UserSocialAuth
+
+def _get_gateway_access_token(user) -> str | None:
+    cache_key = f"mcp_gateway_token_{user.id}"
+    cached = cache.get(cache_key)
+    if cached:
+        return cached
+
+    try:
+        social = UserSocialAuth.objects.get(
+            user=user,
+            provider=USER_SOCIAL_AUTH_PROVIDER_AAP,
+        )
+    except UserSocialAuth.DoesNotExist:
+        return None
+
+    refresh_token = social.extra_data.get("refresh_token")
+    if not refresh_token:
+        return None
+
+    resp = requests.post(
+        f"{settings.AAP_API_URL}/o/token/",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": settings.SOCIAL_AUTH_AAP_KEY,
+            "client_secret": settings.SOCIAL_AUTH_AAP_SECRET,
+        },
+    )
+    if resp.status_code != 200:
+        logger.warning("Gateway token exchange failed: %s", resp.status_code)
+        return None
+
+    token_data = resp.json()
+    access_token = token_data["access_token"]
+
+    # Cache with buffer before expiry (default 10 min before)
+    expires_in = max(token_data.get("expires_in", 3600) - 600, 60)
+    cache.set(cache_key, access_token, timeout=expires_in)
+
+    # Update stored refresh token if rotated
+    new_refresh = token_data.get("refresh_token")
+    if new_refresh and new_refresh != refresh_token:
+        social.extra_data["refresh_token"] = new_refresh
+        social.save(update_fields=["extra_data"])
+
+    return access_token
+```
+
+Then update `get_mcp_headers`:
+
+```python
+@staticmethod
+def get_mcp_headers(request, config):
+    mcp_headers = {}
+    jwt_header_name = "X-DAB-JW-TOKEN"
+    token = request.headers.get(jwt_header_name, None)
+    user = request.user
+    if token and user.is_authenticated and user.aap_user and config.mcp_servers:
+        gateway_token = _get_gateway_access_token(user)
+        for mcp_server in config.mcp_servers:
+            if mcp_server["type"] == "mcp-server" and gateway_token:
+                mcp_headers[mcp_server["name"]] = {
+                    "Authorization": f"Bearer {gateway_token}"
+                }
+            elif mcp_server["type"] in ["controller", "eda", "hub", "lightspeed"]:
+                mcp_headers[mcp_server["name"]] = {jwt_header_name: token}
+    return mcp_headers
+```
+
+### 2. Remove `_AUTH_ACCESS` dict
+
+Delete the `_AUTH_ACCESS = {}` module-level dict (from PR #2049) since
+we're using Django's cache framework instead.
+
+## What this does NOT need
+
+- No new URL endpoint (the exchange happens internally in `get_mcp_headers`)
+- No new Django app or model
+- No changes to Gateway
+- No cookie/CSRF forwarding
+- No 302 redirect handling
+
+## Line count
+
+The `_get_gateway_access_token` function is ~35 lines. The `get_mcp_headers`
+update is ~12 lines. Total: ~47 lines of new code.
+
+## Limitations (POC scope)
+
+- Only works for on-prem deployments where users log in via AAP OAuth2
+  (not SaaS/RHSSO or upstream/GitHub)
+- Depends on the refresh token being valid — if the user's Gateway session
+  expired and the refresh token is revoked, this returns None
+- The `requests.post` call should use TLS verification in production
+  (not `verify=False`)
+
+## Verification
+
+1. Log in via AAP OAuth2 (on-prem mode)
+2. Send a chat message that triggers an MCP server tool call
+3. Verify the MCP server receives `Authorization: Bearer <gateway-token>`
+4. Verify the MCP server can call Gateway APIs with the token


### PR DESCRIPTION
## Summary

- Replace the 302 redirect approach ([PR #2049](https://github.com/ansible/ansible-ai-connect-service/pull/2049)) with a standard OAuth2 `refresh_token` grant for obtaining Gateway access tokens for MCP servers
- Reuse the refresh token already stored in `UserSocialAuth` from the user's AAP OAuth2 login — no cookie forwarding, no redirect parsing, no `verify=False`
- Use Django's cache framework with TTL-based expiry instead of a plain module-level dict

## Background

MCP servers need to call AAP Gateway APIs with user RBAC. The DAB JWT (`X-DAB-JW-TOKEN`) is not accepted by Gateway's API — Gateway requires OAuth2 access tokens (`Authorization: Bearer`). See `docs/MCP-Authentication.md` for full design analysis.

PR #2049 solved this by automating the OAuth2 authorization code flow server-side (forwarding cookies, parsing the 302 redirect). That approach has security concerns:
- Cookie/credential forwarding
- No redirect URL validation
- No `state` parameter (OAuth CSRF protection)
- TLS verification disabled
- Fragile coupling to auth server form fields

## This approach

Users who log in via AAP OAuth2 already have a **refresh token from Gateway** stored in `UserSocialAuth.extra_data`. This POC simply exchanges that refresh token for a fresh access token:

```mermaid
sequenceDiagram
    participant Client as Lightspeed Backend<br/>(get_mcp_headers)
    participant Cache as Django Cache
    participant DB as UserSocialAuth
    participant Gateway as AAP Gateway<br/>OAuth Server
    participant MCP as MCP Server

    Client->>Cache: Check cached access_token<br/>for user.id
    alt Token cached
        Cache-->>Client: access_token
    else Cache miss
        Cache-->>Client: None

        Client->>DB: Get UserSocialAuth<br/>(user, provider="aap")
        DB-->>Client: extra_data.refresh_token

        Client->>Gateway: POST /o/token/<br/>(grant_type=refresh_token,<br/>refresh_token, client_id,<br/>client_secret)
        Gateway-->>Client: 200 OK<br/>{access_token, expires_in,<br/>refresh_token}

        Client->>Cache: Store access_token<br/>with TTL (expires_in − 10 min)

        opt Refresh token rotated
            Client->>DB: Update stored<br/>refresh_token
        end
    end

    loop For each MCP server (type: "mcp-server")
        Client->>MCP: Set header<br/>Authorization: Bearer {access_token}
    end
```

## Changes

**`ansible_ai_connect/ai/api/views.py`** (1 file, ~50 lines):

- **`_get_gateway_access_token(user)`** — exchanges stored refresh token for a Gateway access token. Caches the result with TTL (10 min before expiry). Updates the stored refresh token if Gateway rotates it.
- **`get_mcp_headers()`** — updated to provide `Authorization: Bearer <gateway-token>` for `"mcp-server"` type servers, while keeping the DAB JWT for other AAP services (controller, eda, hub, lightspeed).

## Security comparison

| Concern | PR #2049 (302 redirect) | This POC (refresh_token) |
|---|---|---|
| Cookie forwarding | Yes — replays user session | No |
| Redirect validation | Missing | N/A — no redirects |
| OAuth `state` parameter | Missing | N/A — no auth code flow |
| TLS verification | Disabled (`verify=False`) | Default (enabled) |
| Credential type | Cookies + CSRF token | OAuth2 refresh_token (designed for this) |
| Token caching | Plain dict, no TTL | Django cache with TTL |

## Limitations (POC scope)

- Only works for on-prem deployments (AAP OAuth2 login). SaaS (RHSSO) and upstream (GitHub) use different auth providers.
- Depends on the refresh token being valid. If Gateway revoked it, returns `None` gracefully.
- No unit tests yet (POC).

## Test plan

- [ ] Log in via AAP OAuth2 (on-prem mode)
- [ ] Send a chat message that triggers an MCP server tool call
- [ ] Verify MCP server receives `Authorization: Bearer <gateway-token>`
- [ ] Verify MCP server can call Gateway APIs with the token
- [ ] Verify token caching (second request should not hit Gateway `/o/token/`)

Jira: [AAP-75808](https://redhat.atlassian.net/browse/AAP-75808)

Assisted-by: Claude Code / Opus 4.6 (Anthropic)