### PR TITLE
fix(ci): check out repo and make backport workflow label-driven

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,13 +16,15 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Backport to release branches
         uses: korthout/backport-action@v3
         with:
           label_pattern: '^backport/(?<target>.+)$'
-
-          target_branches: |
-            all:stable-2.4 stable-2.5 stable-2.6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The **Backport merged pull request** workflow (`backport.yml`) has failed on **every merged PR** and has never once succeeded. Two independent bugs:

1. **Missing checkout.** The job invoked `korthout/backport-action@v3` with no prior `actions/checkout`, so the action's first `git fetch` ran outside a git repo:
   ```
   git fetch --depth=2 origin refs/pull/<n>/head
   fatal: not a git repository (or any of the parent directories): .git
   ```
   Example failure: https://github.com/ansible/ansible-ai-connect-service/actions/runs/33200352768 (on merging #2042). The last 12 runs are 10 failures + 2 skips.

2. **Backport targets that don't exist.** It was hardcoded to `target_branches: all:stable-2.4 stable-2.5 stable-2.6`. None of those branches exist (the repo has only `main`), and the `all:` prefix meant *every* merge would attempt a backport regardless of labels.

## Fix

- Add `actions/checkout@v4` with `fetch-depth: 0` before the backport step.
- Drop the hardcoded `target_branches`, so backports are driven solely by the `backport/<branch>` label (via the existing `label_pattern`). This matches the contribution docs and is a clean no-op when no such label is present — so it stops failing immediately, and does the right thing once `stable-*` branches exist and a PR is labelled.

## Test plan
- [ ] With no `backport/*` label, the workflow completes successfully as a no-op on the next merge (previously it errored).
- [ ] Labelling a merged PR `backport/<existing-branch>` opens a backport PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)