### PR TITLE
AAP-80970 AAP-80967: Bump fast-uri to >=3.1.3 (CVE-2026-13676)

### DIFF
--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -83,7 +83,7 @@
     "marked": ">=18.0.2",
     "dompurify": ">=3.4.0",
     "postcss": ">=8.5.10",
-    "fast-uri": ">=3.1.1",
+    "fast-uri": ">=3.1.3",
     "js-cookie": ">=3.0.6"
   }
 }

--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -8990,9 +8990,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -192,7 +192,7 @@
         }
       }
     },
-    "fast-uri": ">=3.1.1",
+    "fast-uri": ">=3.1.3",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
   }
 }


### PR DESCRIPTION
## Summary
- Security fix for CVE-2026-13676 (`fast-uri` Unicode hostname canonicalization / host policy bypass)
- Bumps `overrides.fast-uri` from `>=3.1.1` to `>=3.1.3` in `aap_chatbot` and `ansible_ai_connect_admin_portal`
- Updates `ansible_ai_connect_admin_portal` lockfile from `fast-uri` 3.1.2 → 3.1.4 (`aap_chatbot` already at 4.1.1)

## Jira
- https://issues.redhat.com/browse/AAP-80970
- https://issues.redhat.com/browse/AAP-80967

## Exposure
Build-time transitive dependency via `ajv`. Not used for HTTP host-based policy enforcement. Risk assessed as Low.

## Test plan
- [ ] Verify lockfiles resolve `fast-uri` >= 3.1.3
- [ ] CI passes (lint/unit/build for admin portal and aap_chatbot)

## Checklist
- [x] This is a security fix
- [ ] Backports will be handled separately

Made with [Cursor](https://cursor.com)