### PR TITLE
fix(auth): prioritize JWT authentication and fix CSRF cookie collision

### DIFF
--- a/ansible_ai_connect/ai/api/versions/v1/tests/test_jwt_authentication.py
+++ b/ansible_ai_connect/ai/api/versions/v1/tests/test_jwt_authentication.py
@@ -4,7 +4,7 @@ import string
 import uuid
 from datetime import datetime, timedelta
 from http import HTTPStatus
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import jwt
 from cryptography.hazmat.backends import default_backend
@@ -206,3 +206,36 @@ class TestJWTAuthentication(APIVersionTestCaseBase, APITransactionTestCase):
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(response.data, expected_response)
+
+    def test_mcp_headers_empty_without_token(self):
+        """get_mcp_headers returns empty dict when no X-DAB-JW-TOKEN is present."""
+        from ansible_ai_connect.ai.api.views import Chat
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.user.is_authenticated = True
+
+        mock_config = MagicMock()
+        mock_config.mcp_servers = [
+            {"name": "mcp::aap-controller", "type": "controller"},
+        ]
+
+        mcp_headers = Chat.get_mcp_headers(mock_request, mock_config)
+        self.assertEqual(mcp_headers, {})
+
+    def test_jwt_auth_sets_aap_user_with_active_session(self):
+        """Regression test for AAP-82827: When both a session cookie and JWT
+        token are present, JWT auth should resolve first and set aap_user=True."""
+        self.jwt_client.get(self.api_version_reverse("me"))
+        user = User.objects.get(username=self.username)
+        self.assertTrue(user.aap_user)
+
+        user.aap_user = False
+        user.save()
+
+        client = self.client_class(headers={"X-DAB-JW-TOKEN": self.encrypted_token})
+        client.force_login(user)
+
+        response = client.get(self.api_version_reverse("me"))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTrue(response.wsgi_request.user.aap_user)

--- a/ansible_ai_connect/main/middleware.py
+++ b/ansible_ai_connect/main/middleware.py
@@ -69,12 +69,12 @@ class EnsureCsrfCookieMiddleware:
         self.get_response = get_response
 
     def _is_gateway_request(self, request):
-        """Detect gateway-proxied requests: gateway session cookie is
-        present but Django's own session cookie is not."""
-        return (
-            settings.GATEWAY_SESSION_COOKIE_NAME in request.COOKIES
-            and settings.SESSION_COOKIE_NAME not in request.COOKIES
-        )
+        """Detect gateway-proxied requests by the presence of the
+        gateway session cookie.  The previous check also required
+        Django's own session cookie to be absent, but that breaks
+        when both cookies coexist (e.g. the user visited Lightspeed
+        on port 8447 in the same browser — AAP-82827)."""
+        return settings.GATEWAY_SESSION_COOKIE_NAME in request.COOKIES
 
     def _ensure_csrf_cookie(self, request):
         """Ensure the CSRF secret is available in request.META and

--- a/ansible_ai_connect/main/settings/base.py
+++ b/ansible_ai_connect/main/settings/base.py
@@ -300,10 +300,10 @@ REST_FRAMEWORK = {
     },
     "PAGE_SIZE": 10,
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        "ansible_ai_connect.users.authentication.LightspeedJWTAuthentication",
         "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
         "rest_framework.authentication.SessionAuthentication",
         "ansible_ai_connect.users.auth.RHSSOAuthentication",
-        "ansible_ai_connect.users.authentication.LightspeedJWTAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/ansible_ai_connect/main/settings/tests/test_cookie_security.py
+++ b/ansible_ai_connect/main/settings/tests/test_cookie_security.py
@@ -215,14 +215,18 @@ class TestEnsureCsrfCookieMiddlewareGateway(TestCase):
         middleware(request)
         self.assertFalse(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
 
-    def test_standalone_when_both_sessions_exist(self):
+    def test_gateway_csrf_when_both_sessions_exist(self):
+        """AAP-82827: when both gateway and Django session cookies exist
+        (cookie collision from port 8447), treat as gateway request."""
         request = self.factory.get("/")
         request.COOKIES["gateway_sessionid"] = "gw_session"
         request.COOKIES[settings.SESSION_COOKIE_NAME] = "django_session"
         request.COOKIES["csrftoken"] = "gwCsrfToken1234567890abcdefABCDE"
         middleware = EnsureCsrfCookieMiddleware(get_response=lambda r: HttpResponse())
         middleware(request)
-        self.assertTrue(request.META.get("CSRF_COOKIE_NEEDS_UPDATE"))
+        self.assertEqual(
+            request.COOKIES[settings.CSRF_COOKIE_NAME], "gwCsrfToken1234567890abcdefABCDE"
+        )
 
     def test_falls_back_to_standalone_when_gateway_csrf_cookie_missing(self):
         request = self.factory.get("/")

--- a/ansible_ai_connect/users/authentication.py
+++ b/ansible_ai_connect/users/authentication.py
@@ -3,6 +3,9 @@ from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 
 class LightspeedJWTAuthentication(JWTAuthentication):
 
+    def authenticate_header(self, request):
+        return 'Bearer realm="api"'
+
     def authenticate(self, request):
         userdata = super().authenticate(request)
         if userdata:


### PR DESCRIPTION

<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-82827
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Claude Code

## Description
fix(auth): prioritize JWT authentication and fix CSRF cookie collision (AAP-82827) Move LightspeedJWTAuthentication to the first position in DEFAULT_AUTHENTICATION_CLASSES so that Gateway-injected X-DAB-JW-TOKEN headers are always processed before OAuth2 or session cookies.  This prevents a 403 when the user visits Lightspeed on port 8447 in the same browser as the Gateway UI — the OAuth/session cookies no longer shadow the JWT authentication path.


Since LightspeedJWTAuthentication is now the first auth class, add
authenticate_header() returning 'Bearer realm="api"'.  DRF calls
authenticate_header() on the first authenticator when authentication
fails — if it returns None (the BaseAuthentication default), DRF
coerces 401 Unauthorized to 403 Forbidden.  This method is only
called on the error path; it does not affect the JWT authentication
flow itself.

Also fix EnsureCsrfCookieMiddleware._is_gateway_request() to detect gateway-proxied requests solely by the presence of the gateway session cookie, without requiring Django's own session cookie to be absent. The previous condition broke when both cookies coexisted after the user accessed port 8447 directly.

Issue: https://redhat.atlassian.net/browse/AAP-82827


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

## Type of Change
- [X] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [X] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

