### PR TITLE
fix(chatbot): use gateway CSRF token when both session cookies coexist

### DIFF
--- a/aap_chatbot/src/useChatbot/useChatbot.test.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.test.ts
@@ -89,11 +89,11 @@ describe("readCsrfCookie", () => {
     expect(readCsrfCookie()).toEqual("gw_token");
   });
 
-  it("uses __Host-csrftoken when both gateway and django sessions exist", () => {
+  it("uses csrftoken when both gateway and django sessions exist (AAP-82827)", () => {
     cookieSpy.mockReturnValue(
       "csrftoken=gw_token; __Host-csrftoken=django_token; gateway_sessionid=abc123; __Host-sessionid=xyz789",
     );
-    expect(readCsrfCookie()).toEqual("django_token");
+    expect(readCsrfCookie()).toEqual("gw_token");
   });
 
   it("returns null when neither cookie is present", () => {

--- a/aap_chatbot/src/useChatbot/useChatbot.ts
+++ b/aap_chatbot/src/useChatbot/useChatbot.ts
@@ -45,11 +45,12 @@ export const readCookie = (name: string): string | null => {
   return null;
 };
 
-// Mirror the gateway detection logic from EnsureCsrfCookieMiddleware:
-// gateway session cookie present AND Django's own session cookie absent.
+// Detect gateway-proxied requests by the presence of the gateway
+// session cookie.  The previous check also required __Host-sessionid
+// to be absent, but that breaks when both cookies coexist (e.g. the
+// user visited Lightspeed on port 8447 in the same browser — AAP-82827).
 const isGatewayRequest = (): boolean =>
-  readCookie("gateway_sessionid") !== null &&
-  readCookie("__Host-sessionid") === null;
+  readCookie("gateway_sessionid") !== null;
 
 export const readCsrfCookie = (): string | null =>
   isGatewayRequest()


### PR DESCRIPTION

<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://redhat.atlassian.net/browse/AAP-82827
<!-- This PR does not need a corresponding Jira item. -->

<!-- Provide a model name or remove the lines if AI assistant wasn't used. -->
Assisted-by: Claude Code

## Description
Fix isGatewayRequest() to detect gateway-proxied requests solely by the presence of the gateway_sessionid cookie.  The previous check also required __Host-sessionid to be absent, which broke when both cookies coexisted after the user visited Lightspeed on port 8447 in the same browser — the chatbot would send __Host-csrftoken (Lightspeed's token) instead of csrftoken (Gateway's token), causing a CSRF 403.


## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

## Type of Change
- [X] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [ ] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
