### PR TITLE
ci: bump ecosystem-cert-preflight-checks task 0.1 → 0.2

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -381,7 +381,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:fd146c14794b6bc15384359d0dc8afc8a4a5f2b167503c6288ec2d86c8cbc9c0
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:f13f01c9b09ff188165ac78b1e1183f3f20b905bac8caf85f6e89980aa8d0a48
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -411,7 +411,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:fd146c14794b6bc15384359d0dc8afc8a4a5f2b167503c6288ec2d86c8cbc9c0
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:f13f01c9b09ff188165ac78b1e1183f3f20b905bac8caf85f6e89980aa8d0a48
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## What

Bumps the `ecosystem-cert-preflight-checks` Konflux task from the `0.1` bundle (`fd146c14…`) to the current `0.2` bundle (`f13f01c9…`) in both the pull-request and push Tekton pipelines.

## Why

On every push to `main`, `ecosystem-cert-preflight-checks` fast-fails in ~13s before producing any findings, which fails the `on-push` pipeline even though `build-container` and all scans pass. It has failed the last several consecutive push runs across content-unrelated commits (GHA/CI-only changes), so it is not triggered by repo content.

The task is pinned to the `0.1` line while the Konflux catalog has moved entirely to `0.2` — the whole recent tag history for `task-ecosystem-cert-preflight-checks` is `0.2-*`. A stale task bundle failing at setup time is the most likely cause; the sibling `ansible-wisdom-admin-dashboard` component runs this task successfully on a newer bundle.

## Scope

- `.tekton/ansible-ai-connect-service-pull-request.yaml`
- `.tekton/ansible-ai-connect-service-push.yaml`

Both updated to `:0.2@sha256:f13f01c9b09ff188165ac78b1e1183f3f20b905bac8caf85f6e89980aa8d0a48`.

## Verification

Preflight is skipped on PRs (runs only on `push`), so this PR's own CI cannot exercise it — the real test is the first merge to `main` after this lands. If it still fast-fails on `0.2`, the next thing to check is whether the failure is a genuine certification finding (visible in the task log via `oc`/Konflux UI) vs. a component cert-project config gap, which would argue for removing the task rather than bumping it.

---
🤖 Authored with AI assistance; the "0.1 is off-catalog" claim is from the live Konflux task-catalog tag listing, and the fast-fail pattern from the last several on-push run histories.