### PR TITLE
fix: keep Http404 as 404 in exception handler (AAP-78941)

### DIFF
--- a/ansible_ai_connect/main/exception_handler.py
+++ b/ansible_ai_connect/main/exception_handler.py
@@ -33,6 +33,14 @@ def exception_handler_with_error_type(exc, context):
         if hasattr(exc, "default_code"):
             response.error_type = exc.default_code
 
+        # Django Http404 / PermissionDenied (and similar) are converted to a
+        # Response by DRF but do not implement get_full_details(). Reshaping
+        # those would raise AttributeError and turn a correct 404/403 into a
+        # 500 — which Gateway outlier detection then treats as an unhealthy
+        # upstream (AAP-78941). Leave DRF's response intact for those cases.
+        if not hasattr(exc, "get_full_details"):
+            return response
+
         # Discard the default 'detail' property
         # We add the 'code', 'message' and 'model' to 'data' root
         if isinstance(response.data, dict):

--- a/ansible_ai_connect/main/exception_handler.py
+++ b/ansible_ai_connect/main/exception_handler.py
@@ -33,11 +33,6 @@ def exception_handler_with_error_type(exc, context):
         if hasattr(exc, "default_code"):
             response.error_type = exc.default_code
 
-        # Django Http404 / PermissionDenied (and similar) are converted to a
-        # Response by DRF but do not implement get_full_details(). Reshaping
-        # those would raise AttributeError and turn a correct 404/403 into a
-        # 500 — which Gateway outlier detection then treats as an unhealthy
-        # upstream (AAP-78941). Leave DRF's response intact for those cases.
         if not hasattr(exc, "get_full_details"):
             return response
 

--- a/ansible_ai_connect/main/exception_handler.py
+++ b/ansible_ai_connect/main/exception_handler.py
@@ -12,12 +12,24 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
+from django.http import Http404
+from rest_framework.exceptions import APIException, NotFound, PermissionDenied
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
 
 def exception_handler_with_error_type(exc, context):
+    # DRF's exception_handler converts Http404 / Django PermissionDenied to
+    # APIException subclasses only via a local rebind — the original exc is what
+    # we receive. Convert here so reshape sees get_full_details / default_code
+    # and 404/403 bodies match every other API error (AAP-78941).
+    if isinstance(exc, Http404):
+        exc = NotFound(*exc.args)
+    elif isinstance(exc, DjangoPermissionDenied):
+        exc = PermissionDenied(*exc.args)
+
     # Call the default exception handler first
     response = exception_handler(exc, context)
 
@@ -25,16 +37,13 @@ def exception_handler_with_error_type(exc, context):
     context["request"].accepted_media_type = "application/json"
     context["request"].accepted_renderer = JSONRenderer()
 
-    if isinstance(response, Response):
+    if isinstance(response, Response) and isinstance(exc, APIException):
         # Add error type if specified.
         # This is used in Segment Events. The events have an 'error_type' property.
         # We therefore have to keep the same property name to support correlation
         # of _new_ Segment events with _old_ Segment events.
         if hasattr(exc, "default_code"):
             response.error_type = exc.default_code
-
-        if not hasattr(exc, "get_full_details"):
-            return response
 
         # Discard the default 'detail' property
         # We add the 'code', 'message' and 'model' to 'data' root

--- a/ansible_ai_connect/main/tests/test_exception_handler.py
+++ b/ansible_ai_connect/main/tests/test_exception_handler.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from http import HTTPStatus
+from uuid import uuid4
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -21,6 +22,7 @@ from rest_framework.exceptions import NotAuthenticated, ValidationError
 
 from ansible_ai_connect.ai.api.exceptions import WisdomBadRequest
 from ansible_ai_connect.main.exception_handler import exception_handler_with_error_type
+from ansible_ai_connect.test_utils import WisdomServiceAPITestCaseBase
 
 
 class ExceptionHandlerWithErrorTypeTests(SimpleTestCase):
@@ -32,21 +34,25 @@ class ExceptionHandlerWithErrorTypeTests(SimpleTestCase):
         request = self.factory.get("/api/v1/service-index/resources/missing/")
         return {"request": request}
 
-    def test_http404_returns_404_without_raising(self):
-        """Missing resources must stay 404; do not crash into 500 (AAP-78941)."""
+    def test_http404_returns_reshaped_404(self):
+        """Missing resources must stay 404 with the standard error body (AAP-78941)."""
         response = exception_handler_with_error_type(
             Http404("No Resource matches"), self._context()
         )
 
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
-        self.assertIn("detail", response.data)
+        self.assertEqual(response.data["code"], "not_found")
+        self.assertEqual(str(response.data["message"]), "No Resource matches")
+        self.assertEqual(response.error_type, "not_found")
 
-    def test_permission_denied_returns_403_without_raising(self):
+    def test_permission_denied_returns_reshaped_403(self):
         response = exception_handler_with_error_type(PermissionDenied(), self._context())
 
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(response.data["code"], "permission_denied")
+        self.assertEqual(response.error_type, "permission_denied")
 
     def test_api_exception_is_still_reshaped(self):
         exc = WisdomBadRequest("bad input")
@@ -77,3 +83,17 @@ class ExceptionHandlerWithErrorTypeTests(SimpleTestCase):
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.data["code"], exc.default_code)
         self.assertEqual(response.error_type, exc.default_code)
+
+
+class TestMissingResourceDelete(WisdomServiceAPITestCaseBase):
+    def test_delete_missing_resource_returns_404(self):
+        """DELETE of an unknown ansible_id must be 404, not 500 (AAP-78941)."""
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.delete(f"/api/v1/service-index/resources/{uuid4()}/")
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertEqual(response.data["code"], "not_found")
+        self.assertIn("message", response.data)

