### PR TITLE
ci(dependabot): use uv ecosystem for Python deps instead of pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   # Python dependencies
-  - package-ecosystem: "pip"
+  # Use the "uv" ecosystem (not "pip"): requirements.txt is a generated
+  # artifact exported from uv.lock + pyproject.toml, and the uv-export CI
+  # gate regenerates it. A pip updater edits only requirements.txt, which
+  # `uv lock` then reverts, so those PRs can never pass CI. The uv ecosystem
+  # updates pyproject.toml + uv.lock (the source of truth) instead.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### Problem

`.github/dependabot.yml` configures the Python updater with `package-ecosystem: "pip"`, pointed at `/`. But in this repo **`requirements.txt` is a generated artifact** exported from `uv.lock` + `pyproject.toml`, and the `wisdom-service - uv-export` gate regenerates and diffs it:

```sh
uv lock
uv export --format requirements-txt --no-hashes --no-emit-project -o requirements.txt
git diff --exit-code -- uv.lock requirements.txt
```

The pip updater hand-edits only `requirements.txt` and never touches `uv.lock`. Since the bumped version still satisfies all constraints, `uv lock` keeps the old pin, the export reverts the change, and the gate fails. Such PRs can never pass CI, and a rebase/recreate doesn't help.

Concrete example: #2065 (`propcache 0.4.1 -> 0.5.2`) — reverted by the gate; re-done correctly the uv way in #2134.

### Fix

Switch the Python updater to `package-ecosystem: "uv"`, so Dependabot updates `pyproject.toml` + `uv.lock` (the source of truth) instead of the generated `requirements.txt`.

### Follow-up note

Dependabot's uv updater does not itself regenerate the committed `requirements.txt` export. If a future Dependabot uv PR still trips the uv-export gate, the next step is to automate `uv export` on dependency PRs (or stop committing the generated `requirements.txt`). Flagging so we can decide separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)