### PR TITLE
AAP-85811 AAP-85812: Bump Django to 5.2.17 (CVE-2026-15307)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   'cbor2~=5.9.0',
   'cython',
   'daphne~=4.2.2',
-  'Django~=5.2.16',
+  'Django~=5.2.17',
   'django-deprecate-fields~=0.1.1',
   'django-extensions~=3.2.1',
   'django-health-check~=3.17.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-match-patch==20241021
     # via django-import-export
-django==5.2.16
+django==5.2.17
     # via
     #   ansible-ai-connect
     #   django-allow-cidr

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = "~=7.2.1" },
     { name = "cython" },
     { name = "daphne", specifier = "~=4.2.2" },
-    { name = "django", specifier = "~=5.2.16" },
+    { name = "django", specifier = "~=5.2.17" },
     { name = "django-allow-cidr" },
     { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "resource-registry"], specifier = ">=2026.1.26" },
     { name = "django-csp", specifier = "~=3.7" },
@@ -850,16 +850,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Jira Issue: [AAP-85811](https://issues.redhat.com/browse/AAP-85811), [AAP-85812](https://issues.redhat.com/browse/AAP-85812)

## Description

Bump Django from `~=5.2.16` to `~=5.2.17` to address **CVE-2026-15307** (remote code execution via GeoDjango spatial lookups on affected 5.2.x releases).

ansible-ai-connect-service does not enable `django.contrib.gis` / GeoDjango, so the vulnerable code path is not used at runtime. We still bump the pin to leave the supported version range and satisfy dependency scanners.

`uv.lock` and `requirements.txt` regenerated.

> **Note:** Postcss / CVE-2026-69153 (AAP-85481, AAP-85482) was split out and merged in #2116. This PR is Django-only after rebase onto `main`.

## Testing
### Steps to test
1. Pull down the PR
2. Confirm `uv tree | grep django` resolves to **5.2.17**
3. Run `pip-audit -r requirements.txt` — Django CVE-2026-15307 should not be reported for the pinned version
4. CI selftest / pip-audit workflow should pass

## Type of Change
- [x] Security fix

## Backport Policy

This change should be:
- [x] **Backported** to specific releases (add labels after merge)

### Backport Justification
Security vulnerability fix (CVE-2026-15307) — patch-level Django bump with no API changes; should apply cleanly to supported stable branches.

**Special backport considerations:**
Direct dependency pin only; mirror the same `Django~=5.2.17` change on downstream `ansible-wisdom-service` stable branches.

### Scenarios tested
- Verified lockfile resolves Django 5.2.17
- No application code changes

## Production deployment
- [x] This code change is ready for production on its own