### PR TITLE
ci: auto-regenerate requirements.txt on Dependabot uv PRs

### DIFF
--- a/.github/workflows/dependabot_uv_export.yml
+++ b/.github/workflows/dependabot_uv_export.yml
@@ -1,0 +1,51 @@
+name: wisdom-service - dependabot uv export
+# Regenerate the committed requirements.txt on Dependabot "uv" PRs.
+#
+# Dependabot's uv updater bumps pyproject.toml + uv.lock but does NOT
+# regenerate the committed requirements.txt export, so those PRs fail the
+# "wisdom-service - uv-export" gate. This workflow re-runs the export and
+# pushes the result back to the PR branch.
+#
+# Why a PAT (UV_EXPORT_PAT) instead of the default GITHUB_TOKEN:
+#   * Dependabot PRs run with a read-only GITHUB_TOKEN, so it cannot push.
+#   * Commits pushed with GITHUB_TOKEN do NOT trigger new workflow runs, so
+#     the required uv-export gate would never re-run and the PR would stay
+#     blocked. A push authenticated with a PAT re-triggers the gate.
+# The PAT must be stored as a *Dependabot* secret (Settings -> Secrets and
+# variables -> Dependabot), because Dependabot-triggered runs cannot read
+# regular Actions secrets.
+on:
+  pull_request:
+    branches:
+      - main
+      - 'stable-*'
+    paths:
+      - pyproject.toml
+      - uv.lock
+
+permissions:
+  contents: read
+
+jobs:
+  uv-export:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.UV_EXPORT_PAT }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Regenerate requirements.txt from uv.lock
+        run: ./tools/scripts/uv-export.sh
+      - name: Commit and push if requirements.txt changed
+        run: |
+          if git diff --quiet -- requirements.txt; then
+            echo "requirements.txt already up to date; nothing to do."
+            exit 0
+          fi
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git commit -am "deps: regenerate requirements.txt from uv.lock"
+          git push


### PR DESCRIPTION
Follow-up to #2135 (switching the Python Dependabot updater to the `uv` ecosystem).

### Problem this closes

`.github/workflows/uv_export.yml` (the `wisdom-service - uv-export` gate) regenerates `requirements.txt` from `uv.lock` and fails on any drift. Four other workflows install from that committed file (`code_coverage.yml`, `pip_audit.yml`, `security_report.yml`, `sync-openapi-spec.yml`), so it must stay in the repo.

Dependabot's `uv` updater bumps `pyproject.toml` + `uv.lock` but **does not** regenerate the committed `requirements.txt`. So even after #2135, uv-ecosystem PRs would still trip the uv-export gate.

### What this adds

A new workflow (`dependabot_uv_export.yml`) that, on Dependabot PRs touching `pyproject.toml`/`uv.lock`, re-runs the existing `tools/scripts/uv-export.sh` and pushes the regenerated `requirements.txt` back to the PR branch — so the gate goes green automatically.

### ⚠️ @hasys — I need your help setting up the PAT

This can't work without a credential I can't create myself, and it needs repo-admin rights:

Two hard GitHub constraints drive the design:
1. Dependabot PRs run with a **read-only `GITHUB_TOKEN`**, so it can't push.
2. Commits pushed with `GITHUB_TOKEN` **don't re-trigger** workflow runs — so the required uv-export gate would never re-run and the PR would stay blocked.

The push therefore has to use a **PAT** (or GitHub App token). Could you help set up:

- A fine-grained **PAT** with `contents: write` on this repo (a machine/bot account is preferable to a personal one), and
- Store it as a **Dependabot secret** named `UV_EXPORT_PAT` under **Settings → Secrets and variables → Dependabot** (it must be a *Dependabot* secret, not an Actions secret — Dependabot-triggered runs can't read Actions secrets).

Happy to pair on it or switch to a GitHub App token if you'd rather not use a PAT — let me know your preference and I'll adjust the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)