### PR TITLE
ci: make the SonarCloud skip guard actually skip the scan

### DIFF
--- a/.github/workflows/sonar-pr.yaml
+++ b/.github/workflows/sonar-pr.yaml
@@ -45,6 +45,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract PR metadata and validate workflow_run
+        id: pr_meta
         env:
           REPO_NAME: ${{ github.event.repository.full_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,8 +75,11 @@ jobs:
             echo "::warning::PR head: $PR_HEAD_REPO/$PR_HEAD @ $PR_HEAD_SHA"
             echo "::warning::Workflow: $WORKFLOW_HEAD_REPO/$WORKFLOW_HEAD_BRANCH @ $WORKFLOW_HEAD_SHA"
             echo "::notice::Skipping SonarCloud analysis - PR has been updated since workflow started"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
           # Export validated variables
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
@@ -86,6 +90,7 @@ jobs:
           gh pr checkout "$PR_NUMBER"
 
       - name: Extract repo owner and name (fork-aware)
+        if: steps.pr_meta.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -100,11 +105,25 @@ jobs:
           echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
 
       - name: Verify SONAR_TOKEN is set
+        if: steps.pr_meta.outputs.skip != 'true'
         run: test -n "$SONAR_TOKEN" || { echo "SONAR_TOKEN is empty — check vars.SONAR_TOKEN_SECRET_NAME"; exit 1; }
         env:
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
 
+      - name: Fail fast if PR context is incomplete
+        if: steps.pr_meta.outputs.skip != 'true'
+        run: |
+          # An empty sonar.pullrequest.key makes the scanner silently fall back to
+          # a branch analysis and overwrite main's results. Never let that happen.
+          for v in PR_NUMBER PR_BASE PR_HEAD; do
+            if [ -z "${!v}" ]; then
+              echo "::error::$v is empty - refusing to run a scan that would be treated as a branch analysis"
+              exit 1
+            fi
+          done
+
       - name: SonarCloud Scan
+        if: steps.pr_meta.outputs.skip != 'true'
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Turn the `workflow_run` staleness check in `sonar-pr.yaml` into a real skip: it now records `skip=true` as a step output and every subsequent step is gated on it. Adds a fail-fast step that refuses to scan when `PR_NUMBER` / `PR_BASE` / `PR_HEAD` are empty.

## Why

The guard ends with `exit 0`, which only ends *that step* — the job keeps going. When it fires, `PR_NUMBER`/`PR_BASE`/`PR_HEAD` are never exported and `gh pr checkout` never runs, so the scan is invoked as:

```
-Dsonar.pullrequest.key= -Dsonar.pullrequest.branch= -Dsonar.pullrequest.base=
```

With an empty pull-request key the scanner falls back to **branch** mode and publishes an analysis of the `workflow_run` checkout as `main`, stamped with the stale PR SHA via `sonar.scm.revision`. It then evaluates main's quality gate and exits 3.

Seen in [run 33199399627](https://github.com/ansible/ansible-ai-connect-service/actions/runs/33199399627): the guard correctly logged `Skipping SonarCloud analysis - PR has been updated since workflow started`, then scanned anyway and failed on main's gate (`new_violations: 2`). The PR that triggered it was never analyzed, and main's Sonar state was overwritten from an unrelated checkout.

## Scope

`.github/workflows/sonar-pr.yaml` only. No change to what gets scanned on a healthy run — the added `if:` conditions are all no-ops when the guard passes.

## Note

#2042 (Dependabot, `sonarqube-scan-action` 4 → 8) edits the same `uses:` line this PR adds an `if:` above, so whichever lands second will need a rebase. That bump is worth landing regardless — the action currently emits an unsupported-version/security warning on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
