### PR TITLE
ci: fix backport workflow, which has never succeeded

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,13 +16,17 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
 
+      # korthout/backport-action shells out to git, so the workspace must be a
+      # repository. On pull_request_target this checks out the base branch, not
+      # the pull request's head, which is what we want here.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Backport to release branches
         uses: korthout/backport-action@v3
         with:
+          # Backports are opt-in: label a merged PR `backport/<branch>` to get one.
           label_pattern: '^backport/(?<target>.+)$'
-
-          target_branches: |
-            all:stable-2.4 stable-2.5 stable-2.6
 
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

Fixes `.github/workflows/backport.yml`, which has never successfully backported anything.

## Why

Across its last 100 runs: **45 failures, 0 successes**, going back to when it was added in #1786 on 2025-11-24. The failures were easy to miss because runs on non-merge events record as `skipped`, and only a merged PR reaches the actual job — so the workflow looks mostly quiet in the runs list.

It surfaced now because merging #2127 emailed the failure:

```
git fetch --depth=2 origin refs/pull/2127/head
fatal: not a git repository (or any of the parent directories): .git
##[error]Expected to fetch 'refs/pull/2127/head' from 'origin', but couldn't find it
```

Three defects, stacked:

1. **No checkout step.** `korthout/backport-action` shells out to `git`, so the first command ran against an empty workspace and the job died before reaching any backport logic. This alone is fatal.

2. **`all:` is not recognised syntax.** The log shows `target_branches` parsed as three names — `all:stable-2.4`, `stable-2.5`, `stable-2.6` — so the first entry was a literal branch name with a stray prefix.

3. **None of those branches exist here.** I checked against a control: 501 remote branches, zero matching `stable-*`. `stable-2.x` is the downstream `ansible-wisdom-service` convention; this repo is main-only.

There is also a design conflict independent of the bugs: `target_branches` was set unconditionally, making *every* merged PR a backport candidate, which contradicts the `label_pattern: '^backport/(?<target>.+)$'` configured directly above it.

## Scope

- Adds `actions/checkout@v4`.
- Drops `target_branches`, leaving backports opt-in via a `backport/<branch>` label — what `label_pattern` implies was intended.
- No change to `copy_labels_pattern`, `pull_description` or `pull_title`.

On `pull_request_target`, `actions/checkout` takes the base branch rather than the pull request head, so this does not introduce execution of untrusted code.

## Verification

The workflow only does real work on a merged PR, so this cannot be proven green by its own CI — the run on this PR will record as `skipped` like every other non-merge event. The real test is the first merge after this lands, same as any `pull_request_target` change. If it still fails, the next thing to check is whether `secrets.GITHUB_TOKEN` has enough scope to open a PR, which the missing checkout has been masking all along.

Worth being explicit that this restores the mechanism, not any particular backport: with `target_branches` gone, nothing is backported until someone applies a `backport/<branch>` label to a merged PR.

---
🤖 Authored with AI assistance; the "never succeeded" claim is from the workflow's run history, and the absent `stable-*` branches were confirmed with a control rather than inferred from the failure message.
