### PR TITLE
AAP-89838 AAP-89837 AAP-89855 AAP-89854 AAP-89999 AAP-89998 AAP-90026 AAP-90025: Bump fast-uri to 4.1.3 (CVE-2026-75931, CVE-2026-75899, CVE-2026-75975, CVE-2026-76172)

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -6130,9 +6130,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
+      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
       "dev": true,
       "funding": [
         {

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -83,7 +83,7 @@
     "marked": ">=18.0.2",
     "dompurify": ">=3.4.13",
     "postcss": ">=8.5.23",
-    "fast-uri": ">=4.1.2",
+    "fast-uri": ">=4.1.3",
     "js-cookie": ">=3.0.6",
     "baseline-browser-mapping": ">=2.11.0",
     "browserslist": ">=4.28.7"

--- a/ansible_ai_connect_admin_portal/package-lock.json
+++ b/ansible_ai_connect_admin_portal/package-lock.json
@@ -8932,9 +8932,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
+      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
       "funding": [
         {
           "type": "github",

--- a/ansible_ai_connect_admin_portal/package.json
+++ b/ansible_ai_connect_admin_portal/package.json
@@ -192,7 +192,7 @@
         }
       }
     },
-    "fast-uri": ">=3.1.4",
+    "fast-uri": ">=4.1.3",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "brace-expansion": "1.1.18",
     "form-data": ">=4.0.6",


### PR DESCRIPTION
## Summary
- Bump `fast-uri` override to `>=4.1.3` in `aap_chatbot` and `ansible_ai_connect_admin_portal`
- Surgically update `package-lock.json` entries to `fast-uri@4.1.3` with correct integrity

## Jira
- [AAP-89837](https://redhat.atlassian.net/browse/AAP-89837)
- [AAP-89838](https://redhat.atlassian.net/browse/AAP-89838) (CVE-2026-75931)
- [AAP-89854](https://redhat.atlassian.net/browse/AAP-89854)
- [AAP-89855](https://redhat.atlassian.net/browse/AAP-89855) (CVE-2026-75899)
- [AAP-89998](https://redhat.atlassian.net/browse/AAP-89998)
- [AAP-89999](https://redhat.atlassian.net/browse/AAP-89999) (CVE-2026-75975)
- [AAP-90025](https://redhat.atlassian.net/browse/AAP-90025) (CVE-2026-76172)
- [AAP-90026](https://redhat.atlassian.net/browse/AAP-90026) (CVE-2026-76172)

**Note:** CVE-2026-75931, CVE-2026-75899, CVE-2026-75975, and CVE-2026-76172 are all fixed by the same `fast-uri` 4.1.3 dependency bump.

## Test plan
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)