### PR TITLE
AAP-85481 AAP-85482: Bump postcss to 8.5.23 (CVE-2026-69153)

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -9362,9 +9362,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -82,7 +82,7 @@
     "minimatch": "^3.1.3",
     "marked": ">=18.0.2",
     "dompurify": ">=3.4.0",
-    "postcss": ">=8.5.10",
+    "postcss": ">=8.5.23",
     "fast-uri": ">=3.1.1",
     "js-cookie": ">=3.0.6"
   }

--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -14172,9 +14172,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -56,7 +56,7 @@
     "jest-watch-typeahead": "^2.2.2",
     "mini-css-extract-plugin": "^2.4.5",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.28",
+    "postcss": "^8.5.23",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^6.2.1",
     "postcss-normalize": "^10.0.1",

--- a/ansible_ai_connect_chatbot/package-lock.json
+++ b/ansible_ai_connect_chatbot/package-lock.json
@@ -8528,9 +8528,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",

--- a/ansible_ai_connect_chatbot/package.json
+++ b/ansible_ai_connect_chatbot/package.json
@@ -42,7 +42,7 @@
     "immutable": ">=5.1.8",
     "js-yaml": ">=4.3.0",
     "marked": ">=18.0.2",
-    "postcss": ">=8.5.10",
+    "postcss": ">=8.5.23",
     "js-cookie": ">=3.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Jira Issue: [AAP-85481](https://issues.redhat.com/browse/AAP-85481), [AAP-85482](https://issues.redhat.com/browse/AAP-85482)

## Description

Bump **postcss** to **8.5.23** to address **CVE-2026-69153** (information disclosure via crafted `sourceMappingURL` — incomplete fix of CVE-2026-45623).

Affected version range: postcss **≤ 8.5.22**. Fixed in **8.5.23**.

Changes:
- `ansible_ai_connect_chatbot`: override `postcss` `>=8.5.10` → `>=8.5.23` (8.5.13 → 8.5.23 in lockfile)
- `aap_chatbot`: override `postcss` `>=8.5.10` → `>=8.5.23` (8.5.14 → 8.5.23 in lockfile)
- `ansible_ai_connect_admin_portal`: devDependency `postcss` `^8.4.28` → `^8.5.23` (8.5.12 → 8.5.23 in lockfile)

PostCSS is used at **build time only** (Vite/webpack during container image build); the Python service does not process attacker-controlled CSS at runtime.

## Testing
### Steps to test
1. Pull down the PR
2. Confirm resolved postcss version in each lockfile: `python3 -c "import json; print(json.load(open('ansible_ai_connect_chatbot/package-lock.json'))['packages']['node_modules/postcss']['version'])"` — expect **8.5.23**
3. `cd ansible_ai_connect_chatbot && npm ci && npm audit --audit-level=moderate` (postcss CVE should not appear)
4. Repeat for `aap_chatbot` and `ansible_ai_connect_admin_portal` as needed
5. CI Chatbot/admin-portal npm-audit workflows should pass

## Type of Change
- [x] Security fix

## Backport Policy

This change should be:
- [x] **Backported** to specific releases (add labels after merge)

### Backport Justification
Security vulnerability fix (CVE-2026-69153) — patch-level postcss bump with no API changes; should apply cleanly to supported stable branches.

**Special backport considerations:**
Lockfile entries surgically patched; mirror the same override/devDependency bump on downstream `ansible-wisdom-service` stable branches.

### Scenarios tested
- Verified all three lockfiles resolve postcss **8.5.23**
- No application code changes

## Production deployment
- [x] This code change is ready for production on its own

Made with [Cursor](https://cursor.com)