### PR TITLE
Bump ansible-core and pyasn1 to fix pip-audit CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Ansible Lightspeed with IBM watsonx Code Assistant."
 version = "0.1.0"
 dependencies = [
   'aiohttp~=3.14.1',
-  'ansible-core~=2.16.14',
+  'ansible-core~=2.16.19',
   'ansible-anonymizer~=1.5.0',
   'ansible-lint~=25.5.0',
   'boto3~=1.40',
@@ -49,7 +49,7 @@ dependencies = [
   'django-csp~=3.7',
   'django-ansible-base[api-documentation,jwt-consumer,resource-registry]>=2026.1.26',
   'filelock==3.20.3',
-  'pyasn1==0.6.3',
+  'pyasn1==0.6.4',
 ]
 readme = "README.rst"
 license = {text = "Apache-2.0"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ansible-anonymizer==1.5.0
     # via ansible-ai-connect
 ansible-compat==25.12.0
     # via ansible-lint
-ansible-core==2.16.14
+ansible-core==2.16.19
     # via
     #   ansible-ai-connect
     #   ansible-compat
@@ -328,7 +328,7 @@ py-ubjson==0.16.1
     # via autobahn
 pyaml==25.7.0
     # via llama-stack-client
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   ansible-ai-connect
     #   oauth2client

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = "~=3.14.1" },
     { name = "ansible-anonymizer", specifier = "~=1.5.0" },
-    { name = "ansible-core", specifier = "~=2.16.14" },
+    { name = "ansible-core", specifier = "~=2.16.19" },
     { name = "ansible-lint", specifier = "~=25.5.0" },
     { name = "black", marker = "extra == 'dev'", specifier = "~=26.3.1" },
     { name = "boto3", specifier = "~=1.40" },
@@ -253,7 +253,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "protobuf", specifier = "~=5.29.6" },
     { name = "psycopg", specifier = "~=3.2.3" },
-    { name = "pyasn1", specifier = "==0.6.3" },
+    { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.*" },
     { name = "pydrive2", specifier = "~=1.20.0" },
     { name = "pytz" },
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "ansible-core"
-version = "2.16.14"
+version = "2.16.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -308,9 +308,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "resolvelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/5c/ac61c1444b36b07bfde70dea95beb5a89525b11c92f6e7ef8b87e3ba0248/ansible_core-2.16.14.tar.gz", hash = "sha256:80279fffd98686badfaa32e1ec785d98a6df1b2fc1e4097dec0597640d746415", size = 3159494, upload-time = "2024-12-02T17:47:55.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/75/b73552520a48c6a7822445f760e23a59612c0d77df481ba1b9ba8ed4e1d9/ansible_core-2.16.19.tar.gz", hash = "sha256:5125f26412039ffb99a3a7723618535ab80e6ef38944aa2453997350388f4ef4", size = 3172397, upload-time = "2026-06-18T19:40:08.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/c3/ad44b1a08f3dbf591dc1ab58619446a6d473fabf3361e553e3e75ed97cc8/ansible_core-2.16.14-py3-none-any.whl", hash = "sha256:b7b6df2fb0cf065b091d0332e98afbe4b028f2ffe58078e7dcf83f09e35cc8ad", size = 2254208, upload-time = "2024-12-02T17:47:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/fdb88b61521a1f263acf420d27bca357a38a2ac5865364016cedd41c15a5/ansible_core-2.16.19-py3-none-any.whl", hash = "sha256:d7a32ba0f96f9c6582b7ff159a4a6f0e694662cfc4840497c88fed63bf58cd14", size = 2261447, upload-time = "2026-06-18T19:40:06.223Z" },
 ]
 
 [[package]]
@@ -2421,11 +2421,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `ansible-core` from 2.16.14 to 2.16.19 to fix **CVE-2026-11332** (arbitrary code execution via `ansible-galaxy role install`)
- Bumps `pyasn1` from 0.6.3 to 0.6.4 to fix **PYSEC-2026-3455**, **PYSEC-2026-3456**, **PYSEC-2026-3457** (DoS via crafted ASN.1 data)

## Test plan
- [ ] CI pip-audit check passes
- [ ] Existing unit tests pass without regressions


Made with [Cursor](https://cursor.com)