### PR TITLE
fix: retry WCA API calls on HTTP 422 responses

### DIFF
--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -236,9 +236,9 @@ class WCABaseMetaData(
         if isinstance(exc, requests.RequestException):
             status_code = getattr(getattr(exc, "response", None), "status_code", None)
             # retry on server errors and client errors
-            # with 429 status code (rate limited),
+            # with 429 status code (rate limited) and 422 status code,
             # don't retry on other client errors
-            return bool(status_code and (400 <= status_code < 500) and status_code != 429)
+            return bool(status_code and (400 <= status_code < 500) and status_code not in (422, 429))
         else:
             # retry on all other errors (e.g. network)
             return False

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/pipelines_base.py
@@ -238,7 +238,9 @@ class WCABaseMetaData(
             # retry on server errors and client errors
             # with 429 status code (rate limited) and 422 status code,
             # don't retry on other client errors
-            return bool(status_code and (400 <= status_code < 500) and status_code not in (422, 429))
+            return bool(
+                status_code and (400 <= status_code < 500) and status_code not in (422, 429)
+            )
         else:
             # retry on all other errors (e.g. network)
             return False

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
@@ -27,9 +27,7 @@ from unittest.mock import Mock, patch
 import requests
 from django.test import SimpleTestCase, override_settings
 
-from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
-    WCABaseMetaData,
-)
+from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import WCABaseMetaData
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_onprem import (
     WCAOnPremMetaData,
 )

--- a/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
+++ b/ansible_ai_connect/ai/api/model_pipelines/wca/tests/test_pipelines_base_ssl.py
@@ -21,11 +21,15 @@ This test suite validates the SSL manager integration for WCA pipelines
 to ensure external service connectivity works correctly with centralized SSL management.
 """
 
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 import requests
 from django.test import SimpleTestCase, override_settings
 
+from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_base import (
+    WCABaseMetaData,
+)
 from ansible_ai_connect.ai.api.model_pipelines.wca.pipelines_onprem import (
     WCAOnPremMetaData,
 )
@@ -275,3 +279,33 @@ class TestWCASSLConfigurationIntegration(SimpleTestCase):
 
         # Verify SSL manager was called correctly
         mock_ssl_manager.get_requests_session.assert_called_once_with()
+
+
+class TestWCAFatalException(SimpleTestCase):
+    """Test the fatal_exception logic for WCA retry behavior."""
+
+    def _make_request_exception(self, status_code):
+        exc = requests.RequestException()
+        response = requests.Response()
+        response.status_code = status_code
+        exc.response = response
+        return exc
+
+    def test_non_request_exception_is_not_fatal(self):
+        self.assertFalse(WCABaseMetaData.fatal_exception(Exception()))
+
+    def test_server_error_is_not_fatal(self):
+        exc = self._make_request_exception(HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertFalse(WCABaseMetaData.fatal_exception(exc))
+
+    def test_too_many_requests_is_not_fatal(self):
+        exc = self._make_request_exception(HTTPStatus.TOO_MANY_REQUESTS)
+        self.assertFalse(WCABaseMetaData.fatal_exception(exc))
+
+    def test_unprocessable_entity_is_not_fatal(self):
+        exc = self._make_request_exception(HTTPStatus.UNPROCESSABLE_ENTITY)
+        self.assertFalse(WCABaseMetaData.fatal_exception(exc))
+
+    def test_bad_request_is_fatal(self):
+        exc = self._make_request_exception(HTTPStatus.BAD_REQUEST)
+        self.assertTrue(WCABaseMetaData.fatal_exception(exc))


### PR DESCRIPTION
## Summary
- Add HTTP 422 to the list of non-fatal (retryable) status codes in the WCA pipeline's `fatal_exception` method
- Recent WCA changes occasionally (~1% of the time) return 422 for code generation API calls from ARI (Ansible Risk Insight)
- With this change, 422 responses will be retried with exponential backoff (up to 4 retries by default), matching the existing behavior for 429 (rate limited) responses

## Test plan
- [ ] Verify that WCA API calls returning 422 are retried with exponential backoff
- [ ] Verify that other 4xx errors (e.g. 400, 403, 404) are still treated as fatal (not retried)
- [ ] Verify that 429 and 5xx errors continue to be retried as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)