### PR TITLE
Add idna>=3.15 constraint floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ constraint-dependencies = [
   'pyjwt>=2.13.0',
   'ujson>=5.13.0',
   'msgpack>=1.2.1',
+  'idna>=3.15',
   'twisted>=26.4.0',
   'pygments>=2.20.0',
   'tablib>=3.10.0',

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ constraints = [
     { name = "certifi", git = "https://github.com/ansible/system-certifi?rev=5aa52ab91f9d579bfe52b5acf30ca799f1a563d9" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "dynaconf", specifier = ">=3.2.13" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },


### PR DESCRIPTION
## What

Adds `idna>=3.15` to `[tool.uv] constraint-dependencies`. `uv.lock` gains the manifest entry; the resolved version is already 3.15, so `requirements.txt` is unchanged and no package versions move.

## Why

`stable-2.7` has carried this floor since d828b76e; `main` never got it. Recording it keeps the constraint table consistent across release lines and prevents `uv lock` / `uv export` from regressing below 3.15.

## Scope

`uv_export.yml` reproduced locally (`uv lock` + `uv export`, `git diff --exit-code` clean).

Assisted-by: Claude Code — drafted by one model, independently validated by a second before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)