### PR TITLE
AAP-81280: Enforce TLS certificate validation defaults (CTRL-001)

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/pipelines.py
@@ -328,9 +328,12 @@ class HttpStreamingChatBotPipeline(
             ssl.SSLError: If SSL context creation fails when verify_ssl=True
         """
         if not verify_ssl:
-            # SECURITY NOTE: This disables SSL verification
-            # should only be used in development/testing
-            # This matches requests.Session.verify=False behavior for consistency
+            if not settings.DEBUG:
+                logger.critical(
+                    "SECURITY WARNING: SSL verification is disabled for aiohttp "
+                    "connector (DEBUG=False). All HTTPS traffic through this "
+                    "connector is vulnerable to man-in-the-middle attacks.",
+                )
             return aiohttp.TCPConnector(ssl=False)
 
         # Get SSL context from centralized SSL manager

--- a/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_ssl_manager_integration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_ssl_manager_integration.py
@@ -17,8 +17,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import requests
-from django.test import TestCase as DjangoTestCase
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from ansible_ai_connect.ai.api.model_pipelines.http.configuration import (
     HttpConfiguration,
@@ -139,7 +138,7 @@ class TestWCAPipelineSSLManagerIntegration(TestCase):
             self.assertEqual(pipeline.session, mock_session)
 
 
-class TestHttpStreamingPipelineSSLManagerIntegration(DjangoTestCase):
+class TestHttpStreamingPipelineSSLManagerIntegration(SimpleTestCase):
     """Test HTTP streaming pipeline integration with centralized SSL manager"""
 
     def setUp(self):
@@ -174,27 +173,27 @@ class TestHttpStreamingPipelineSSLManagerIntegration(DjangoTestCase):
         self.assertEqual(pipeline.config.verify_ssl, False)
 
     @override_settings(DEBUG=False)
-    def test_aiohttp_connector_ssl_disabled_logs_critical_production(self):
+    @patch("aiohttp.TCPConnector")
+    def test_aiohttp_connector_ssl_disabled_logs_critical_production(self, mock_tcp_connector):
         pipeline = HttpStreamingChatBotPipeline(config=self.config)
         with self.assertLogs(
             logger="ansible_ai_connect.ai.api.model_pipelines.http.pipelines",
             level="CRITICAL",
         ) as log:
-            connector = pipeline._get_aiohttp_connector(verify_ssl=False)
-        self.assertTrue(
-            any("SSL verification is disabled" in msg for msg in log.output)
-        )
-        self.assertIsNotNone(connector)
+            pipeline._get_aiohttp_connector(verify_ssl=False)
+        self.assertTrue(any("SSL verification is disabled" in msg for msg in log.output))
+        mock_tcp_connector.assert_called_once_with(ssl=False)
 
     @override_settings(DEBUG=True)
-    def test_aiohttp_connector_ssl_disabled_no_critical_debug(self):
+    @patch("aiohttp.TCPConnector")
+    def test_aiohttp_connector_ssl_disabled_no_critical_debug(self, mock_tcp_connector):
         pipeline = HttpStreamingChatBotPipeline(config=self.config)
         with self.assertNoLogs(
             logger="ansible_ai_connect.ai.api.model_pipelines.http.pipelines",
             level="CRITICAL",
         ):
-            connector = pipeline._get_aiohttp_connector(verify_ssl=False)
-        self.assertIsNotNone(connector)
+            pipeline._get_aiohttp_connector(verify_ssl=False)
+        mock_tcp_connector.assert_called_once_with(ssl=False)
 
 
 class TestSSLManagerBehavior(TestCase):

--- a/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_ssl_manager_integration.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/http/tests/test_ssl_manager_integration.py
@@ -17,6 +17,8 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import requests
+from django.test import TestCase as DjangoTestCase
+from django.test import override_settings
 
 from ansible_ai_connect.ai.api.model_pipelines.http.configuration import (
     HttpConfiguration,
@@ -137,7 +139,7 @@ class TestWCAPipelineSSLManagerIntegration(TestCase):
             self.assertEqual(pipeline.session, mock_session)
 
 
-class TestHttpStreamingPipelineSSLManagerIntegration(TestCase):
+class TestHttpStreamingPipelineSSLManagerIntegration(DjangoTestCase):
     """Test HTTP streaming pipeline integration with centralized SSL manager"""
 
     def setUp(self):
@@ -170,6 +172,29 @@ class TestHttpStreamingPipelineSSLManagerIntegration(TestCase):
         pipeline = HttpStreamingChatBotPipeline(config=config_ssl_disabled)
         self.assertIsNotNone(pipeline)
         self.assertEqual(pipeline.config.verify_ssl, False)
+
+    @override_settings(DEBUG=False)
+    def test_aiohttp_connector_ssl_disabled_logs_critical_production(self):
+        pipeline = HttpStreamingChatBotPipeline(config=self.config)
+        with self.assertLogs(
+            logger="ansible_ai_connect.ai.api.model_pipelines.http.pipelines",
+            level="CRITICAL",
+        ) as log:
+            connector = pipeline._get_aiohttp_connector(verify_ssl=False)
+        self.assertTrue(
+            any("SSL verification is disabled" in msg for msg in log.output)
+        )
+        self.assertIsNotNone(connector)
+
+    @override_settings(DEBUG=True)
+    def test_aiohttp_connector_ssl_disabled_no_critical_debug(self):
+        pipeline = HttpStreamingChatBotPipeline(config=self.config)
+        with self.assertNoLogs(
+            logger="ansible_ai_connect.ai.api.model_pipelines.http.pipelines",
+            level="CRITICAL",
+        ):
+            connector = pipeline._get_aiohttp_connector(verify_ssl=False)
+        self.assertIsNotNone(connector)
 
 
 class TestSSLManagerBehavior(TestCase):

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -211,6 +211,13 @@ class WCABaseMetaData(
 
         # Ignore SSL errors with inference_url
         if not self.config.verify_ssl:
+            if not settings.DEBUG:
+                logger.critical(
+                    "SECURITY WARNING: SSL verification is disabled for WCA inference "
+                    "URL '%s' (DEBUG=False). This exposes model inference traffic to "
+                    "man-in-the-middle attacks.",
+                    self.config.inference_url,
+                )
             self.session.mount(
                 self.config.inference_url,
                 AllowBrokenSSLContextHTTPAdapter(),

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
@@ -169,11 +169,9 @@ class TestWCABaseMetaDataSSL(SimpleTestCase):
             logger="ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base",
             level="CRITICAL",
         ) as log:
-            metadata = WCAOnPremMetaData(config)
+            WCAOnPremMetaData(config)
 
-        self.assertTrue(
-            any("SSL verification is disabled" in msg for msg in log.output)
-        )
+        self.assertTrue(any("SSL verification is disabled" in msg for msg in log.output))
         mock_session.mount.assert_called_once()
 
     @override_settings(DEBUG=True)
@@ -187,7 +185,7 @@ class TestWCABaseMetaDataSSL(SimpleTestCase):
             logger="ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base",
             level="CRITICAL",
         ):
-            metadata = WCAOnPremMetaData(config)
+            WCAOnPremMetaData(config)
 
         mock_session.mount.assert_called_once()
 

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
@@ -24,7 +24,7 @@ to ensure external service connectivity works correctly with centralized SSL man
 from unittest.mock import Mock, patch
 
 import requests
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_onprem import (
     WCAOnPremMetaData,
@@ -157,6 +157,39 @@ class TestWCABaseMetaDataSSL(SimpleTestCase):
         # Test timeout calculation with None
         self.assertIsNone(metadata.task_gen_timeout(1))
         self.assertIsNone(metadata.task_gen_timeout(5))
+
+    @override_settings(DEBUG=False)
+    @patch("ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base.ssl_manager")
+    def test_ssl_disabled_logs_critical_in_production(self, mock_ssl_manager):
+        config = self._create_mock_config(verify_ssl=False)
+        mock_session = Mock(spec=requests.Session)
+        mock_ssl_manager.get_requests_session.return_value = mock_session
+
+        with self.assertLogs(
+            logger="ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base",
+            level="CRITICAL",
+        ) as log:
+            metadata = WCAOnPremMetaData(config)
+
+        self.assertTrue(
+            any("SSL verification is disabled" in msg for msg in log.output)
+        )
+        mock_session.mount.assert_called_once()
+
+    @override_settings(DEBUG=True)
+    @patch("ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base.ssl_manager")
+    def test_ssl_disabled_no_critical_in_debug(self, mock_ssl_manager):
+        config = self._create_mock_config(verify_ssl=False)
+        mock_session = Mock(spec=requests.Session)
+        mock_ssl_manager.get_requests_session.return_value = mock_session
+
+        with self.assertNoLogs(
+            logger="ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base",
+            level="CRITICAL",
+        ):
+            metadata = WCAOnPremMetaData(config)
+
+        mock_session.mount.assert_called_once()
 
 
 class TestWCASSLConfigurationIntegration(SimpleTestCase):

--- a/ansible_ai_connect/ai/apps.py
+++ b/ansible_ai_connect/ai/apps.py
@@ -50,7 +50,29 @@ class AiConfig(AppConfig):
 
     def ready(self) -> None:
         self._pipeline_factory = ModelPipelineFactory()
+        self._check_tls_settings()
         return super().ready()
+
+    @staticmethod
+    def _check_tls_settings() -> None:
+        if settings.DEBUG:
+            return
+
+        if not settings.ANSIBLE_BASE_JWT_VALIDATE_CERT:
+            logger.critical(
+                "SECURITY WARNING: ANSIBLE_BASE_JWT_VALIDATE_CERT is disabled "
+                "(DEBUG=False). JWT certificate validation is OFF. "
+                "This exposes the service to man-in-the-middle attacks. "
+                "Set ANSIBLE_BASE_JWT_VALIDATE_CERT=True or remove the override."
+            )
+
+        if not settings.SOCIAL_AUTH_VERIFY_SSL:
+            logger.critical(
+                "SECURITY WARNING: SOCIAL_AUTH_VERIFY_SSL is disabled "
+                "(DEBUG=False). SSL verification for social auth is OFF. "
+                "This exposes authentication flows to man-in-the-middle attacks. "
+                "Set SOCIAL_AUTH_VERIFY_SSL=True or remove the override."
+            )
 
     def get_model_pipeline(self, feature: Type[PIPELINE_TYPE]) -> PIPELINE_TYPE:
         return self._pipeline_factory.get_pipeline(feature)

--- a/ansible_ai_connect/ai/tests/test_apps.py
+++ b/ansible_ai_connect/ai/tests/test_apps.py
@@ -272,3 +272,29 @@ class TestAiApp(WisdomServiceLogAwareTestCase):
     def test_wca_onprem_disable_wca(self):
         app_config = AppConfig.create("ansible_ai_connect.ai")
         app_config.ready()
+
+    @override_settings(DEBUG=False, ANSIBLE_BASE_JWT_VALIDATE_CERT=False)
+    def test_tls_warning_jwt_cert_disabled_production(self):
+        app_config = AppConfig.create("ansible_ai_connect.ai")
+        with self.assertLogs(logger="ansible_ai_connect.ai.apps", level="CRITICAL") as log:
+            app_config.ready()
+            self.assertInLog("ANSIBLE_BASE_JWT_VALIDATE_CERT is disabled", log)
+
+    @override_settings(DEBUG=True, ANSIBLE_BASE_JWT_VALIDATE_CERT=False)
+    def test_no_tls_warning_jwt_cert_disabled_debug(self):
+        app_config = AppConfig.create("ansible_ai_connect.ai")
+        app_config.ready()
+
+    @override_settings(DEBUG=False, SOCIAL_AUTH_VERIFY_SSL=False)
+    def test_tls_warning_social_auth_ssl_disabled_production(self):
+        app_config = AppConfig.create("ansible_ai_connect.ai")
+        with self.assertLogs(logger="ansible_ai_connect.ai.apps", level="CRITICAL") as log:
+            app_config.ready()
+            self.assertInLog("SOCIAL_AUTH_VERIFY_SSL is disabled", log)
+
+    @override_settings(
+        DEBUG=False, ANSIBLE_BASE_JWT_VALIDATE_CERT=True, SOCIAL_AUTH_VERIFY_SSL=True
+    )
+    def test_no_tls_warning_when_all_enabled(self):
+        app_config = AppConfig.create("ansible_ai_connect.ai")
+        app_config.ready()

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -342,8 +342,8 @@ ANSIBLE_BASE_REST_FILTERS_RESERVED_NAMES = (
 
 ANSIBLE_BASE_JWT_KEY = os.getenv("ANSIBLE_BASE_JWT_KEY")
 ANSIBLE_BASE_JWT_VALIDATE_CERT = (
-    os.getenv("ANSIBLE_BASE_JWT_VALIDATE_CERT", "False").lower() == "true"
-) or False
+    os.getenv("ANSIBLE_BASE_JWT_VALIDATE_CERT", "True").lower() != "false"
+)
 ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = json.loads(
     os.getenv("ANSIBLE_BASE_MANAGED_ROLE_REGISTRY", "{}")
 )

--- a/docs/config/examples/README-ANSIBLE_AI_MODEL_MESH_CONFIG.md
+++ b/docs/config/examples/README-ANSIBLE_AI_MODEL_MESH_CONFIG.md
@@ -172,9 +172,17 @@ In this example, SSL verification will use the system's default CA bundle since 
 
 In this example, SSL verification is disabled since no `ca_cert_file` is provided and `verify_ssl` is `false`.
 
+> **Security Warning:** Disabling SSL verification (`verify_ssl: false`) in production
+> creates a man-in-the-middle (MITM) risk. All HTTPS traffic between the service and the
+> model inference endpoint will be sent without certificate validation, allowing an attacker
+> on the network path to intercept or modify requests and responses. Only disable SSL
+> verification in isolated development or testing environments. In production, use
+> `ca_cert_file` to specify a custom CA certificate if the default system CA bundle does
+> not include the required certificates.
+
 ## Use Cases
 
 - **OpenShift/Kubernetes environments**: Use `ca_cert_file` to specify the service account CA certificate
 - **Internal services with custom certificates**: Use `ca_cert_file` to specify the internal CA certificate
-- **Development/testing**: Use `verify_ssl: false` to disable SSL verification
+- **Development/testing**: Use `verify_ssl: false` to disable SSL verification (**never in production** — see security warning above)
 - **Public services**: Use `verify_ssl: true` with system default CA bundle


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-81280>

Assisted-by: Claude Code (Claude Opus 4.6)

## Description

Addresses SDLC threat model ticket AAP-81280 (CTRL-001: Enforce TLS Certificate Validation).

- **AR-01**: Flip `ANSIBLE_BASE_JWT_VALIDATE_CERT` default from `False` to `True` (secure by default — only explicit `"false"` disables it; typos like `"fls"` default to `True`)
- **AR-02/AR-05**: Add `_check_tls_settings()` startup check in `AiConfig.ready()` — logs `CRITICAL` when `ANSIBLE_BASE_JWT_VALIDATE_CERT` or `SOCIAL_AUTH_VERIFY_SSL` is disabled in production (`DEBUG=False`)
- **AR-03**: Add `CRITICAL` log warning before mounting `AllowBrokenSSLContextHTTPAdapter` when `verify_ssl=false` in production
- **AR-04**: Add `CRITICAL` log warning before creating `aiohttp.TCPConnector(ssl=False)` in production
- **Documentation**: Add MITM security warning to `verify_ssl: false` documentation

### Design decisions

- **CRITICAL log warnings, not hard blocks**: `verify_ssl: false` and `ANSIBLE_BASE_JWT_VALIDATE_CERT=False` are still allowed in production to preserve PoC/development compatibility. The warnings ensure insecure configurations are highly visible in logs.
- **`DEBUG` gate**: All warnings are suppressed when `DEBUG=True` to avoid noise during local development.
- **Secure-by-default env var parsing**: Uses `!= "false"` pattern so that any invalid/typo value (e.g., `"tru"`, `"fls"`) results in `True` (secure default).

## Testing

### Steps to test
1. Pull down the PR
2. Run unit tests: `make test WISDOM_TEST=ansible_ai_connect.ai.tests.test_apps.TestAiApp`
3. Run WCA SSL tests: `make test WISDOM_TEST=ansible_ai_connect.ai.api.model_pipelines.wca.tests.test_pipelines_base_ssl`
4. Run HTTP SSL tests: `make test WISDOM_TEST=ansible_ai_connect.ai.api.model_pipelines.http.tests.test_ssl_manager_integration`
5. Verify `ANSIBLE_BASE_JWT_VALIDATE_CERT` defaults to `True` when env var is unset
6. Verify `ANSIBLE_BASE_JWT_VALIDATE_CERT=false` still works for on-prem deployments that need it

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [x] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.7` - Backport to stable-2.7 branch

### Backport Justification
- Security hardening from SDLC threat model review (AAP-81280 / CTRL-001)
- Ensures TLS certificate validation defaults are secure-by-default
- Adds visibility for insecure TLS configurations in production logs

**Special backport considerations:**
- Should apply cleanly to stable-2.7. The `ANSIBLE_BASE_JWT_VALIDATE_CERT` default change may need operator-side verification for on-prem deployments.

### Scenarios tested
- Verified all 8 new unit tests cover positive and negative cases for TLS warnings
- Verified `_check_tls_settings()` skips warnings when `DEBUG=True`
- Verified `AllowBrokenSSLContextHTTPAdapter` mount still occurs even when warning is logged
- Verified `aiohttp.TCPConnector(ssl=False)` still returned even when warning is logged

## Production deployment
- [ ] This code change is ready for production on its own
- [x] This code change requires the following considerations before going to production:

**Note**: The `ANSIBLE_BASE_JWT_VALIDATE_CERT` default change from `False` to `True` may affect on-prem deployments that rely on the old default. These deployments should explicitly set `ANSIBLE_BASE_JWT_VALIDATE_CERT=False` in their configmap if they need to disable JWT certificate validation. SaaS/upstream/dev deployments are not affected since this setting only applies when `ANSIBLE_BASE_JWT_KEY` is configured (on-prem AAP Gateway integration).