### PR TITLE
Re-resolve 2 packages in the lockfile [lship]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -399,7 +399,7 @@ social-auth-core==4.7.0
     # via
     #   ansible-ai-connect
     #   social-auth-app-django
-sqlparse==0.5.5
+sqlparse==0.6.0
     # via
     #   django
     #   django-ansible-base

--- a/uv.lock
+++ b/uv.lock
@@ -2827,11 +2827,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]
@@ -3088,16 +3088,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.35.4"
+version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Lockfile-only fixes

2 packages that no `pyproject.toml` declares. There is no floor to
raise, so the lockfile was re-resolved with a targeted upgrade and the resulting
versions were verified to reach the target version:

- `sqlparse` (.) 0.5.5 → 0.6.0 (CVE-2026-59894, GHSA-3496-9g83-7v6x, CVE-2026-71491, GHSA-f2ff-p2ww-7p4p, CVE-2026-59893, GHSA-prg7-hcfm-mfcr, CVE-2026-54284, GHSA-pwgv-4x5q-6m9f, PYSEC-2026-3696, PYSEC-2026-3697, PYSEC-2026-3698, PYSEC-2026-3699)

- `virtualenv` (.) 20.35.4 → 20.36.1 (CVE-2026-22702, GHSA-597g-3phw-6986, PYSEC-2026-2009)


## Lockfile changes

What moved alongside the deliberate changes above. A targeted upgrade lands the
newest allowed release rather than the advisory's minimum, and re-resolving a
stale lock also moves whatever else the declarations already required.

Removals and major-version crossings are listed individually because those are
what may need rejecting; the rest are counted:

- `sqlparse`  0.5.5 → 0.6.0

- `virtualenv`  20.35.4 → 20.36.1





## Second declarations not updated

Each of these files declares a package this PR bumped elsewhere, and still
carries the old floor. lship reads requirements files but never rewrites them —
it does not model `-r` includes, hash lines, or `-e` entries — so these need a
human edit if the file is consumed by anything:

- `requirements.txt` also declares `sqlparse`





## Fixes lship refused to apply

A fix exists for each of these, and applying it automatically would cross a
major-version boundary or breach a cap this project declares. Each needs its
own migration PR — this one does not address them:

- `setuptools` (.) 80.9.0 → 83.0.0 (CVE-2026-59890, GHSA-h35f-9h28-mq5c, PYSEC-2026-3447) — major bump

- `multer` (ansible_ai_connect_admin_portal) 1.4.5-lts.1 → 2.2.0 (CVE-2025-47935, GHSA-44fp-w29j-9vj5, CVE-2025-47944, GHSA-4pg4-qvpc-4q3h, CVE-2026-3520, GHSA-5528-5vmv-3xc2, CVE-2026-5079, GHSA-72gw-mp4g-v24j, CVE-2025-7338, GHSA-fjgf-rc76-4x9p, CVE-2025-48997, GHSA-g5hg-p3ph-g8qg, CVE-2026-2359, GHSA-v52c-386h-88mc, CVE-2026-3304, GHSA-xf7r-hgr6-v32p) — major bump




## Test plan
- [ ] CI passes
- [ ] `uv lock --check` / `uv pip compile` resolves successfully

<!-- lship:{"operation_hash":"1edc968fe19e8f0a","trackers":[{"cve_ids":["CVE-2026-59890","GHSA-h35f-9h28-mq5c","PYSEC-2026-3447"],"package":"setuptools","current_version":"80.9.0","fixed_version":"83.0.0"},{"cve_ids":["CVE-2026-59894","GHSA-3496-9g83-7v6x","CVE-2026-71491","GHSA-f2ff-p2ww-7p4p","CVE-2026-59893","GHSA-prg7-hcfm-mfcr","CVE-2026-54284","GHSA-pwgv-4x5q-6m9f","PYSEC-2026-3696","PYSEC-2026-3697","PYSEC-2026-3698","PYSEC-2026-3699"],"package":"sqlparse","current_version":"0.5.5","fixed_version":"0.6.0"},{"cve_ids":["CVE-2026-22702","GHSA-597g-3phw-6986","PYSEC-2026-2009"],"package":"virtualenv","current_version":"20.35.4","fixed_version":"20.36.1"},{"cve_ids":["CVE-2021-29510","GHSA-5jqp-qgf6-3pvh","CVE-2024-3772","GHSA-mr82-8j83-vxmv","PYSEC-2021-47","PYSEC-2026-1812"],"package":"pydantic","current_version":"2.*","fixed_version":"1.10.13"},{"cve_ids":["CVE-2025-47935","GHSA-44fp-w29j-9vj5","CVE-2025-47944","GHSA-4pg4-qvpc-4q3h","CVE-2026-3520","GHSA-5528-5vmv-3xc2","CVE-2026-5079","GHSA-72gw-mp4g-v24j","CVE-2025-7338","GHSA-fjgf-rc76-4x9p","CVE-2025-48997","GHSA-g5hg-p3ph-g8qg","CVE-2026-2359","GHSA-v52c-386h-88mc","CVE-2026-3304","GHSA-xf7r-hgr6-v32p"],"package":"multer","current_version":"1.4.5-lts.1","fixed_version":"2.2.0"}]} -->