### PR TITLE
AAP-83188 AAP-83186: Bump js-yaml to 4.3.0 in ansible_ai_connect_chatbot (CVE-2026-59869)

### DIFF
--- a/ansible_ai_connect_chatbot/package-lock.json
+++ b/ansible_ai_connect_chatbot/package-lock.json
@@ -6834,9 +6834,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/ansible_ai_connect_chatbot/package.json
+++ b/ansible_ai_connect_chatbot/package.json
@@ -41,7 +41,8 @@
     "dompurify": ">=3.4.0",
     "marked": ">=18.0.2",
     "postcss": ">=8.5.10",
-    "js-cookie": ">=3.0.6"
+    "js-cookie": ">=3.0.6",
+    "js-yaml": "4.3.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.1",


### PR DESCRIPTION
## Summary
- Bumps transitive `js-yaml` to 4.3.0 in `ansible_ai_connect_chatbot` via npm overrides to address CVE-2026-59869
- Admin portal / aap_chatbot were already fixed at 4.3.0 in #2103; chatbot lock still resolved 4.2.0

## Security
- [x] This is a security fix

## Jira
- https://redhat.atlassian.net/browse/AAP-83188
- https://redhat.atlassian.net/browse/AAP-83186

## Exposure
- `js-yaml` is a transitive build/tooling dependency (eslint/cosmiconfig); no direct app imports
- Not used for runtime YAML parsing in production Lightspeed images

## Test plan
- [ ] Verify lockfile resolves only js-yaml@4.3.0 under ansible_ai_connect_chatbot
- [ ] CI passes

## Backport
- Downstream stables still vulnerable; separate backports as needed (no dedicated container tickets currently)