--- a/ansible_ai_connect/main/tests/test_exception_handler.py
+++ b/ansible_ai_connect/main/tests/test_exception_handler.py
@@ -1,0 +1,77 @@
+#  Copyright Red Hat
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from http import HTTPStatus
+
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.test import RequestFactory, SimpleTestCase
+from rest_framework.exceptions import NotAuthenticated, ValidationError
+
+from ansible_ai_connect.ai.api.exceptions import WisdomBadRequest
+from ansible_ai_connect.main.exception_handler import exception_handler_with_error_type
+
+
+class ExceptionHandlerWithErrorTypeTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def _context(self):
+        request = self.factory.get("/api/v1/service-index/resources/missing/")
+        return {"request": request}
+
+    def test_http404_returns_404_without_raising(self):
+        """Missing resources must stay 404; do not crash into 500 (AAP-78941)."""
+        response = exception_handler_with_error_type(Http404("No Resource matches"), self._context())
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertIn("detail", response.data)
+
+    def test_permission_denied_returns_403_without_raising(self):
+        response = exception_handler_with_error_type(PermissionDenied(), self._context())
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_api_exception_is_still_reshaped(self):
+        exc = WisdomBadRequest("bad input")
+        response = exception_handler_with_error_type(exc, self._context())
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(response.data["code"], exc.default_code)
+        self.assertEqual(response.data["message"], "bad input")
+        self.assertEqual(response.error_type, exc.default_code)
+
+    def test_drf_validation_error_is_still_reshaped(self):
+        exc = ValidationError({"field": ["required"]})
+        response = exception_handler_with_error_type(exc, self._context())
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(response.data["code"], "invalid")
+        self.assertIn("field", response.data["detail"])
+
+    def test_unhandled_exception_still_propagates_as_none(self):
+        # DRF returns None for non-API exceptions → framework 500 path unchanged.
+        response = exception_handler_with_error_type(RuntimeError("boom"), self._context())
+        self.assertIsNone(response)
+
+    def test_not_authenticated_is_still_reshaped(self):
+        exc = NotAuthenticated()
+        response = exception_handler_with_error_type(exc, self._context())
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(response.data["code"], exc.default_code)
+        self.assertEqual(response.error_type, exc.default_code)

--- a/ansible_ai_connect/main/tests/test_exception_handler.py
+++ b/ansible_ai_connect/main/tests/test_exception_handler.py
@@ -34,7 +34,9 @@ class ExceptionHandlerWithErrorTypeTests(SimpleTestCase):
 
     def test_http404_returns_404_without_raising(self):
         """Missing resources must stay 404; do not crash into 500 (AAP-78941)."""
-        response = exception_handler_with_error_type(Http404("No Resource matches"), self._context())
+        response = exception_handler_with_error_type(
+            Http404("No Resource matches"), self._context()
+        )
 
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)


### PR DESCRIPTION
Jira Issue: <https://issues.redhat.com/browse/AAP-78941>

Assisted-by: Cursor
Generated by: Cursor

## Description

Resource sync DELETEs for missing service-index resources raise Django `Http404`. DRF's `exception_handler` converts that to `NotFound` only via a **local** rebind, so our custom handler still saw `Http404` (no `get_full_details`) and crashed into a **500**.

Gateway Envoy outlier detection then ejected the sole Lightspeed upstream, so chatbot tests failed together with `503` / `no healthy upstream`.

This PR:
1. Converts `Http404` → DRF `NotFound` and Django `PermissionDenied` → DRF `PermissionDenied` before reshape (mirrors DRF's conversion).
2. Only reshapes when `isinstance(exc, APIException)`.
3. Leaves unhandled exceptions as `None` → genuine **5xx**.

Result: missing-resource DELETEs return a consistent reshaped **404** (`code` / `message` / `detail`), not 500.

## Testing

### Steps to test
1. Pull down the PR
2. Run: `wisdom-manage test ansible_ai_connect.main.tests.test_exception_handler`
3. Optional on Cont/OCP: `DELETE /api/lightspeed/v1/service-index/resources/<random-uuid>/` → **404** with reshaped body

### Scenarios tested
- Unit: `Http404` → reshaped 404 (`code=not_found`)
- Unit: Django `PermissionDenied` → reshaped 403
- Unit: `WisdomBadRequest` / `ValidationError` / `NotAuthenticated` still reshaped
- Unit: `RuntimeError` still returns `None` (true 500 path unchanged)
- API: `DELETE /api/v1/service-index/resources/<uuid>/` → 404 (not 500)

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**This upstream repo (`ansible-ai-connect-service`) has only `main`.** Auto-backport labels like `backport/stable-2.6` do **not** apply here.

To reach PBCI Cont/OCP:
1. Merge this PR to upstream `main`
2. Cherry-pick / open PRs against downstream `ansible-automation-platform/ansible-wisdom-service` on `stable-2.6` and `stable-2.7` (and `main` / whichever stream tracks devel)
3. Bump the Lightspeed source submodule in `ansible-lightspeed-container` so Cont images pick up the fix

There is no `stable-2.8` branch in wisdom-service; 2.8-next Cont pulls from the devel/main packaging stream once the container bump lands.

### Backport Justification
- PBCI chatbot 503s from this defect span Cont+OCP across 2.6 / 2.7 / 2.8-next packaging streams
- Correctness fix: missing resource must not be reported as 5xx

### Follow-ups
- Gateway ejection amplifier (separate from this trigger fix): [AAP-87887](https://issues.redhat.com/browse/AAP-87887)

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production: