### PR TITLE
fix: add PKCE support to AAPOAuth2 backend for AAP Gateway compatibility

### DIFF
--- a/ansible_ai_connect/users/auth.py
+++ b/ansible_ai_connect/users/auth.py
@@ -17,7 +17,7 @@ import logging
 import jwt
 from django.conf import settings
 from rest_framework import authentication
-from social_core.backends.oauth import BaseOAuth2
+from social_core.backends.oauth import BaseOAuth2PKCE
 from social_django.models import UserSocialAuth
 from social_django.utils import load_backend, load_strategy
 
@@ -29,8 +29,10 @@ from ansible_ai_connect.users.constants import (
 logger = logging.getLogger("auth")
 
 
-class AAPOAuth2(BaseOAuth2):
+class AAPOAuth2(BaseOAuth2PKCE):
     """AAP OAuth authentication backend"""
+
+    PKCE_DEFAULT_CODE_CHALLENGE_METHOD = "S256"
 
     name = USER_SOCIAL_AUTH_PROVIDER_AAP
     # SOCIAL_AUTH_AAP_USER_FIELDS

--- a/ansible_ai_connect/users/tests/test_auth.py
+++ b/ansible_ai_connect/users/tests/test_auth.py
@@ -206,6 +206,39 @@ class TestAAPOAuth2(WisdomServiceLogAwareTestCase):
             access_token = "dummy_token"
             self.assertFalse(authentication.user_has_valid_license(access_token))
 
+    @patch("django.conf.settings.AAP_API_URL", "http://aap.test")
+    def test_auth_params_include_pkce_challenge(self):
+        backend = AAPOAuth2()
+        session = {}
+        backend.strategy = MagicMock()
+        backend.strategy.setting = lambda name, default=None, **kwargs: default
+        backend.strategy.session_set = lambda k, v: session.__setitem__(k, v)
+        backend.strategy.session_get = lambda k, d=None: session.get(k, d)
+        backend.strategy.random_string = lambda n: "a" * n
+        backend.get_key_and_secret = MagicMock(return_value=("id", "secret"))
+        backend.get_redirect_uri = MagicMock(return_value="http://localhost/callback")
+
+        params = backend.auth_params(state="test-state")
+
+        self.assertIn("code_challenge", params)
+        self.assertIn("code_challenge_method", params)
+        self.assertEqual(params["code_challenge_method"], "S256")
+
+    @patch("django.conf.settings.AAP_API_URL", "http://aap.test")
+    def test_auth_complete_params_include_pkce_verifier(self):
+        backend = AAPOAuth2()
+        session = {"aap_code_verifier": "test-verifier"}
+        backend.strategy = MagicMock()
+        backend.strategy.setting = lambda name, default=None, **kwargs: default
+        backend.strategy.session_get = lambda k, d=None: session.get(k, d)
+        backend.data = {"code": "auth-code"}
+        backend.get_key_and_secret = MagicMock(return_value=("id", "secret"))
+        backend.get_redirect_uri = MagicMock(return_value="http://localhost/callback")
+
+        params = backend.auth_complete_params(state="test-state")
+
+        self.assertEqual(params["code_verifier"], "test-verifier")
+
 
 class TestRHSSOAuthentication(WisdomServiceLogAwareTestCase):
     def setUp(self):


### PR DESCRIPTION

Jira Issue: https://redhat.atlassian.net/browse/AAP-86187

Assisted-by: Claude Code

## Description
AAP Gateway now enforces PKCE on OAuth applications by default. The AAPOAuth2 backend was extending BaseOAuth2 which does not include PKCE parameters in the authorization request, causing login to fail with "This application requires PKCE. Include a code_challenge parameter."

Change AAPOAuth2 to extend BaseOAuth2PKCE from social-auth-core, which handles the full PKCE flow (code_verifier, code_challenge with S256).

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. ...
3. ...

## Type of Change
- [X] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [X] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [X] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
<!-- Required if backporting. Explain why this needs to be in older releases -->
<!-- Examples: -->
<!-- - Critical bug affecting production -->
<!-- - Security vulnerability fix (include CVE if applicable) -->
<!-- - Regression introduced in X.Y.Z -->
<!-- - Customer-blocking issue -->
<!-- - Data corruption/loss prevention -->

**Special backport considerations:**
<!-- Any conflicts, dependencies, or modifications needed for backport -->
<!-- Will this apply cleanly to older releases? -->
<!-- Does this depend on other commits that also need backporting? -->

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
