### PR TITLE
fix: bump tablib to 3.10.0 for CVE-2026-9318

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ constraint-dependencies = [
   'msgpack>=1.2.1',
   'twisted>=26.4.0',
   'pygments>=2.20.0',
+  'tablib>=3.10.0',
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -409,7 +409,7 @@ subprocess-tee==0.4.2
     # via
     #   ansible-compat
     #   ansible-lint
-tablib==3.9.0
+tablib==3.10.0
     # via django-import-export
 termcolor==3.2.0
     # via fire

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ constraints = [
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "tablib", specifier = ">=3.10.0" },
     { name = "twisted", specifier = ">=26.4.0" },
     { name = "ujson", specifier = ">=5.13.0" },
 ]
@@ -2858,11 +2859,11 @@ wheels = [
 
 [[package]]
 name = "tablib"
-version = "3.9.0"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/00/416d2ba54d7d58a7f7c61bf62dfeb48fd553cf49614daf83312f2d2c156e/tablib-3.9.0.tar.gz", hash = "sha256:1b6abd8edb0f35601e04c6161d79660fdcde4abb4a54f66cc9f9054bd55d5fe2", size = 125565, upload-time = "2025-10-15T18:21:56.263Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/b9/59d9c8b9c34642e7a718e8a1a7a91af3eb9b48f79bac794263702d41519c/tablib-3.10.0.tar.gz", hash = "sha256:781cfa9a42de8f33c52aff857fd0a04e483de4fd1c53eaaa9a6aeac62bad11de", size = 127128, upload-time = "2026-07-31T17:30:15.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/6b/32e51d847148b299088fc42d3d896845fd09c5247190133ea69dbe71ba51/tablib-3.9.0-py3-none-any.whl", hash = "sha256:eda17cd0d4dda614efc0e710227654c60ddbeb1ca92cdcfc5c3bd1fc5f5a6e4a", size = 49580, upload-time = "2025-10-15T18:21:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0f/3ae17545ff976687f679ed3a101df7017135ee04769e858a4ccea0cc3f3e/tablib-3.10.0-py3-none-any.whl", hash = "sha256:5721bf3a52d491f8f843628a3a3200db164f6ad9e92fb6eaa64dc3f945f30ad9", size = 50170, upload-time = "2026-07-31T17:30:04.925Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Jira Issue: no-jira
<!-- This PR does not need a corresponding Jira item. -->

Assisted-by: Cursor
Generated by: Cursor

## Description

Bump `tablib` from 3.9.0 to 3.10.0 via `constraint-dependencies` to fix pip-audit failure:

- **CVE-2026-9318**: stored XSS in HTML export functionality (fix version 3.10.0)

`tablib` is a transitive dependency of `django-import-export`.

## Testing

### Steps to test
1. Pull down the PR
2. Run pip-audit against the exported `requirements.txt` / project venv
3. Confirm `tablib` resolves to 3.10.0 and CVE-2026-9318 is no longer reported

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [x] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI/CD update

## Backport Policy

This change should be:
- [ ] **Not backported** - main/master only
- [x] **Backported** to specific releases (add labels after merge)

### Automated Backport Instructions

**After this PR is merged**, add one or more labels to automatically create backport PRs:

- `backport/stable-2.4` - Backport to stable-2.4 branch
- `backport/stable-2.5` - Backport to stable-2.5 branch
- `backport/stable-2.6` - Backport to stable-2.6 branch
- `backport/all` - Backport to all active stable branches
- `no-backport` - Explicitly mark as not needing backport

### Backport Justification
- Security vulnerability fix affecting pip-audit CI on all branches using tablib 3.9.0

**Special backport considerations:**
- Lockfile-only change; should cherry-pick cleanly

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

Made with [Cursor](https://cursor.com)