### PR TITLE
Drop the baseline-browser-mapping override to unblock the build

### DIFF
--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -6024,11 +6024,11 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
-        "node-releases": "^2.0.53",
         "electron-to-chromium": "^1.5.402",
-        "update-browserslist-db": "^1.3.0",
-        "baseline-browser-mapping": "^2.11.12"
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -200,7 +200,6 @@
     "http-proxy-middleware": "2.0.10",
     "body-parser": ">=1.20.6",
     "js-yaml": "4.3.1",
-    "baseline-browser-mapping": ">=2.11.0",
     "browserslist": ">=4.28.7"
   }
 }


### PR DESCRIPTION
## What

Removes `"baseline-browser-mapping": ">=2.11.0"` from the admin portal `overrides`. One line, plus a lockfile key reordering that npm produces automatically.

`"browserslist": ">=4.28.7"` is kept — that override is the one doing the work.

## Why

`build-container` has failed on **every PR and on `main`** since 2026-08-24. `wisdom-service.Containerfile:69` runs `npx update-browserslist-db@latest`, which shells out to `npm install caniuse-lite baseline-browser-mapping`, and npm refuses when a package is both overridden and directly installed:

```
npm error code EOVERRIDE
npm error Override for baseline-browser-mapping@* conflicts with direct dependency
```

**Nothing in this repo changed to cause it.** `update-browserslist-db` only runs that install when the pinned `caniuse-lite` is stale — otherwise it exits early and never touches npm. The override landed in #2119 on 08-18 and was inert until `caniuse-lite@1.0.30001810` was published on **2026-08-24 20:04Z**. #2119's own Konflux run passed on 08-18 with the override already in place. A third-party publish broke the build, not a commit.

## Why removing it is safe

`browserslist@4.28.8` declares `baseline-browser-mapping: ^2.10.44`, which resolves to **2.11.15** on its own — above the 2.11.0 fix for CVE-2026-45819. The override was restating a floor the transitive resolution already satisfied.

Verified A/B against this exact tree:

| | Failure signatures |
|---|---|
| this branch | **0** — `caniuse-lite has been successfully updated` |
| `origin/main` (control) | **3** — reproduces the CI failure |

- `package-lock.json` diff is a key reordering inside `browserslist`'s dependency map only — **0 `"version":` lines move**
- `baseline-browser-mapping` still resolves to **2.11.15**
- `npm audit` → **0 vulnerabilities**

## Scope

Does not touch the `npx update-browserslist-db@latest` step itself. That step has been in the Containerfile since 2024-09-09 and resolves a tool version at build time inside a non-hermetic build, which is the underlying reason a third party can turn us red. Worth removing, but it changes build behaviour and belongs in its own PR.

**Do not backport the #2119 override to `stable-2.6`** — the `npx` step is on that branch too, so it would break that build the same way. 2.6 and 2.7 are currently unaffected because neither has the override.

## Test plan

- [ ] `build-container` goes green
- [ ] `npm audit` stays at 0 vulnerabilities

---

*Authored with AI assistance; findings verified against the PipelineRun logs, the npm registry, and repository history.*
