### PR TITLE
Re-resolve fflate in the lockfile [lship]

### DIFF
--- a/aap_chatbot/package-lock.json
+++ b/aap_chatbot/package-lock.json
@@ -3938,11 +3938,11 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
-        "node-releases": "^2.0.53",
         "electron-to-chromium": "^1.5.402",
-        "update-browserslist-db": "^1.3.0",
-        "baseline-browser-mapping": "^2.11.12"
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6175,9 +6175,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {

--- a/aap_chatbot/package.json
+++ b/aap_chatbot/package.json
@@ -86,6 +86,7 @@
     "fast-uri": ">=4.1.3",
     "js-cookie": ">=3.0.6",
     "baseline-browser-mapping": ">=2.11.0",
-    "browserslist": ">=4.28.7"
+    "browserslist": ">=4.28.7",
+    "fflate": ">=0.4.9 <0.5.0"
   }
 }

--- a/ansible_ai_connect_chatbot/package-lock.json
+++ b/ansible_ai_connect_chatbot/package-lock.json
@@ -3274,11 +3274,11 @@
         }
       ],
       "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
-        "node-releases": "^2.0.53",
         "electron-to-chromium": "^1.5.402",
-        "update-browserslist-db": "^1.3.0",
-        "baseline-browser-mapping": "^2.11.12"
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5489,9 +5489,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {

--- a/ansible_ai_connect_chatbot/package.json
+++ b/ansible_ai_connect_chatbot/package.json
@@ -45,7 +45,8 @@
     "postcss": ">=8.5.23",
     "js-cookie": ">=3.0.6",
     "baseline-browser-mapping": ">=2.11.0",
-    "browserslist": ">=4.28.7"
+    "browserslist": ">=4.28.7",
+    "fflate": ">=0.4.9 <0.5.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.1",


### PR DESCRIPTION
## What

Adds an `overrides` floor for `fflate` in both chatbot packages and re-resolves the lockfiles onto it.

```json
"fflate": ">=0.4.9 <0.5.0"
```

| package | from | to |
|---|---|---|
| `aap_chatbot` | 0.4.8 | 0.4.9 |
| `ansible_ai_connect_chatbot` | 0.4.8 | 0.4.9 |

## Why the cap matters

GHSA-px8p-9vwx-vf98 / CVE-2026-45820 is **non-contiguous** — five disjoint vulnerable windows:

| vulnerable | first patched |
|---|---|
| `>=0.4.5 <0.4.9` | 0.4.9 |
| `>=0.5.0 <0.5.4` | 0.5.4 |
| `>=0.6.0 <0.6.11` | 0.6.11 |
| `>=0.7.0 <0.7.5` | 0.7.5 |
| `>=0.8.0 <0.8.3` | 0.8.3 |

An unbounded `>=0.4.9` would satisfy the audit today while re-admitting four later vulnerable ranges on any future resolution. The `<0.5.0` cap is load-bearing, not tidiness.

## Scope

Lockfile delta is one entry per package — `fflate` 0.4.8 → 0.4.9, nothing added or removed. `fflate` reaches the tree via `posthog-js` as a production dependency, so this ships in both chatbot bundles.

## Deferred, not addressed here

- `setuptools` 80.9.0 → 83.0.0 (CVE-2026-59890) — major bump
- `multer` (`ansible_ai_connect_admin_portal`) 1.4.5-lts.1 → 2.2.0 — major bump, **8 CVEs**; the largest open pile and worth its own ticket rather than recurring in every lship body

> **Removed from this list: `pydantic`.** lship reported `2.* -> 1.10.13` with "unreadable current". That is wrong and would be harmful if actioned. The repo is on `pydantic==2.12.5`, and neither cited CVE affects it — CVE-2021-29510 covers only 1.x ranges, and CVE-2024-3772 is fixed in **2.4.0**, which 2.12.5 is well past. lship took the `first_patched_version` from the *1.x* branch of a multi-branch advisory and proposed a two-major downgrade to fix nothing.

## Test plan
- [ ] CI passes
- [ ] Both `npm-audit` workflows pass (they are the gate that proves the floor took)

<!-- lship:{"operation_hash":"341c60729348149d","trackers":[{"cve_ids":["CVE-2026-73228","GHSA-2m8g-3cmr-wg3w","CVE-2026-73229","GHSA-g47c-3xmw-q6m2"],"package":"djangorestframework","current_version":"3.15.2","fixed_version":"3.17.2"},{"cve_ids":["CVE-2026-59890","GHSA-h35f-9h28-mq5c","PYSEC-2026-3447"],"package":"setuptools","current_version":"80.9.0","fixed_version":"83.0.0"},{"cve_ids":["CVE-2021-29510","GHSA-5jqp-qgf6-3pvh","CVE-2024-3772","GHSA-mr82-8j83-vxmv","PYSEC-2021-47","PYSEC-2026-1812"],"package":"pydantic","current_version":"2.*","fixed_version":"1.10.13"},{"cve_ids":["CVE-2026-45820","GHSA-px8p-9vwx-vf98"],"package":"fflate","current_version":"0.4.8","fixed_version":"0.4.9"},{"cve_ids":["CVE-2025-47935","GHSA-44fp-w29j-9vj5","CVE-2025-47944","GHSA-4pg4-qvpc-4q3h","CVE-2026-3520","GHSA-5528-5vmv-3xc2","CVE-2026-5079","GHSA-72gw-mp4g-v24j","CVE-2025-7338","GHSA-fjgf-rc76-4x9p","CVE-2025-48997","GHSA-g5hg-p3ph-g8qg","CVE-2026-2359","GHSA-v52c-386h-88mc","CVE-2026-3304","GHSA-xf7r-hgr6-v32p"],"package":"multer","current_version":"1.4.5-lts.1","fixed_version":"2.2.0"},{"cve_ids":["CVE-2026-45820","GHSA-px8p-9vwx-vf98"],"package":"fflate","current_version":"0.4.8","fixed_version":"0.4.9"}]} -->
