### PR TITLE
Disable Dependabot version updates in favour of MintMaker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,19 @@
+# Dependabot version updates are DISABLED.
+#
+# `open-pull-requests-limit: 0` is GitHub's documented way to pause version
+# updates for an ecosystem, chosen over deleting this file so the per-ecosystem
+# reasoning below survives and re-enabling is a one-character change.
+#
+# Dependency updates come from MintMaker (Renovate) instead. Running both
+# produced duplicate PRs for the same bumps across four ecosystems.
+#
+# Note: Dependabot SECURITY updates were already disabled at the repository
+# level (security_and_analysis.dependabot_security_updates), so after this
+# change no Dependabot updates of any kind reach this repository. Renovate is
+# the only source, and its vulnerabilityAlerts/osvVulnerabilityAlerts are
+# disabled in the shared aap-konflux-pipelines preset -- worth confirming that
+# is intended before this lands.
+#
 version: 2
 updates:
   # Python dependencies
@@ -10,7 +26,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0  # disabled — see header
     labels:
       - "dependencies"
       - "python"
@@ -28,7 +44,7 @@ updates:
     directory: "/ansible_ai_connect_admin_portal"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0  # disabled — see header
     labels:
       - "dependencies"
       - "javascript"
@@ -43,7 +59,7 @@ updates:
     directory: "/ansible_ai_connect_chatbot"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0  # disabled — see header
     labels:
       - "dependencies"
       - "javascript"
@@ -58,7 +74,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0  # disabled — see header
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## What

Sets `open-pull-requests-limit: 0` on all four Dependabot ecosystems — `uv`, both npm directories, and `github-actions`.

## Why this form

`open-pull-requests-limit: 0` is [GitHub's documented way](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) to pause version updates — *"You can temporarily disable version updates for a package manager by setting this option to zero"*. I chose it over deleting the file for two reasons: re-enabling becomes a one-character change, and the per-ecosystem reasoning survives.

That reasoning is worth keeping. The `uv` block already records the exact trap MintMaker fell into this week:

> Use the "uv" ecosystem (not "pip"): requirements.txt is a generated artifact exported from uv.lock + pyproject.toml… A pip updater edits only requirements.txt, which `uv lock` then reverts, so those PRs can never pass CI.

Someone had already worked that out for Dependabot. MintMaker had no equivalent knowledge, which is what #2181 adds.

## Two things to check before merging

**1. This leaves no Dependabot coverage at all.** Security updates were *already* disabled at the repository level:

```
security_and_analysis.dependabot_security_updates: { "status": "disabled" }
```

So after this, Renovate is the sole source — and the shared `aap-konflux-pipelines` preset sets `vulnerabilityAlerts: { enabled: false }` and `osvVulnerabilityAlerts: false`. Worth confirming that is intended rather than inherited, because between the two there may be no bot raising security-driven bumps.

**2. There are 9 open Dependabot PRs.** This change does not close them. Dependabot treats a manually closed PR as "don't offer this version again", which is fine here since the ecosystem is being paused anyway — but they should be closed deliberately rather than left to rot.

## Context

MintMaker's PRs in this repo were failing for two reasons now fixed or in review — editing generated files (#2181, plus regenerated locks on #2177/#2180) and flattening path-scoped npm overrides (#2181, plus repaired locks on #2178/#2179). All four are green now. Worth landing #2181 before or alongside this, so the surviving bot is the corrected one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)