### PR TITLE
Format two admin portal files so pre-commit passes

### DIFF
--- a/ansible_ai_connect_admin_portal/src/ErrorModal.tsx
+++ b/ansible_ai_connect_admin_portal/src/ErrorModal.tsx
@@ -17,8 +17,7 @@ interface ErrorModalProps {
 }
 
 export type HasError =
-  | { inError: false }
-  | { inError: true; message: string; detail: string };
+  { inError: false } | { inError: true; message: string; detail: string };
 export const NO_ERROR: HasError = { inError: false };
 
 export const ErrorModal = (props: ErrorModalProps) => {

--- a/ansible_ai_connect_admin_portal/src/api/types.ts
+++ b/ansible_ai_connect_admin_portal/src/api/types.ts
@@ -1,10 +1,6 @@
 // Loading statuses and payloads
 export type Status =
-  | "NOT_ASKED"
-  | "LOADING"
-  | "FAILURE"
-  | "SUCCESS"
-  | "SUCCESS_NOT_FOUND";
+  "NOT_ASKED" | "LOADING" | "FAILURE" | "SUCCESS" | "SUCCESS_NOT_FOUND";
 export type NotAsked = { status: "NOT_ASKED" };
 export type Loading = { status: "LOADING" };
 export type Failure = { status: "FAILURE"; error: Error };
@@ -12,23 +8,11 @@ export type Success<R> = { status: "SUCCESS"; data: R };
 export type SuccessNotFound = { status: "SUCCESS_NOT_FOUND" };
 
 export type WcaKey =
-  | NotAsked
-  | Loading
-  | Failure
-  | Success<WcaKeyResponse>
-  | SuccessNotFound;
+  NotAsked | Loading | Failure | Success<WcaKeyResponse> | SuccessNotFound;
 export type WcaModelId =
-  | NotAsked
-  | Loading
-  | Failure
-  | Success<WcaModelIdResponse>
-  | SuccessNotFound;
+  NotAsked | Loading | Failure | Success<WcaModelIdResponse> | SuccessNotFound;
 export type Telemetry =
-  | NotAsked
-  | Loading
-  | Failure
-  | Success<TelemetryResponse>
-  | SuccessNotFound;
+  NotAsked | Loading | Failure | Success<TelemetryResponse> | SuccessNotFound;
 
 // Request objects for the REST [GET] APIs
 export interface WcaKeyRequest {


### PR DESCRIPTION
## What

Formats two admin portal files. No behaviour change — union type members are joined onto one line where they fit.

- `ansible_ai_connect_admin_portal/src/api/types.ts`
- `ansible_ai_connect_admin_portal/src/ErrorModal.tsx`

## Why

`pre-commit` has failed on **every PR since 2026-08-19**, including PRs containing no TypeScript at all — it first went red on `konflux/mintmaker/main/charset-normalizer-3.x`, a dependency-only branch.

Neither file has been touched since #1161, so nothing in this repo made it start. They are simply unformatted under the prettier the hook declares: `mirrors-prettier` v4.0.0-alpha.8 pins `prettier@4.0.0-alpha.8` via `additional_dependencies`, and that version rewrites both. CI had been passing on a cached hook environment; once it was rebuilt, the declared config started being enforced and the existing drift surfaced.

So this isn't a new problem — it's an old one that was invisible while the cache held.

## Verification

- Formatted with **exactly** the pinned version, so this is what CI produces — the diff matches the CI failure output line for line
- `prettier 3.9.6` produces **byte-identical** output on both files, so this is not an artifact of the alpha
- All **109** tracked `ts`/`tsx`/`js` files now report `All matched files use Prettier code style!`

## Worth a follow-up, not in this PR

The hook is pinned to a **prettier 4 alpha**. That's a slightly odd thing to gate CI on, and since 3.9.6 formats these files identically, moving the hook to a stable 3.x looks like a no-op for the tree. I'd rather that be a deliberate decision than a drive-by change here.

## Test plan

- [ ] `pre-commit` passes
- [ ] No behavioural diff — types only

---

*Authored with AI assistance; the reformat was produced by the pinned prettier and cross-checked against a second version.*
