### PR TITLE
fix(ci): point the preflight stepSpec at 0.2's renamed step

### DIFF
--- a/.tekton/ansible-ai-connect-service-pull-request.yaml
+++ b/.tekton/ansible-ai-connect-service-pull-request.yaml
@@ -497,7 +497,7 @@ spec:
           memory: 4Gi
         requests:
           memory: 4Gi
-      name: check-container
+      name: app-check
   taskRunTemplate:
     serviceAccountName: build-pipeline-ansible-ai-connect-service
   timeouts:

--- a/.tekton/ansible-ai-connect-service-push.yaml
+++ b/.tekton/ansible-ai-connect-service-push.yaml
@@ -527,7 +527,7 @@ spec:
           memory: 4Gi
         requests:
           memory: 4Gi
-      name: check-container
+      name: app-check
   taskRunTemplate:
     serviceAccountName: build-pipeline-ansible-ai-connect-service
   timeouts:


### PR DESCRIPTION
## What

One line in each of the two `.tekton` pipelines: the `taskRunSpecs` entry for `ecosystem-cert-preflight-checks` now names `app-check` instead of `check-container`.

## Why

`main` has been red on **every push since 2026-09-01**. `ecosystem-cert-preflight-checks` fails in **0 seconds** — it is not finding anything wrong with the image, it never starts.

#2149 bumped that task `0.1 → 0.2`. Both pipelines still carry:

```yaml
taskRunSpecs:
- pipelineTaskName: ecosystem-cert-preflight-checks
  stepSpecs:
  - computeResources: { limits: { memory: 4Gi }, requests: { memory: 4Gi } }
    name: check-container          # not a step in 0.2
```

0.2 renamed every step:

```
0.1  check-container, gather-pflt-results
0.2  introspect, generate-container-auth, set-skip-for-bundles,
     app-check, app-set-outcome, final-outcome
```

Tekton rejects a `stepSpecs` entry naming a step the task does not define, so the TaskRun is refused at admission — hence 0 seconds, deterministically, on every commit.

`check-container` and `app-check` are the same step renamed; both run `quay.io/opdev/preflight:stable`, so `app-check` is where the 4Gi belongs. 0.2's two new params (`artifact-type`, `platform`) both have defaults and need no pipeline change.

## Scope

Also applied to the pull-request pipeline, which carries the identical block. Worth knowing that pipeline **defines** this task but does not run it — on #2166 the only task in its table was `build-container` — which is why #2149 merged green: its own PR could not exercise the task it changed.

## What this does not fix

Before #2149, this same task was failing *intermittently* at 10–14 seconds, with several commits passing (2026-08-29 to 08-31). That is a different failure, and it may resurface once the task actually runs again. Worth watching the first few pushes after this merges rather than assuming green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPs3EfPg2BET5sjoyFBvHk
